### PR TITLE
LanguagePage: Show selected language in place instead of animating through the list.

### DIFF
--- a/src/qml/LanguagePage.qml
+++ b/src/qml/LanguagePage.qml
@@ -45,7 +45,7 @@ Item {
     Component.onCompleted: {
         var i = langSettings.currentIndex;
         if(i != -1)
-            langLV.currentIndex = i
+            langLV.positionViewAtIndex(i, ListView.SnapPosition)
     }
 
     IconButton {


### PR DESCRIPTION
Other components show the current selection in place, the language selector appears to be the exception to this.

This implements a change that was part of a previous PR: https://github.com/AsteroidOS/asteroid-settings/pull/41/files#diff-53af673de884c3a59e579fbef9e47e375eb4e78099ce466dad6183f25e8e178aL48 that wasn't merged.