### PR TITLE
Add support for disabling burn in protection.

### DIFF
--- a/i18n/asteroid-settings.ar.ts
+++ b/i18n/asteroid-settings.ar.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>تشغيل البلوتوث</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>إطفاء البلوتوث</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>متصل</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>غير متصل</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>إطفاء AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>إعادة تشغيل AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>الصوت %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>شحن فقط</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>وضع ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>وضع المطور</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>وضع MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>استخدم صيغة ١٢ ساعة:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>استخدم فهرنهايت:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>الوقت</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>التاريخ</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>اللغة</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>بلوتوث</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>العرض</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>السطوع</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>دائمة الظهور</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>الصوت</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>الوحدات</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>الخلفية</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>المظهر</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>إغلاق</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>إعادة تشغيل</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>حول</translation>
     </message>

--- a/i18n/asteroid-settings.ca.ts
+++ b/i18n/asteroid-settings.ca.ts
@@ -127,5 +127,9 @@
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-burn-in-protection">
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.cs.ts
+++ b/i18n/asteroid-settings.cs.ts
@@ -127,5 +127,9 @@
         <source>Tap-to-wake</source>
         <translation>Probuzení klepnutím</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.da.ts
+++ b/i18n/asteroid-settings.da.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth til</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth fra</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Forbundet</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Ikke forbundet</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Sluk AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Genstart AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Lydstyrke %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Kun opladning</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB-tilstand</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Udviklertilstand</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP-tilstand</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Brug 12-timer format:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Brug Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Tidspunkt</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Sprog</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation type="unfinished">Lysstyrke</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Lyd</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Enheder</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Baggrund</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Udseende på ur</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Sluk</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Genstart</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Om</translation>
     </message>

--- a/i18n/asteroid-settings.de_DE.ts
+++ b/i18n/asteroid-settings.de_DE.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth an</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth aus</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Verbunden</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Nicht verbunden</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>AsteroidOS ausschalten</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>AsteroidOS neu starten</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Lautstärke %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Nur Aufladen</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB-Modus</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Entwicklermodus</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP-Modus</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>12-Std.-Format:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Uhrzeit</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Bildschirm</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Helligkeit</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Immer aktiver Bildschirm (AOD)</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Neigen zum Aufwachen</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Tippen zum Aufwachen</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Ton</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Einheiten</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Hintergrundbild</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Ziffernblatt</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Ausschalten</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Neustart</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Über</translation>
     </message>

--- a/i18n/asteroid-settings.el.ts
+++ b/i18n/asteroid-settings.el.ts
@@ -127,5 +127,9 @@
         <source>Tap-to-wake</source>
         <translation>Ενεργοποίηση με πάτημα</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.en_GB.ts
+++ b/i18n/asteroid-settings.en_GB.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth on</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth off</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Connected</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Not connected</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Power off AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Reboot AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Charging only</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB Mode</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Developer Mode</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP Mode</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Use 12H format:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Use Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Time</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Display</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Brightness</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Always on Display</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation>Burn in protection</translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Tilt-to-wake</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Tap-to-wake</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Sound</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Units</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Wallpaper</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Watchface</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Power Off</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Reboot</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>About</translation>
     </message>

--- a/i18n/asteroid-settings.es.ts
+++ b/i18n/asteroid-settings.es.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth encendido</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth apagado</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>No conectado</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Apagar AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Reiniciar AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
-        <translation>Volumen %1 %</translation>
+        <translation>Volumen %1&#xa0;%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Solo carga</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Modo desarrollador</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Modo MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
-        <translation>Usar formato 12 h:</translation>
+        <translation>Usar formato 12&#xa0;h:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Pantalla</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Brillo</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Pantalla siempre encendida</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar para encender</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Tocar para encender</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Sonido</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Fondo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Esfera</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>

--- a/i18n/asteroid-settings.es_AR.ts
+++ b/i18n/asteroid-settings.es_AR.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth activado</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth desactivado</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Desconectado</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Apagar AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Reiniciar AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Volumen %1 %</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Solo carga</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Modo desarrollo</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Modo MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Usar formato 12h:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation type="unfinished">Brillo</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Sonido</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Fondo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Carátula</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>

--- a/i18n/asteroid-settings.fa.ts
+++ b/i18n/asteroid-settings.fa.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>بلوتوث روشن</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>بلوتوث خاموش</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>وصل‌شده</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>وصل‌نشده</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>خاموش کردن استروید</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>راه‌اندازی دوبارهٔ استروید</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>حجم صدا %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>فقط شارژ شدن</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>پل توسعهٔ اندروید</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>حالت توسعه‌دهنده</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>حالت انتقال رسانه</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>استفاده از قالب ۱۲ساعته:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>استفاده از فارنهایت:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>زمان</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>زبان</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>بلوتوث</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>صفحهٔ نمایش</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>روشنایی</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>صفحهٔ همواره روشن</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>چرخاندن برای بیداری</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>ضربه برای بیداری</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>صدا</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>واحدها</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>کاغذدیواری</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>صفحهٔ ساعت</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>یواِس‌بی</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>خاموش</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>راه‌اندازی دوباره</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>درباره</translation>
     </message>

--- a/i18n/asteroid-settings.fi.ts
+++ b/i18n/asteroid-settings.fi.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth päällä</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth pois</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Yhdistetty</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>EI yhdistetty</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Sammuta AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Uudelleenkäynnistä AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Äänenvoimakkuus %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Vain lataus</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB Tila</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Kehittäjätila</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP Tila</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Käytä 12H muotoa:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Käytä Fahrenheitia:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Aika</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Päiväys</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Kieli</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Näyttö</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Kirkkaus</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Tyyni näyttö (ei sammu)</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Nosta herättääksesi puhelin</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Napauta herättääksesi puhelin</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Ääni</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Yksiköt</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Taustakuva</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Kellotaulu</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Sammuta</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Käynnistä uudelleen</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Tietoa</translation>
     </message>

--- a/i18n/asteroid-settings.fr.ts
+++ b/i18n/asteroid-settings.fr.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth activé</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth désactivé</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Connecté</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Non connecté</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Éteindre AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Redémarrer AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Charge uniquement</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Mode ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Mode Développeur</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Mode MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Format 12H :</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Fahrenheit :</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Heure</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Langue</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Afficher</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Lumière</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Toujours en vue</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Incliner-pour-se-réveiller</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Tapoter-pour-réveiller</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Son</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unités</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Fond d&apos;écran</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Cadrans</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Éteindre</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Redémarrer</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>À propos</translation>
     </message>

--- a/i18n/asteroid-settings.gl.ts
+++ b/i18n/asteroid-settings.gl.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth activado</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth desactivado</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Non conectado</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Apaga-lo AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Reinicia-lo AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Só carrega</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Modo desenvolvedor</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Modo MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Enpregar formato 12H:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Empregar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Pantalla</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Luminosidade</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Sempre en Pantalla</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar-para-prender</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Tocar para despertar</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Son</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Imaxe do fondo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Esfera do reloxo</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>

--- a/i18n/asteroid-settings.he.ts
+++ b/i18n/asteroid-settings.he.ts
@@ -4,159 +4,164 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth פעיל</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth כבוי</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>מחובר</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>מנותק</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>כיבוי AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>הפעלת AsteroidOS מחדש</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <oldsource>Sound %1%</oldsource>
         <translation>עצמת שמע %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>טעינה בלבד</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>מצב ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>מצב פיתוח</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>מצב התקן אחסון</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>תבנית 12 שעות:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>שימוש בפרנהייט:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>שעה</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>תאריך</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>שפה</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>תצוגה</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>בהירות</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>תצוגה פעילה תמידית</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>להטות כדי להעיר</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>לגעת כדי להעיר</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>צליל</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>יחידות</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>תמונת רקע</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>פני השעון</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>כיבוי</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>הפעלה מחדש</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>על אודות</translation>
     </message>

--- a/i18n/asteroid-settings.hr.ts
+++ b/i18n/asteroid-settings.hr.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth uključen</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth isključen</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Spojen</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Nije spojen</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Isključi AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Ponovo pokreni AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Glasnoća %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Samo punjenje</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB modus</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Modus za razvijatelje</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP modus</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Koristi 12-satni format:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Koristi Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Vrijeme</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Jezik</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Ekran</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Svjetlina</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Uvijek na ekranu</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Nagni-za-buđenje</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Dodirni-za-buđenje</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Zvuk</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Mjerne jedinice</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Pozadina</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Pozadina sata</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Isključi</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Ponovo pokreni</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Informacije</translation>
     </message>

--- a/i18n/asteroid-settings.hu.ts
+++ b/i18n/asteroid-settings.hu.ts
@@ -127,5 +127,9 @@
         <source>Tap-to-wake</source>
         <translation>Ébresztés koppintással</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.id.ts
+++ b/i18n/asteroid-settings.id.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth aktif</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth nonaktif</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Terhubung</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Terputus</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Matikan AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Nyalakan ulang AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Hanya mengisi daya</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Mode ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Mode Pengembang</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Mode MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Gunakan format 12j:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Gunakan Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Waktu</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Tanggal</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Bahasa</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Layar</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Kecerahan</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Selalu Dipajang</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>miringkan untuk bangun</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Ketuk untuk membangunkan</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Suara</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unit</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Gambar latar</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Watchface</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Matikan</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Nyalakan Ulang</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Tentang</translation>
     </message>

--- a/i18n/asteroid-settings.it.ts
+++ b/i18n/asteroid-settings.it.ts
@@ -127,5 +127,9 @@
         <source>Tap-to-wake</source>
         <translation>Tocca-per-riattivare</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.ja.ts
+++ b/i18n/asteroid-settings.ja.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetoothオン</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetoothオフ</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>接続中</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>未接続</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>AsteroidOSの電源を切る</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>AsteroidOSを再起動</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>音量 %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>充電のみ</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADBモード</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>開発者モード</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTPモード</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>12時間表記:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>華氏(℉)表記:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>日付</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation type="unfinished">輝度</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation type="unfinished">振ってスリープを解除</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>サウンド</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>単位</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>壁紙</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>ウォッチフェイス</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>電源を切る</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>再起動</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>情報</translation>
     </message>

--- a/i18n/asteroid-settings.ka.ts
+++ b/i18n/asteroid-settings.ka.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>ბლუთუზი ჩართულია</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>ბლუთუზი გამორთულია</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>დაკავშირებული</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>არაა დაკავშირებული</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>გამორთვა AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>გადატვირთვა AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>ხმის სიმაღლე %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>მხოლოდ დამუხტვა</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB მეთოდი</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>დეველოპერის მეთოდი</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP მეთოდი</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>გამოყენებულ იქნას 12 საათიანი ფორმატი:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>გამოყენებულ იქნას ფარენჰეიტის შკალა:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>დრო</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>თარიღი</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>ენა</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>ბლუთუზი</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation type="unfinished">სიკაშკაშე</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation type="unfinished">დახრით გამოღვიძება</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>ხმა</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>ერთეულები</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>ფონი</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>მაჯისსაათის სახე</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>კვების გამორთვა</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>გადატვირთვა</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>AsteroidOS შესახებ</translation>
     </message>

--- a/i18n/asteroid-settings.ko.ts
+++ b/i18n/asteroid-settings.ko.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>블루투스 켜짐</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>블루투스 꺼짐</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>연결됨</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>연결되지 않음</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>AsteroidOS 종료</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>AsteroidOS 재시동</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>음량 %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>충전 전용</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB 모드</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>개발자 모드</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP 모드</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>12시간제를 사용:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>화씨를 사용:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>시간</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>날짜</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>블루투스</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>화면</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>밝기</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>항상 켜기</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>시계를 볼 때 화면 켜기</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>탭할 때 화면 켜기</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>소리</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>단위</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>배경화면</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>시계화면</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>종료</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>재시동</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>정보</translation>
     </message>

--- a/i18n/asteroid-settings.lb.ts
+++ b/i18n/asteroid-settings.lb.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation></translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth aus</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Verbonnen</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Net verbonnen</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>AsteroidOS ausschalten</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>AsteroidOS nei starten</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Lautstäerkt %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Nëmmen oplueden</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation></translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation></translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP-Modus</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>12-Stonnen-Format:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Auerzäit</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Sprooch</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation type="unfinished">Hellegkeet</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unitéiten</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Hannergrond</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Zifferblat</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Ausschalten</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Neistart</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Iwwer</translation>
     </message>

--- a/i18n/asteroid-settings.lt.ts
+++ b/i18n/asteroid-settings.lt.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth įjungta</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth išjungta</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Prisijungta</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Neprisijungta</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Išjungti AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Perkrauti AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Garsumas %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Tik įkraunama</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB rėžimas</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Kūrėjo rėžimas</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP rėžimas</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Naudoti 12 valandų formatą:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Naudoti Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Laikas</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Kalba</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Ekranas</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Ryškumas</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Visada įjungtas ekranas</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Pakreipti, kad pabustų</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Paliesti, kas pabustų</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Garsas</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Vienetai</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Ekrano paveikslėlis</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Ciferblatas</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Išjungti</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Perkrauti</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Apie</translation>
     </message>

--- a/i18n/asteroid-settings.mr.ts
+++ b/i18n/asteroid-settings.mr.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>ब्लूटूथ चालू</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>ब्लूटुथ बंद</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>जोडलेले</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>न जोडलेले</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>AsteroidOS बंद करा</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>AsteroidOS रीबूट करा</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>आवाज %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>फक्त चार्जिंग</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>एडीबी मोड</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>विकासक मोड</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>एमटीपी मोड</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>12 तास स्वरूप वापरा:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>फॅरनहाइट वापरा:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>वेळ</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>दिनांक</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>ब्लूटुथ</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>प्रदर्शन</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>उज्ज्वलता</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>नेहमी प्रदर्शनावर</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>टिल्ट टू वेक</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>टॅप टू वेक</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>आवाज</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>युनिट</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>वॉलपेपर</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>वॉचफेस</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>युएसबी</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>वीज बंद</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>रीबूट करा</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>बद्दल</translation>
     </message>

--- a/i18n/asteroid-settings.ms.ts
+++ b/i18n/asteroid-settings.ms.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth buka</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth tutup</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Disambungkan</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Tidak Disambungkan</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Tutup kuasa AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Mulakan semula AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Tahap bunyi %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Cas sahaja</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Mod ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Mod Pembangun</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Mod MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Guna format 12H:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Guna Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Masa</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Tarikh</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Bahasa</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Paparan</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Kecerahan</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Sentiasa Dipamerkan</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Pusing-untuk-bangun</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Ketik untuk bangun</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Bunyi</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unit</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Paparan</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Muka jam</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Tutup Kuasa</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Mulakan Semula</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Mengenai</translation>
     </message>

--- a/i18n/asteroid-settings.nb_NO.ts
+++ b/i18n/asteroid-settings.nb_NO.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Blåtann på</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Blåtann av</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Tilkoblet</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Ikke tilkoblet</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Skru av AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Start AsteroidOS på nytt</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Lydstyrke %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Kun lading</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB-modus</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Utviklermodus</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP-modus</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Bruk tolvtimersformat:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Bruk fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>TId</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Blåtann</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation type="unfinished">Skjerm</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation type="unfinished">Lysstyrke</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation type="unfinished">Skjerm alltid påslått</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Skakke-vekking</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation type="unfinished">Trykk for å vekke</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Lyd</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Enheter</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Bakgrunn</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Klokkeskive</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Skru av</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Omstart</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Om</translation>
     </message>
@@ -163,16 +168,6 @@
         <location filename="asteroid-settings.desktop.h" line="6"/>
         <source>Settings</source>
         <translation>Innstillinger</translation>
-    </message>
-    <message id="id-tilt-to-wake-on">
-        <location filename="../TiltToWakePage.qml" line="29"/>
-        <source>Tilt-to-wake on</source>
-        <translation>Skakke-vekking på</translation>
-    </message>
-    <message id="id-tilt-to-wake-off">
-        <location filename="../TiltToWakePage.qml" line="31"/>
-        <source>Tilt-to-wake off</source>
-        <translation>Skakke-vekking av</translation>
     </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.nl_BE.ts
+++ b/i18n/asteroid-settings.nl_BE.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth aan</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth uit</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Verbonden</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Niet verbonden</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>AsteroidOS uitschakelen</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>AsteroidOS herstarten</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Geluid %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Alleen laden</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB-modus</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Ontwikkelaarsmodus</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP-modus</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>12-uursnotatie:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Tijd</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Scherm</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Helderheid</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Actief scherm</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Kantelen om te ontwaken</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Drukken om te ontwaken</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Geluid</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Eenheden</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Achtergrond</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Horlogestijl</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Uitschakelen</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Herstarten</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Over</translation>
     </message>

--- a/i18n/asteroid-settings.nl_NL.ts
+++ b/i18n/asteroid-settings.nl_NL.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth aan</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth uit</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Verbonden</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Niet verbonden</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>AsteroidOS uitschakelen</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>AsteroidOS herstarten</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Geluid %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Alleen laden</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB-modus</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Ontwikkelaarsmodus</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP-modus</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>12-uursnotatie:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Tijd</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Scherm</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Helderheid</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Actief scherm</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Kantelen om te ontwaken</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Drukken om te ontwaken</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Geluid</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Eenheden</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Achtergrond</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Horlogestijl</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Uitschakelen</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Herstarten</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Over</translation>
     </message>

--- a/i18n/asteroid-settings.pl.ts
+++ b/i18n/asteroid-settings.pl.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth włączony</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth wyłączony</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Połączono</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Nie połączony</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Wyłącz AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Uruchom AsteroidOS ponownie</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Głośność %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Tylko ładowanie</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Tryb ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Tryb Dewelopera</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Tryb MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Użyj 12H formatu:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Użyj Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Czas</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Język</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Wyświetlacz</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Jasność</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Zawsze na widoku</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Przechylanie się do przodu</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Dotknij, aby wybudzić</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Dźwięk</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Jednostki</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Tapeta</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Wygląd zegarka</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Wyłącz</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Uruchom ponownie</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>O urządzeniu</translation>
     </message>

--- a/i18n/asteroid-settings.pt.ts
+++ b/i18n/asteroid-settings.pt.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth ligado</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth desligado</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Ligado</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Não ligado</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Desligar AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Reiniciar AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Carregar apenas</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Modo de ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Modo de Programador</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Modo de MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Usar formato de 12 horas:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Ecrã</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Brilho</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Ecrã sempre ligado</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar para acordar</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Tocar para acordar</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Som</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Imagem de fundo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Mostrador</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>

--- a/i18n/asteroid-settings.pt_BR.ts
+++ b/i18n/asteroid-settings.pt_BR.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth ligado</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth desligado</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Não conectado</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Desligar AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Reiniciar AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Apenas carregar</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Modo desenvolvedor</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Modo MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Usar formato 12h:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Tela</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Brilho</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Tela sempre ligada</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar para acordar</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Tocar para acordar</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Som</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Papel de parede</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Mostrador</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>

--- a/i18n/asteroid-settings.pt_PT.ts
+++ b/i18n/asteroid-settings.pt_PT.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth ligado</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth desligado</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Ligado</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Não ligado</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Desligar AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Reiniciar AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Carregar apenas</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Modo de ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Modo de Programador</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Modo de MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Usar formato de 12 horas:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Ecrã</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Brilho</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Ecrã sempre ligado</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar para acordar</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Tocar para acordar</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Som</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Imagem de fundo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Mostrador</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>

--- a/i18n/asteroid-settings.ro.ts
+++ b/i18n/asteroid-settings.ro.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth pornit</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth oprit</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Conectat</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Neconectat</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Oprire AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Reporniți AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Volum %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Doar încărcare</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Mod ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Mod Dezvoltator</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Mod MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Utilizați formatul 12H:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Utilizați Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Timp</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Dată</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Limbă</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Ecran</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Luminozitate</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Întotdeauna pe ecran</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Înclinați să se trezească</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Atingeți pentru a trezi</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Sunet</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unităţi</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Imagine fundal</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Faţă ceas</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Oprire</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Repornire</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Despre</translation>
     </message>

--- a/i18n/asteroid-settings.ru.ts
+++ b/i18n/asteroid-settings.ru.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth включен</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth выключен</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Соединен</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Не соединён</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Выключить AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Перезагрузить AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Громкость %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Только зарядка</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Режим ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Режим разработчика</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Режим MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Использовать 12-часовой формат:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Использовать градусы Фаренгейта:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Время</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Язык</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Дисплей</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Яркость</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Всегда на экране</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Пробуждение по наклону</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Пробуждение по касанию</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Звук</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Единицы</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Обои</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Циферблат</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Выключить</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Перезагрузить</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>О продукте</translation>
     </message>

--- a/i18n/asteroid-settings.sk.ts
+++ b/i18n/asteroid-settings.sk.ts
@@ -127,5 +127,9 @@
         <source>Tap-to-wake</source>
         <translation>Prebudenie klepnutím</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.sv.ts
+++ b/i18n/asteroid-settings.sv.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth på</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth av</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Ansluten</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Inte ansluten</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Stäng av AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Starta om AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Volym %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Laddar enbart</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB-läge</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Utvecklarläge</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP-läge</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Använd 12h-format:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Använd Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Tid</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Skärm</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Ljusstyrka</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Always on skärm</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Skaka för att aktivera</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Tryck-för-att-vakna</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Ljud</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Enheter</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Bakgrundsbild</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Klockansikte</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Stäng av</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Starta om</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Om</translation>
     </message>

--- a/i18n/asteroid-settings.ta.ts
+++ b/i18n/asteroid-settings.ta.ts
@@ -127,5 +127,9 @@
         <source>Tap-to-wake</source>
         <translation>எழுந்திரு என்பதைத் தட்டவும்</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.te.ts
+++ b/i18n/asteroid-settings.te.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>బ్లూటూత్ ఆన్</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>బ్లూటూత్ ఆఫ్</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>కనెక్టెడ్</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>కనెక్టెడ్ లేదు</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>ఆస్టిరోఇడ్ OS ని ఆపివేయండి</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>ఆస్టిరోఇడ్ OS ని రీబూట్ చేయి</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>శబ్దం %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>ఛార్జింగ్ మాత్రమే</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ఎడిబి మోడ్</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>డెవలపర్ మోడ్</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>ఎంటిపి మోడ్</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>12H ఫార్మాట్ ను వాడు:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>ఫరెన్హెఇట్ ను వాడు:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>సమయం</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>తేది</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>భాష</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>బ్లూటూత్</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>ప్రదర్శన</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>ప్రకాశం</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>ఎల్లప్పుడూ ప్రదర్శనలో ఉంటుంది</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>వంపు నుండి మేల్కొలపండి</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>మేల్కొలపడానికి నొక్కండి</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>శబ్దం</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>యూనిట్స్</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>వాల్పేపర్</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>గడియారముఖం</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>యుఎస్బి</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>మూసివేయి</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>రీబూట్</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>గురించి</translation>
     </message>

--- a/i18n/asteroid-settings.th.ts
+++ b/i18n/asteroid-settings.th.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>เปิดบลูทูธ</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>ปิดบลูทูธ</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>เชื่อมต่อ</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>ไม่เชื่อมต่อ</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>ปิด AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>รีบูต AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>ระดับ %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>ชาร์จเท่านั้น</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>โหมด ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>โหมดผู้พัฒนา</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>โหมด MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>ใช้รูปแบบ 12H:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>ใช้ฟาเรนไฮต์:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>เวลา</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>วันเดือนปี</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>ภาษา</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>บลูทูธ</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>แสดงผล</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>ความสว่าง</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>แสดงบนหน้าจอ</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>เอียงเพื่อปลุก</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>แตะเพื่อปลุก</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>เสียง</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>หน่วย</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>วอลเปเปอร์</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>หน้าปัด</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>ปิด</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>รีบูต</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>เกี่ยวกับ</translation>
     </message>

--- a/i18n/asteroid-settings.tr.ts
+++ b/i18n/asteroid-settings.tr.ts
@@ -127,5 +127,9 @@
         <source>Tap-to-wake</source>
         <translation>Dokunarak uyandır</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.uk.ts
+++ b/i18n/asteroid-settings.uk.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth увімкнений</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth вимкнений</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>З&apos;єднано</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>не з&apos;єднаний</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Вимкнути AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Перезавантажити AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>гучність %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Лише заряджання</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB режим</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Режим розробника</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Режим MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>застосовувати 12h формат:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>застосовувати градус Фаренгейта:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Час</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>мова</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Дисплей</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Яскравість</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Завжди на дисплеї</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Пробудження за нахилом</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Пробудження за дотиком</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>звук</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>одиниці</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Шпалери</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Циферблат</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Вимкнути</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Перезавантажити</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Про ПЗ</translation>
     </message>

--- a/i18n/asteroid-settings.vi.ts
+++ b/i18n/asteroid-settings.vi.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth đang bật</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth đang tắt</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>Đã kết nối</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>Chưa kết nối</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>Tắt AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>Khởi động lại AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>Âm lượng %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>Chỉ đang sạc</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>Chế độ ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>Chế độ nhà phát triển</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>Chế độ MTP</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>Sử dụng định dạng 12H:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>Sử dụng Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>Thời gian</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Ngày</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>Ngôn ngữ</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>Hiển thị</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>Độ sáng</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>Màn hình luôn bật</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation>Nghiêng để đánh thức</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation>Nhấn để đánh thức</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>Âm thanh</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Đơn vị</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>Hình nền</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>Mặt đồng hồ</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>Tắt nguồn</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>Khởi động lại</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>Giới thiệu</translation>
     </message>

--- a/i18n/asteroid-settings.zh_Hans.ts
+++ b/i18n/asteroid-settings.zh_Hans.ts
@@ -127,5 +127,9 @@
         <source>Tap-to-wake</source>
         <translation>触摸唤醒</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.zh_Hant.ts
+++ b/i18n/asteroid-settings.zh_Hant.ts
@@ -4,158 +4,163 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
         <source>Bluetooth on</source>
         <translation>藍牙已開啟</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth off</source>
         <translation>藍牙已關閉</translation>
     </message>
     <message id="id-connected">
-        <location filename="../BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Connected</source>
         <translation>已連線</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Not connected</source>
         <translation>未連線</translation>
     </message>
     <message id="id-poweroff-warn">
-        <location filename="../PoweroffPage.qml" line="29"/>
+        <location filename="../src/qml/PoweroffPage.qml" line="29"/>
         <source>Power off AsteroidOS</source>
         <translation>關閉 AsteroidOS</translation>
     </message>
     <message id="id-reboot-warn">
-        <location filename="../RebootPage.qml" line="29"/>
+        <location filename="../src/qml/RebootPage.qml" line="29"/>
         <source>Reboot AsteroidOS</source>
         <translation>重新啟動 AsteroidOS</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="36"/>
         <source>Volume %1%</source>
         <translation>音量 %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../USBPage.qml" line="35"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>Charging only</source>
         <translation>僅充電</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../USBPage.qml" line="37"/>
+        <location filename="../src/qml/USBPage.qml" line="37"/>
         <source>ADB Mode</source>
         <translation>ADB 模式</translation>
     </message>
     <message id="id-developer-mode">
-        <location filename="../USBPage.qml" line="39"/>
+        <location filename="../src/qml/USBPage.qml" line="39"/>
         <source>Developer Mode</source>
         <translation>開發者模式</translation>
     </message>
     <message id="id-mtp-mode">
-        <location filename="../USBPage.qml" line="41"/>
+        <location filename="../src/qml/USBPage.qml" line="41"/>
         <source>MTP Mode</source>
         <translation>MTP 模式</translation>
     </message>
     <message id="id-12h-format">
-        <location filename="../UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="48"/>
         <source>Use 12H format:</source>
         <translation>使用12小時制:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../UnitsPage.qml" line="63"/>
+        <location filename="../src/qml/UnitsPage.qml" line="63"/>
         <source>Use Fahrenheit:</source>
         <translation>使用華氏溫標:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../TimePage.qml" line="40"/>
-        <location filename="../main.qml" line="72"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="40"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../DatePage.qml" line="31"/>
-        <location filename="../main.qml" line="78"/>
+        <location filename="../src/qml/DatePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../LanguagePage.qml" line="31"/>
-        <location filename="../main.qml" line="84"/>
+        <location filename="../src/qml/LanguagePage.qml" line="31"/>
+        <location filename="../src/qml/main.qml" line="84"/>
         <source>Language</source>
         <translation>語言</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../main.qml" line="90"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Bluetooth</source>
         <translation>藍牙</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../DisplayPage.qml" line="33"/>
-        <location filename="../main.qml" line="96"/>
+        <location filename="../src/qml/DisplayPage.qml" line="39"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Display</source>
         <translation>顯示</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../DisplayPage.qml" line="55"/>
+        <location filename="../src/qml/DisplayPage.qml" line="61"/>
         <source>Brightness</source>
         <translation>亮度</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../DisplayPage.qml" line="104"/>
+        <location filename="../src/qml/DisplayPage.qml" line="110"/>
         <source>Always on Display</source>
         <translation>始終在顯示幕上</translation>
     </message>
+    <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="126"/>
+        <source>Burn in protection</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-tilt-to-wake">
-        <location filename="../DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/DisplayPage.qml" line="144"/>
         <source>Tilt-to-wake</source>
         <translation type="unfinished">傾斜喚醒</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../DisplayPage.qml" line="139"/>
+        <location filename="../src/qml/DisplayPage.qml" line="163"/>
         <source>Tap-to-wake</source>
         <translation type="unfinished">點擊喚醒</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../main.qml" line="102"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Sound</source>
         <translation>音效</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../UnitsPage.qml" line="26"/>
-        <location filename="../main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>單位</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="116"/>
         <source>Wallpaper</source>
         <translation>桌布</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="122"/>
         <source>Watchface</source>
         <translation>錶面</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../USBPage.qml" line="29"/>
-        <location filename="../main.qml" line="128"/>
+        <location filename="../src/qml/main.qml" line="128"/>
+        <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../main.qml" line="134"/>
+        <location filename="../src/qml/main.qml" line="134"/>
         <source>Power Off</source>
         <translation>關機</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../main.qml" line="140"/>
+        <location filename="../src/qml/main.qml" line="140"/>
         <source>Reboot</source>
         <translation>重新啟動</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../main.qml" line="146"/>
+        <location filename="../src/qml/main.qml" line="146"/>
         <source>About</source>
         <translation>關於</translation>
     </message>

--- a/src/qml/DisplayPage.qml
+++ b/src/qml/DisplayPage.qml
@@ -22,11 +22,17 @@ import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 import org.asteroid.settings 1.0
 import org.nemomobile.systemsettings 1.0
+import Nemo.Configuration 1.0
 
 Item {
     TapToWake { id: tapToWake }
     TiltToWake { id: tiltToWake }
     DisplaySettings { id: displaySettings }
+    ConfigurationValue {
+        id: useBip
+        key: "/org/asteroidos/settings/use-burn-in-protection"
+        defaultValue: DeviceInfo.needsBurnInProtection
+    }
 
     PageHeader {
         id: title
@@ -113,6 +119,24 @@ Item {
                 width: Dims.l(20)
                 checked: displaySettings.lowPowerModeEnabled
                 onCheckedChanged: displaySettings.lowPowerModeEnabled = checked
+            }
+
+            Label {
+                //% "Burn in protection"
+                text: qsTrId("id-burn-in-protection")
+                font.pixelSize: Dims.l(6)
+                verticalAlignment: Text.AlignVCenter
+                wrapMode: Text.Wrap
+                Layout.maximumWidth: Dims.w(50)
+                visible: DeviceInfo.needsBurnInProtection
+            }
+
+            Switch {
+                Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+                width: Dims.l(20)
+                checked: useBip.value
+                onCheckedChanged: useBip.value = checked
+                visible: DeviceInfo.needsBurnInProtection
             }
 
             Label {


### PR DESCRIPTION
Checkout the main PR: https://github.com/AsteroidOS/asteroid-launcher/pull/69

Actually, it might be better to hide this option when `DeviceInfo.preferBurnInProtection` is set to false. If it is desired that this option is disabled by default (for example LCDs) then it doesn't make sense to show it anyway.