### PR TITLE
Enhance about

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include <QQuickView>
 #include <QScreen>
 #include <QtQml>
+#include <sys/utsname.h>
 
 #include <asteroidapp.h>
 
@@ -28,12 +29,16 @@
 
 int main(int argc, char *argv[])
 {
+    utsname buf;
+    uname(&buf);
     QScopedPointer<QGuiApplication> app(AsteroidApp::application(argc, argv));
     QScopedPointer<QQuickView> view(AsteroidApp::createView());
     qmlRegisterType<VolumeControl>("org.asteroid.settings", 1, 0, "VolumeControl");
     qmlRegisterType<TiltToWake>("org.asteroid.settings", 1, 0, "TiltToWake");
     qmlRegisterType<TapToWake>("org.asteroid.settings", 1, 0, "TapToWake");
     view->setSource(QUrl("qrc:/qml/main.qml"));
+    view->rootContext()->setContextProperty("qtVersion", QString(qVersion()));
+    view->rootContext()->setContextProperty("kernelVersion", QString(buf.release));
     view->resize(app->primaryScreen()->size());
     view->show();
     return app->exec();

--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2022 - Ed Beroset <beroset@ieee.org>
  * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,37 +17,76 @@
  */
 
 import QtQuick 2.9
+import org.asteroid.utils 1.0
 import org.asteroid.controls 1.0
 import org.nemomobile.systemsettings 1.0
 
-Item {
+Flickable {
     AboutSettings {
         id: about
     }
+    DiskUsage {
+        id: diskUsage
+    }
 
-    Icon {
-        name: "logo-asteroidos"
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.topMargin: Dims.h(10)
-        anchors.top: parent.top
-        anchors.bottom: osLabel.top
-        anchors.bottomMargin: Dims.h(3)
-        width: height
-    }
-    Label {
-        id: osLabel
-        text: about.operatingSystemName
-        font.bold: true
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.bottom: releaseLabel.top
-    }
-    Label {
-        id: releaseLabel
-        text: about.softwareVersion
-        opacity: 0.8
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: Dims.h(7)
+    contentHeight: contentcolumn.implicitHeight
+    Column {
+        id: contentcolumn
+        anchors.fill: parent
+        Item { //this acts as a spacer to put the logo in the middle of the screen.
+            height: parent.width*0.1
+            width: height
+        }
+        Icon {
+            name: "logo-asteroidos"
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: parent.width*0.4
+            height: width
+        }
+        Label {
+            id: osLabel
+            text: about.operatingSystemName
+            anchors.horizontalCenter: parent.horizontalCenter
+        }
+        Label {
+            id: releaseLabel
+            text: about.softwareVersion
+            opacity: 0.8
+            anchors.horizontalCenter: parent.horizontalCenter
+        }
+        Repeater {
+            model: [
+                { label: qsTr("Build ID"), text: DeviceInfo.buildID },
+                { label: qsTr("Codename"), text: DeviceInfo.machineName },
+                { label: qsTr("Host name"), text: DeviceInfo.hostname },
+                { label: qsTr("WLAN MAC"), text: about.wlanMacAddress },
+                { label: qsTr("IMEI"), text: about.imei },
+                { label: qsTr("Serial number"), text: about.serial },
+                { label: qsTr("Total disk space"), text: qsTr("%L1").arg(Math.round(about.totalDiskSpace() / 1e7)/100) + " GB" },
+                { label: qsTr("Available disk space"), text: qsTr("%L1").arg(Math.round(about.availableDiskSpace() / 1e7)/100)
+                            + " GB (" + (100.0 * about.availableDiskSpace() / about.totalDiskSpace()).toFixed(0) + "%)" },
+                { label: qsTr("Display size"), text: Dims.w(100) + qsTr("W") + " x " + Dims.h(100) + qsTr("H") },
+                { label: qsTr("Kernel version"), text: kernelVersion },
+                { label: qsTr("Qt version"), text: qtVersion }
+            ]
+            delegate: Column {
+                width: contentcolumn.width
+                anchors.horizontalCenter: contentcolumn.horizontalCenter
+                visible: modelData.text
+                Item {
+                    height: parent.width*0.05
+                    width: height
+                }
+                Label {
+                    text: modelData.label
+                    font.bold: true
+                    anchors.horizontalCenter: parent.horizontalCenter
+                }
+                Label {
+                    text: modelData.text
+                    anchors.horizontalCenter: parent.horizontalCenter
+                }
+            }
+        }
     }
 }
-


### PR DESCRIPTION
This enhances the About page by adding many requested data items.  Anything that is not relevant or not available (e.g. the IMEI on watches without cellular network capability) is not displayed.  This, in combination with some other PRs addresses most of issue #33 