### PR TITLE
Speed up loading time and enhance scroll behaviour of WallpaperPage.qml

### DIFF
--- a/src/qml/WallpaperPage.qml
+++ b/src/qml/WallpaperPage.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2021 - Timo Könnecke <github.com/eLtMosen>
+ * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
+ *               2022 - Darrel Griët <dgriet@gmail.com>
  *               2015 - Florent Revest <revestflo@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -17,6 +18,7 @@
  */
 
 import QtQuick 2.9
+import QtGraphicalEffects 1.12
 import Qt.labs.folderlistmodel 2.1
 import Nemo.Configuration 1.0
 import org.asteroid.controls 1.0
@@ -25,19 +27,19 @@ import org.asteroid.utils 1.0
 
 Item {
 
-    property string assetPath: "file:///usr/share/asteroid-launcher/"
+    property string assetPath: "file:///usr/share/asteroid-launcher/wallpapers/"
 
     ConfigurationValue {
         id: wallpaperSource
 
         key: "/desktop/asteroid/background-filename"
-        defaultValue: assetPath + "wallpapers/000-flatmesh.qml"
+        defaultValue: assetPath + "full/000-flatmesh.qml"
     }
 
     FolderListModel {
         id: qmlWallpapersModel
 
-        folder: assetPath + "wallpapers"
+        folder: assetPath + "full"
         nameFilters: ["*.qml"]
     }
 
@@ -51,7 +53,7 @@ Item {
         model: FolderListModel {
             id: folderModel
 
-            folder: assetPath + "wallpapers"
+            folder: assetPath + "full"
             nameFilters: ["*.jpg"]
             onCountChanged: {
                 var i = 0
@@ -79,8 +81,8 @@ Item {
                     anchors.fill: parent
                     fillMode: Image.PreserveAspectCrop
                     // If a pre-scaled thumbnail file exists, use that.
-                    source: FileInfo.exists((assetPath + "wallpaperpreview/" + Dims.w(50) + "/" + fileName).slice(7)) ?
-                                assetPath + "wallpaperpreview/" + Dims.w(50) + "/" + fileName :
+                    source: FileInfo.exists((assetPath + Dims.w(50) + "/" + fileName).slice(7)) ?
+                                assetPath + Dims.w(50) + "/" + fileName :
                                 // Else use the full resolution wallpaper with negative impact on performance, as failsafe.
                                 folderModel.folder + "/" + fileName
                     asynchronous: true
@@ -97,10 +99,16 @@ Item {
                 }
 
                 Rectangle {
+                    id: highlightSelection
+
+                    property bool notSelected: wallpaperSource.value !== folderModel.folder + "/" + fileName &
+                                               wallpaperSource.value !== folderModel.folder + "/" + fileBaseName + ".qml"
+
                     anchors.fill: img
-                    color: "#4D000000"
-                    visible: wallpaperSource.value === folderModel.folder + "/" + fileName |
-                             wallpaperSource.value === folderModel.folder + "/" + fileBaseName + ".qml"
+                    color: "#30000000"
+                    visible: opacity
+                    opacity: notSelected ? 1 : 0
+                    Behavior on opacity { NumberAnimation { duration: 100 } }
                 }
 
                 Icon {
@@ -108,14 +116,25 @@ Item {
                     anchors {
                         bottom: parent.bottom
                         bottomMargin: parent.height * 0.05
-                        right: parent.right
-                        rightMargin: parent.height * 0.05
-
+                        horizontalCenter: parent.horizontalCenter
+                        horizontalCenterOffset: index % 2 ?
+                                                    -parent.height * 0.4 :
+                                                    parent.height * 0.38
                     }
                     height: width
                     width: parent.width * 0.3
                     visible: wallpaperSource.value === folderModel.folder + "/" + fileName |
                              wallpaperSource.value === folderModel.folder + "/" + fileBaseName + ".qml"
+
+                    layer.enabled: visible
+                    layer.effect: DropShadow {
+                        transparentBorder: true
+                        horizontalOffset: 2
+                        verticalOffset: 2
+                        radius: 8.0
+                        samples: 17
+                        color: "#88000000"
+                    }
                 }
             }
         }

--- a/src/qml/WallpaperPage.qml
+++ b/src/qml/WallpaperPage.qml
@@ -20,6 +20,8 @@ import QtQuick 2.9
 import Qt.labs.folderlistmodel 2.1
 import Nemo.Configuration 1.0
 import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
+
 
 Item {
 
@@ -76,7 +78,11 @@ Item {
 
                     anchors.fill: parent
                     fillMode: Image.PreserveAspectCrop
-                    source: assetPath + "wallpaperpreview/" + Dims.w(100) / 2 + "/" + fileName
+                    // If a pre-scaled thumbnail file exists, use that.
+                    source: FileInfo.exists((assetPath + "wallpaperpreview/" + Dims.w(50) + "/" + fileName).slice(7)) ?
+                                assetPath + "wallpaperpreview/" + Dims.w(50) + "/" + fileName :
+                                // Else use the full resolution wallpaper with negative impact on performance, as failsafe.
+                                folderModel.folder + "/" + fileName
                     asynchronous: true
                 }
 

--- a/src/qml/WallpaperPage.qml
+++ b/src/qml/WallpaperPage.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2021 - Timo Könnecke <github.com/eLtMosen>
+ *               2015 - Florent Revest <revestflo@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,58 +22,68 @@ import Nemo.Configuration 1.0
 import org.asteroid.controls 1.0
 
 Item {
+
+    property string assetPath: "file:///usr/share/asteroid-launcher/"
+
     ConfigurationValue {
         id: wallpaperSource
+
         key: "/desktop/asteroid/background-filename"
-        defaultValue: "file:///usr/share/asteroid-launcher/wallpapers/000-flatmesh.qml"
+        defaultValue: assetPath + "wallpapers/000-flatmesh.qml"
     }
 
     FolderListModel {
         id: qmlWallpapersModel
-        folder: "file:///usr/share/asteroid-launcher/wallpapers"
+
+        folder: assetPath + "wallpapers"
         nameFilters: ["*.qml"]
     }
 
     GridView {
         id: grid
+
         cellWidth: Dims.w(50)
         cellHeight: Dims.h(40)
         anchors.fill: parent
 
         model: FolderListModel {
             id: folderModel
-            folder: "file:///usr/share/asteroid-launcher/wallpapers"
+
+            folder: assetPath + "wallpapers"
             nameFilters: ["*.jpg"]
             onCountChanged: {
                 var i = 0
                 while (i < folderModel.count){
                     var fileName = folderModel.get(i, "fileName")
                     var fileBaseName = folderModel.get(i, "fileBaseName")
-                    if(wallpaperSource.value == folderModel.folder + "/" + fileName |
-                       wallpaperSource.value == folderModel.folder + "/" + fileBaseName + ".qml") {
+                    if(wallpaperSource.value === folderModel.folder + "/" + fileName |
+                       wallpaperSource.value === folderModel.folder + "/" + fileBaseName + ".qml") {
                         grid.positionViewAtIndex(i, GridView.Center)
                     }
-                    i = i+1
+                    i = i + 1
                 }
             }
         }
 
         delegate: Component {
             id: fileDelegate
+
             Item {
                 width: grid.cellWidth
                 height: grid.cellHeight
                 Image {
                     id: img
+
                     anchors.fill: parent
                     fillMode: Image.PreserveAspectCrop
-                    source: folderModel.folder + "/" + fileName
+                    source: assetPath + "wallpaperpreview/" + Dims.w(100) / 2 + "/" + fileName
                     asynchronous: true
                 }
+
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
-                        if(qmlWallpapersModel.indexOf(folderModel.folder + "/" + fileBaseName + ".qml") != -1)
+                        if(qmlWallpapersModel.indexOf(folderModel.folder + "/" + fileBaseName + ".qml") !== -1)
                             wallpaperSource.value = folderModel.folder + "/" + fileBaseName + ".qml"
                         else
                             wallpaperSource.value = folderModel.folder + "/" + fileName
@@ -81,19 +92,24 @@ Item {
 
                 Rectangle {
                     anchors.fill: img
-                    color: "black"
-                    opacity: 0.4
-                    visible: wallpaperSource.value == folderModel.folder + "/" + fileName |
-                             wallpaperSource.value == folderModel.folder + "/" + fileBaseName + ".qml"
+                    color: "#4D000000"
+                    visible: wallpaperSource.value === folderModel.folder + "/" + fileName |
+                             wallpaperSource.value === folderModel.folder + "/" + fileBaseName + ".qml"
                 }
+
                 Icon {
                     name: "ios-checkmark-circle"
-                    anchors.bottom: parent.bottom
-                    anchors.right: parent.right
+                    anchors {
+                        bottom: parent.bottom
+                        bottomMargin: parent.height * 0.05
+                        right: parent.right
+                        rightMargin: parent.height * 0.05
+
+                    }
                     height: width
-                    width: parent.width*0.3
-                    visible: wallpaperSource.value == folderModel.folder + "/" + fileName |
-                             wallpaperSource.value == folderModel.folder + "/" + fileBaseName + ".qml"
+                    width: parent.width * 0.3
+                    visible: wallpaperSource.value === folderModel.folder + "/" + fileName |
+                             wallpaperSource.value === folderModel.folder + "/" + fileBaseName + ".qml"
                 }
             }
         }


### PR DESCRIPTION
### Problems to solve, mostly noticeable on slower watch models:
- Loading time was up to 3 seconds (sparrow) until the page fully loaded the 480px images. 
- Images where scaled down from 480px during run-time.
- The 6 visible preview images loaded one by one in view of the user and gave a laggy impression.
- Scroll behaviour was sluggish and sometimes inputs where not noticed or executed while the user already gave the next input.
- Switching from the WallpaperPage back to settings felt choppy on slow watches
- On Watches with worn battery, scrolling through the wallpapers could lead to shutdown of the watch due to power loss.

### Proposed changes:
- Load pre-scaled preview images instead of the 480px versions into the gridView.
- Thus reduce file size of each image loaded into a grid item by up to 95%.
- Thus prevent scaling work during run-time to reduce load.

Depends on adding the preview images to asteroid-wallpapers. https://github.com/AsteroidOS/asteroid-wallpapers/pull/6

Vanilla behaviour on sparrow, left. Proposed version on the right

https://user-images.githubusercontent.com/15074193/147786843-c6ddc116-d8c3-40f5-857a-022f60c74502.mp4
