### PR TITLE
Implement watchfaces-preview image system

### DIFF
--- a/src/qml/WatchfacePage.qml
+++ b/src/qml/WatchfacePage.qml
@@ -1,5 +1,7 @@
 /*
- * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
+ *               2022 - Darrel Griët <dgriet@gmail.com>
+ *               2015 - Florent Revest <revestflo@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,41 +18,54 @@
  */
 
 import QtQuick 2.9
+import QtGraphicalEffects 1.12
 import Qt.labs.folderlistmodel 2.1
-import Nemo.Time 1.0
-import Nemo.Configuration 1.0
 import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
+import Nemo.Configuration 1.0
+import Nemo.Time 1.0
 
 Item {
+
     property alias displayAmbient: compositor.displayAmbient
+    property string assetPath: "file:///usr/share/asteroid-launcher/"
 
     ConfigurationValue {
         id: watchfaceSource
+
         key: "/desktop/asteroid/watchface"
-        defaultValue: "file:///usr/share/asteroid-launcher/watchfaces/000-default-digital.qml"
+        defaultValue: assetPath + "watchfaces/000-default-digital.qml"
+    }
+
+    ConfigurationValue {
+        id: wallpaperSource
+
+        key: "/desktop/asteroid/background-filename"
     }
 
     ConfigurationValue {
         id: use12H
+
         key: "/org/asteroidos/settings/use-12h-format"
         defaultValue: false
     }
 
     GridView {
         id: grid
+
         cellWidth: Dims.w(50)
         cellHeight: Dims.h(40)
         anchors.fill: parent
 
         model: FolderListModel {
             id: folderModel
-            folder: "file:///usr/share/asteroid-launcher/watchfaces"
+            folder: assetPath + "watchfaces"
             nameFilters: ["*.qml"]
             onCountChanged: {
                 var i = 0
                 while (i < folderModel.count){
                     var fileName = folderModel.get(i, "fileName")
-                    if(watchfaceSource.value == folderModel.folder + "/" + fileName)
+                    if(watchfaceSource.value === folderModel.folder + "/" + fileName)
                         grid.positionViewAtIndex(i, GridView.Center)
 
                     i = i+1
@@ -60,6 +75,7 @@ Item {
 
         Item {
             id: burnInProtectionManager
+
             property int leftOffset
             property int rightOffset
             property int topOffset
@@ -70,51 +86,133 @@ Item {
 
         QtObject {
             id: compositor
+
             property bool displayAmbient: false
         }
 
         WallClock {
             id: wallClock
+
             enabled: true
-            updateFrequency: WallClock.Minute
+            updateFrequency: WallClock.Second
         }
 
         QtObject {
             id: localeManager
+
             property string changesObserver: ""
         }
 
         delegate: Component {
-            id: fileDelegate
+
             Item {
                 width: grid.cellWidth
                 height: grid.cellHeight
-                Loader {
-                    id: preview
-                    anchors.centerIn: parent
-                    width: Math.min(parent.width, parent.height)
-                    height: Math.min(parent.width, parent.height)
-                    source: folderModel.folder + "/" + fileName
-                    asynchronous: true
-                }
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: watchfaceSource.value = folderModel.folder + "/" + fileName
-                }
 
                 Rectangle {
-                    anchors.fill: parent
-                    color: "black"
-                    opacity: 0.4
-                    visible: watchfaceSource.value == folderModel.folder + "/" + fileName
+                    id: maskArea
+
+                    width: Dims.w(40)
+                    height: grid.cellHeight
+                    anchors.centerIn: parent
+                    color: "transparent"
+                    radius: DeviceInfo.hasRoundScreen ?
+                                width :
+                                Dims.w(3)
+                    clip: true
+
+                    Image {
+                        id: previewPng
+
+                        property string previewImg: (assetPath + "watchfaces-preview/" + Dims.w(40) + "/" + fileName).slice(0, -4) + ".png"
+                        property bool previewExists: FileInfo.exists(previewImg)
+
+                        z: 1
+                        anchors.centerIn: parent
+                        width: Math.min(parent.width, parent.height)
+                        height: width
+                        source: !previewExists ? "" : previewImg
+                        asynchronous: true
+                    }
+
+                    Loader {
+                        id: previewQml
+
+                        z: 2
+                        visible: !previewPng.previewExists
+                        active: visible
+                        anchors.centerIn: parent
+                        width: Math.min(parent.width, parent.height)
+                        height: width
+                        source: folderModel.folder + "/" + fileName
+                        asynchronous: true
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: watchfaceSource.value = folderModel.folder + "/" + fileName
+                    }
+
+                    Image {
+                        id: wallpaperBack
+
+                        property string previewSizePath: "wallpapers/" + Dims.w(50)
+                        property string wallpaperPreviewImg: wallpaperSource.value.replace("\wallpapers/full/g", previewSizePath).slice(0, -3) + "jpg"
+
+                        z: 0
+                        anchors.fill: parent
+                        fillMode: Image.PreserveAspectFit
+                        visible: opacity
+                        opacity: watchfaceSource.value === folderModel.folder + "/" + fileName ? 1 : 0
+                        source: FileInfo.exists(wallpaperPreviewImg) ?
+                                    wallpaperPreviewImg :
+                                    wallpaperSource.value
+                        Behavior on opacity { NumberAnimation { duration: 200 } }
+                    }
+
+                    layer.enabled: true
+                    layer.effect: OpacityMask {
+                        maskSource:
+                            Rectangle {
+                                anchors.centerIn: parent
+                                width: Math.min(wallpaperBack.width, wallpaperBack.height)
+                                height: width
+                                radius: maskArea.radius
+                            }
+                    }
                 }
+
                 Icon {
                     name: "ios-checkmark-circle"
-                    anchors.bottom: parent.bottom
-                    anchors.right: parent.right
+
+                    z: 100
+                    width: parent.width * .3
                     height: width
-                    width: parent.width*0.3
-                    visible: watchfaceSource.value == folderModel.folder + "/" + fileName
+                    visible: watchfaceSource.value === folderModel.folder + "/" + fileName
+                    anchors {
+                        bottom: parent.bottom
+                        bottomMargin: DeviceInfo.hasRoundScreen ?
+                                          -parent.height * .03 :
+                                          -parent.height * .08
+                        horizontalCenter: parent.horizontalCenter
+                        horizontalCenterOffset: index % 2 ?
+                                                    DeviceInfo.hasRoundScreen ?
+                                                        -parent.height * .45 :
+                                                        -parent.height * .40 :
+                                                        DeviceInfo.hasRoundScreen ?
+                                                            parent.height * .45 :
+                                                            parent.height * .40
+                    }
+
+                    layer.enabled: visible
+                    layer.effect: DropShadow {
+                        transparentBorder: true
+                        horizontalOffset: 2
+                        verticalOffset: 2
+                        radius: 8.0
+                        samples: 17
+                        color: "#88000000"
+                    }
                 }
             }
         }


### PR DESCRIPTION
In same fashion as done for the WallpaperPage https://github.com/AsteroidOS/asteroid-settings/pull/39
Implement display of preview images instead of rendering a live view per watchfaces.
Impact on page load and scroll behaviour is even bigger then for the WallpaperPage. Video attached.

- Add preview of the user selected wallpaper as additional selection indicator and aid to estimate watchface/wallpaper combination at a glance
- Fade in/out wallpaper behind the selected watchface in 200ms
- Make Checkmark icon more legible by adding a drop shadow
- Align Checkmark in center of page to avoid clipping
- Show preview images from `asteroid-launcher/watchfaces-preview/` instead of slowly rendering live views. https://github.com/AsteroidOS/unofficial-watchfaces/pull/59
- Mask the watchface and wallpaper to either round screen or square screen with rounded edges
- In case of non existent preview image(s), show the live view as fallback.

### vanilla page load & scrolling
https://user-images.githubusercontent.com/15074193/149632599-bddcc1de-5802-4fed-a9e9-e347857492bd.mp4

### Pageload and selection after PR

https://user-images.githubusercontent.com/15074193/149632627-8b64a43e-b32e-49c9-b1fc-a4b0a689410a.mp4

### Masking on square screens
![watchfacePage-square3](https://user-images.githubusercontent.com/15074193/149632652-7c851931-b005-4cdc-9a32-9e3715edcf59.jpg)

### Pre rendered PNG vs Qml rendered live view
![watchfacePage-anti1](https://user-images.githubusercontent.com/15074193/149632745-5c19cb3c-2e7c-494e-bce3-83ab7ae287ef.jpg)

