### PR TITLE
[WatchfacePage.qml] Only load wallpaper background when grid item is …

### DIFF
--- a/src/qml/WatchfacePage.qml
+++ b/src/qml/WatchfacePage.qml
@@ -165,10 +165,10 @@ Item {
                         fillMode: Image.PreserveAspectFit
                         visible: opacity
                         opacity: watchfaceSource.value === folderModel.folder + "/" + fileName ? 1 : 0
-                        source: FileInfo.exists(wallpaperPreviewImg) ?
+                        source: opacity > 0 ? FileInfo.exists(wallpaperPreviewImg) ?
                                     wallpaperPreviewImg :
-                                    wallpaperSource.value
-                        Behavior on opacity { NumberAnimation { duration: 200 } }
+                                    wallpaperSource.value : ""
+                        Behavior on opacity { NumberAnimation { duration: 100 } }
                     }
 
                     layer.enabled: true


### PR DESCRIPTION
…actually clicked

Too further improve initial page load speed. Noticeable when many watchfaces are installed (>~20).

Speed up transition from 200ms to 100ms for even more snappy appearance.