### PR TITLE
Eliminate the use of obsolete dbus-glib library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10.0)
 
 project(asteroid-settings
-	VERSION 0.0.1
+	VERSION 1.0.0
 	DESCRIPTION "Default settings app for AsteroidOS")
 
 find_package(ECM REQUIRED NO_MODULE)
@@ -17,18 +17,7 @@ include(AsteroidCMakeSettings)
 include(AsteroidTranslations)
 
 find_package(Qt5 COMPONENTS Core Qml Quick DBus Multimedia REQUIRED)
-find_package(DBus1 REQUIRED)
 find_package(Mce REQUIRED)
-
-find_package(PkgConfig)
-pkg_check_modules(DBUSGLIB dbus-glib-1 IMPORTED_TARGET REQUIRED)
-set_property(GLOBAL APPEND PROPERTY _CMAKE_dbus-glib-1_TYPE REQUIRED)
-
-if(DBUSGLIB_FOUND)
-	set_property(GLOBAL APPEND PROPERTY PACKAGES_FOUND dbus-glib-1)
-else()
-	set_property(GLOBAL APPEND PROPERTY PACKAGES_NOT_FOUND dbus-glib-1)
-endif()
 
 ecm_find_qmlmodule(Nemo.DBus 2.0)
 ecm_find_qmlmodule(Nemo.Configuration 1.0)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,9 @@ endif()
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mceiface.h ${CMAKE_CURRENT_BINARY_DIR}/mceiface.cpp
 	COMMAND ${QDBUSXML2CPP} -p mceiface.h:mceiface.cpp ${CMAKE_CURRENT_SOURCE_DIR}/mce.xml)
 
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.h ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.cpp
+	COMMAND ${QDBUSXML2CPP} -p VolumeControl2.h:VolumeControl2.cpp ${CMAKE_CURRENT_SOURCE_DIR}/VolumeControl2.xml)
+
 set(SRC
 	main.cpp
 	taptowake.cpp
@@ -16,7 +19,12 @@ set(HEADERS
 	tilttowake.h
 	volumecontrol.h)
 
-add_library(asteroid-settings ${SRC} ${HEADERS} resources.qrc ${CMAKE_CURRENT_BINARY_DIR}/mceiface.h ${CMAKE_CURRENT_BINARY_DIR}/mceiface.cpp)
+add_library(asteroid-settings ${SRC} ${HEADERS} resources.qrc 
+    ${CMAKE_CURRENT_BINARY_DIR}/mceiface.h 
+    ${CMAKE_CURRENT_BINARY_DIR}/mceiface.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.h 
+    ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.cpp
+)
 set_target_properties(asteroid-settings PROPERTIES PREFIX "" SUFFIX "")
 
 target_link_libraries(asteroid-settings PRIVATE
@@ -24,9 +32,7 @@ target_link_libraries(asteroid-settings PRIVATE
 	Qt5::Quick
 	Qt5::DBus
 	Qt5::Multimedia
-	AsteroidApp
-	dbus-1
-	PkgConfig::DBUSGLIB)
+	AsteroidApp)
 
 install(TARGETS asteroid-settings
 	DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/VolumeControl2.xml
+++ b/src/VolumeControl2.xml
@@ -1,0 +1,50 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="com.Meego.MainVolume2">
+  <property name="InterfaceRevision" type="u" access="read"/>
+  <property name="StepCount" type="u" access="read"/>
+  <property name="CurrentStep" type="u" access="readwrite"/>
+  <property name="HighVolumeStep" type="u" access="read"/>
+  <property name="CallState" type="s" access="read"/>
+  <property name="MediaState" type="s" access="read"/>
+  <signal name="StepsUpdated">
+   <arg name="StepCount" type="u"/>
+   <arg name="CurrentStep" type="u"/>
+  </signal>
+  <signal name="NotifyListeningTime">
+   <arg name="ListeningTime" type="u"/>
+  </signal>
+  <signal name="NotifyHighVolume">
+   <arg name="SafeStep" type="u"/>
+  </signal>
+  <signal name="CallStateChanged">
+   <arg name="State" type="s"/>
+  </signal>
+  <signal name="MediaStateChanged">
+   <arg name="State" type="s"/>
+  </signal>
+ </interface>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Properties">
+  <method name="Get">
+   <arg name="interface_name" type="s" direction="in"/>
+   <arg name="property_name" type="s" direction="in"/>
+   <arg name="value" type="v" direction="out"/>
+  </method>
+  <method name="Set">
+   <arg name="interface_name" type="s" direction="in"/>
+   <arg name="property_name" type="s" direction="in"/>
+   <arg name="value" type="v" direction="in"/>
+  </method>
+  <method name="GetAll">
+   <arg name="interface_name" type="s" direction="in"/>
+   <arg name="props" type="a{sv}" direction="out"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
+  </method>
+ </interface>
+</node>

--- a/src/volumecontrol.cpp
+++ b/src/volumecontrol.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2022 - Ed Beroset <beroset@ieee.org>
  * Copyright (C) 2017 - Florent Revest <revestflo@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -27,202 +28,53 @@
  */
 
 #include "volumecontrol.h"
+#include "VolumeControl2.h"
 #include <QDBusMessage>
 #include <QDBusConnection>
 #include <QDBusArgument>
-#include <dbus/dbus-glib-lowlevel.h>
-#include <QTimer>
-#include <QDebug>
+#include <QDBusReply>
 
-#define DBUS_ERR_CHECK(err) \
-    if (dbus_error_is_set(&err)) \
-    { \
-        qWarning() << err.message; \
-        dbus_error_free(&err); \
-    }
+/* 
+ * This manipulates the master volume via the interface described here:
+ * https://wiki.merproject.org/wiki/Nemo/Audio/MainVolume
+ */
 
 static const char *VOLUME_SERVICE = "com.Meego.MainVolume2";
 static const char *VOLUME_PATH = "/com/meego/mainvolume2";
-static const char *VOLUME_INTERFACE = "com.Meego.MainVolume2";
 
-VolumeControl::VolumeControl(QObject *parent) :
-    QObject(parent),
-    dbusConnection(NULL),
-    volumePercentage(0),
-    maximumVolume(0),
-    effect(NULL),
-    reconnectTimeout(2000) // first reconnect after 2000ms
+static QString getPulseaudioBusAddress()
 {
-    update();
-}
-
-VolumeControl::~VolumeControl()
-{
-    if (dbusConnection != NULL) {
-        dbus_connection_remove_filter(dbusConnection, VolumeControl::signalHandler, (void *)this);
-        dbus_connection_unref(dbusConnection);
-    }
-}
-
-void VolumeControl::openConnection()
-{
-    //! If the connection already exists, do nothing
-    if ((dbusConnection != NULL) && (dbus_connection_get_is_connected(dbusConnection))) {
-        return;
-    }
-
-    // Establish a connection to the server
-    char *pa_bus_address = getenv("PULSE_DBUS_SERVER");
-    QByteArray addressArray;
-    if (pa_bus_address == NULL) {
-        QDBusMessage message = QDBusMessage::createMethodCall("org.pulseaudio.Server", "/org/pulseaudio/server_lookup1",
-                                                              "org.freedesktop.DBus.Properties", "Get");
-        message.setArguments(QVariantList() << "org.PulseAudio.ServerLookup1" << "Address");
-        QDBusMessage reply = QDBusConnection::sessionBus().call(message);
+    QString pa_bus_address{getenv("PULSE_DBUS_SERVER")};
+    if (pa_bus_address == nullptr) {
+        QDBusInterface pulseaudio("org.pulseaudio.Server", "/org/pulseaudio/server_lookup1", 
+            "org.freedesktop.DBus.Properties");
+        auto reply = pulseaudio.call("Get", "org.PulseAudio.ServerLookup1", "Address");
         if (reply.type() == QDBusMessage::ReplyMessage && reply.arguments().count() > 0) {
-            addressArray = reply.arguments().first().value<QDBusVariant>().variant().toString().toLatin1();
+            auto addressArray = reply.arguments().first().value<QDBusVariant>().variant().toString().toLatin1();
             pa_bus_address = addressArray.data();
         }
     }
-
-    if (pa_bus_address != NULL) {
-        DBusError dbus_err;
-        dbus_error_init(&dbus_err);
-
-        dbusConnection = dbus_connection_open(pa_bus_address, &dbus_err);
-
-        DBUS_ERR_CHECK(dbus_err);
-    }
-
-    if (dbusConnection != NULL) {
-        dbus_connection_setup_with_g_main(dbusConnection, NULL);
-        dbus_connection_add_filter(dbusConnection, VolumeControl::signalHandler, (void *)this, NULL);
-
-        addSignalMatch();
-    }
-
-    if (!dbusConnection) {
-        QTimer::singleShot(reconnectTimeout, this, SLOT(update()));
-        reconnectTimeout += 5000; // next reconnects wait for 5000ms more
-    }
+    return pa_bus_address;
 }
 
-void VolumeControl::update()
+VolumeControl::VolumeControl(QObject *parent) :
+    QObject(parent)
 {
-    openConnection();
-
-    if (dbusConnection == NULL) {
-        return;
-    }
-
-    DBusError error;
-    dbus_error_init(&error);
-
-    DBusMessage *reply = NULL;
-    DBusMessage *msg = dbus_message_new_method_call(VOLUME_SERVICE, VOLUME_PATH, "org.freedesktop.DBus.Properties", "GetAll");
-    if (msg != NULL) {
-        dbus_message_append_args(msg, DBUS_TYPE_STRING, &VOLUME_INTERFACE, DBUS_TYPE_INVALID);
-
-        reply = dbus_connection_send_with_reply_and_block(dbusConnection, msg, -1, &error);
-
-        DBUS_ERR_CHECK (error);
-
-        dbus_message_unref(msg);
-    }
-
-    int currentStep = -1, stepCount = -1;
-
-    if (reply != NULL) {
-        if (dbus_message_get_type(reply) == DBUS_MESSAGE_TYPE_METHOD_RETURN) {
-            DBusMessageIter iter;
-            dbus_message_iter_init(reply, &iter);
-            // Recurse into the array [array of dicts]
-            while (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_INVALID) {
-                DBusMessageIter dict_entry;
-                dbus_message_iter_recurse(&iter, &dict_entry);
-
-                // Recurse into the dict [ dict_entry (string, variant) ]
-                while (dbus_message_iter_get_arg_type(&dict_entry) != DBUS_TYPE_INVALID) {
-                    DBusMessageIter in_dict;
-                    // Recurse into the dict_entry [ string, variant ]
-                    dbus_message_iter_recurse(&dict_entry, &in_dict);
-                    {
-                        const char *prop_name = NULL;
-                        // Get the string value, "property name"
-                        dbus_message_iter_get_basic(&in_dict, &prop_name);
-
-                        dbus_message_iter_next(&in_dict);
-
-                        DBusMessageIter variant;
-                        // Recurse into the variant [ variant ]
-                        dbus_message_iter_recurse(&in_dict, &variant);
-
-                        if (prop_name == NULL) {
-                        } else if (dbus_message_iter_get_arg_type(&variant) == DBUS_TYPE_UINT32) {
-                            quint32 value;
-                            dbus_message_iter_get_basic(&variant, &value);
-
-                            if (strcmp(prop_name, "StepCount") == 0) {
-                                stepCount = value;
-                            } else if (strcmp(prop_name, "CurrentStep") == 0) {
-                                currentStep = value;
-                            } 
-                        }
-                    }
-
-                    dbus_message_iter_next(&dict_entry);
-                }
-                dbus_message_iter_next(&iter);
-            }
-        }
-        dbus_message_unref(reply);
-    }
-
-    if (currentStep != -1 && stepCount != -1) {
-        setSteps(currentStep, stepCount);
-    }
+    auto busname = getPulseaudioBusAddress();
+    auto con = QDBusConnection::connectToPeer(busname, VOLUME_SERVICE);
+    m_volIface = new ComMeegoMainVolume2Interface(VOLUME_SERVICE, VOLUME_PATH, con, this);
+    setSteps(m_volIface->stepCount(), m_volIface->currentStep());
+    connect(m_volIface, &ComMeegoMainVolume2Interface::StepsUpdated, this, &VolumeControl::setSteps);
 }
 
-void VolumeControl::addSignalMatch()
+void VolumeControl::setSteps(uint stepCount, uint currentStep)
 {
-    DBusMessage *message = dbus_message_new_method_call(NULL, "/org/pulseaudio/core1", NULL, "ListenForSignal");
-    if (message != NULL) {
-        const char *signalPtr = "com.Meego.MainVolume2.StepsUpdated";
-        char **emptyarray = { NULL };
-        dbus_message_append_args(message, DBUS_TYPE_STRING, &signalPtr, DBUS_TYPE_ARRAY, DBUS_TYPE_OBJECT_PATH,
-                                 &emptyarray, 0, DBUS_TYPE_INVALID);
-        dbus_connection_send(dbusConnection, message, NULL);
-        dbus_message_unref(message);
-    }
-}
-
-DBusHandlerResult VolumeControl::signalHandler(DBusConnection *, DBusMessage *message, void *control)
-{
-    if (!message)
-        return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-
-    DBusError error;
-    dbus_error_init(&error);
-
-    if (dbus_message_has_member(message, "StepsUpdated")) {
-        quint32 currentStep = 0;
-        quint32 stepCount = 0;
-
-        if (dbus_message_get_args(message, &error, DBUS_TYPE_UINT32, &stepCount, DBUS_TYPE_UINT32, &currentStep, DBUS_TYPE_INVALID)) {
-            static_cast<VolumeControl*>(control)->setSteps(currentStep, stepCount);
-        }
-    }
-
-    DBUS_ERR_CHECK (error);
-    return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-}
-
-void VolumeControl::setSteps(quint32 volume, quint32 stepCount)
-{
-    // The pulseaudio API reports the step count (starting from 0), so the maximum volume is stepCount - 1
+    /* The pulseaudio API reports the step count (starting from 0), 
+     * so the maximum volume is stepCount - 1
+     */
     maximumVolume = stepCount-1;
-    quint32 clampedVolume = qMin(volume, maximumVolume);
-    int newVolumePercentage = 100*(float)clampedVolume/(float)(maximumVolume);
+    quint32 clampedVolume = qMin(currentStep, maximumVolume);
+    int newVolumePercentage = 100.0 * clampedVolume / maximumVolume;
 
     if (volumePercentage != newVolumePercentage) {
         volumePercentage = newVolumePercentage;
@@ -233,51 +85,17 @@ void VolumeControl::setSteps(quint32 volume, quint32 stepCount)
 void VolumeControl::setVolume(int volume)
 {
     int newVolumePercentage = qBound(0, volume, 100);
-    int newVolume = (maximumVolume)*(float)newVolumePercentage/(float)100;
-
-    if (newVolumePercentage != volumePercentage) {
+    quint32 newVolume = maximumVolume / 100.0 * newVolumePercentage;
+    if (volumePercentage != newVolumePercentage) {
         volumePercentage = newVolumePercentage;
-        // Check the connection, maybe PulseAudio restarted meanwhile
-        openConnection();
-
-        // Don't try to set the volume via D-bus when it isn't available
-        if (dbusConnection == NULL) {
-            return;
-        }
-
-        DBusMessage *message = dbus_message_new_method_call(VOLUME_SERVICE, VOLUME_PATH, "org.freedesktop.DBus.Properties", "Set");
-        if (message != NULL) {
-            static const char *method = "CurrentStep";
-            if (dbus_message_append_args(message, DBUS_TYPE_STRING, &VOLUME_INTERFACE, DBUS_TYPE_STRING, &method, DBUS_TYPE_INVALID)) {
-                DBusMessageIter append;
-                DBusMessageIter sub;
-
-                // Create and append the variant argument ...
-                dbus_message_iter_init_append(message, &append);
-
-                dbus_message_iter_open_container(&append, DBUS_TYPE_VARIANT, DBUS_TYPE_UINT32_AS_STRING, &sub);
-                // Set the variant argument value:
-                dbus_message_iter_append_basic(&sub, DBUS_TYPE_UINT32, &newVolume);
-                // Close the append iterator
-                dbus_message_iter_close_container(&append, &sub);
-
-                // Send/flush the message immediately:
-                dbus_connection_send(dbusConnection, message, NULL);
-            }
-
-            dbus_message_unref(message);
-        }
         emit volumeChanged();
-        if(effect != NULL)
-            effect->stop();
-        effect = new QMediaPlayer(this);
-        effect->setMedia(QUrl::fromLocalFile("/usr/share/sounds/notification.wav"));
-        effect->play();
+        if (m_volIface->isValid()) {
+            m_volIface->setCurrentStep(newVolume);
+            if(effect != NULL)
+                effect->stop();
+            effect = new QMediaPlayer(this);
+            effect->setMedia(QUrl::fromLocalFile("/usr/share/sounds/notification.wav"));
+            effect->play();
+        }
     }
 }
-
-int VolumeControl::volume()
-{
-    return volumePercentage;
-}
-

--- a/src/volumecontrol.h
+++ b/src/volumecontrol.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2022 - Ed Beroset <beroset@ieee.org>
  * Copyright (C) 2017 - Florent Revest <revestflo@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -31,7 +32,8 @@
 
 #include <QObject>
 #include <QMediaPlayer>
-#include <dbus/dbus.h>
+
+class ComMeegoMainVolume2Interface;
 
 class VolumeControl : public QObject
 {
@@ -40,26 +42,18 @@ class VolumeControl : public QObject
 
 public:
     VolumeControl(QObject *parent = NULL);
-    virtual ~VolumeControl();
+    int volume() const { return volumePercentage; }
+    void setVolume(int volume);
 
 signals:
     void volumeChanged();
 
-public slots:
-    void update();
-    void setVolume(int volume);
-
 private:
-    int volume();
-    void openConnection();
-    void setSteps(quint32 currentStep, quint32 stepCount);
-    void addSignalMatch();
-    static DBusHandlerResult signalHandler(DBusConnection *conn, DBusMessage *message, void *control);
-    DBusConnection *dbusConnection;
-    int volumePercentage;
-    quint32 maximumVolume;
-    QMediaPlayer *effect;
-    int reconnectTimeout;
+    void setSteps(uint stepCount, uint currentStep);
+    ComMeegoMainVolume2Interface *m_volIface = nullptr;
+    int volumePercentage = 0;
+    quint32 maximumVolume = 0;
+    QMediaPlayer *effect = nullptr;
 };
 
 #endif


### PR DESCRIPTION
This addresses issue #30 and removes the dependency on the obsolete
dbus-glib library.  Instead, it uses QDbus for somewhat smaller and
cleaner code, but with one remaining issue, which is that the callback
from the StepsUpdated signal from com.Meego.MainVolume2 service is never
triggered.  A workaround is to set the values explicitly within this
code each time the volume is changed, but this does not allow the
volume level display to be updated if it's done by some other
application while the volume setting display is open.