### PR TITLE
USBPage & TimePage: Show selected option in place instead of animating through the list.

### DIFF
--- a/src/qml/TimePage.qml
+++ b/src/qml/TimePage.qml
@@ -77,7 +77,7 @@ Item {
     Component.onCompleted: {
         var hour = wallClock.time.getHours();
         if(use12H.value) {
-            amPmLV.currentIndex = hour / 12;
+            amPmLV.positionViewAtIndex(hour / 12, ListView.SnapPosition);
             hour = hour % 12;
         }
         hourLV.currentIndex = hour;

--- a/src/qml/USBPage.qml
+++ b/src/qml/USBPage.qml
@@ -70,10 +70,10 @@ Item {
 
     Component.onCompleted: {
         usbmodedDbus.typedCall('get_config', [], function (mode) {
-            if     (mode == "mtp_mode")       usbModeLV.currentIndex = 3
-            else if(mode == "developer_mode") usbModeLV.currentIndex = 2
-            else if(mode == "adb_mode")       usbModeLV.currentIndex = 1
-            else  /*mode == "charging_only"*/ usbModeLV.currentIndex = 0
+            if     (mode == "mtp_mode")       usbModeLV.positionViewAtIndex(3, ListView.SnapPosition)
+            else if(mode == "developer_mode") usbModeLV.positionViewAtIndex(2, ListView.SnapPosition)
+            else if(mode == "adb_mode")       usbModeLV.positionViewAtIndex(1, ListView.SnapPosition)
+            else  /*mode == "charging_only"*/ usbModeLV.positionViewAtIndex(0, ListView.SnapPosition)
         });
     }
 


### PR DESCRIPTION
This is a follow-up PR of https://github.com/AsteroidOS/asteroid-settings/pull/57.
