### PR TITLE
Update nightstand mode

### DIFF
--- a/src/qml/NightstandPage.qml
+++ b/src/qml/NightstandPage.qml
@@ -26,6 +26,28 @@ import org.nemomobile.systemsettings 1.0
 import Nemo.Configuration 1.0
 
 Item {
+    property alias nightstandwatchface: watchfaceNightstandSource.value
+    property alias regularwatchface: watchfaceSource.value
+    property string assetPath: "file:///usr/share/asteroid-launcher/"
+
+    ConfigurationValue {
+        id: nightstandTracksRegularWatchface
+        key: "/desktop/asteroid/nightstand/samewatchface"
+        defaultValue: true
+    }
+
+    ConfigurationValue {
+        id: watchfaceSource
+        key: "/desktop/asteroid/watchface"
+        defaultValue: assetPath + "watchfaces/000-default-digital.qml"
+    }
+
+    ConfigurationValue {
+        id: watchfaceNightstandSource
+        key: "/desktop/asteroid/nightstand/watchface"
+        defaultValue: assetPath + "watchfaces/000-default-digital.qml"
+    }
+
     ConfigurationValue {
         id: nightstandBrightness
         key: "/desktop/asteroid/nightstand/brightness"
@@ -110,40 +132,20 @@ Item {
                 }
             }
 
-            Item {
+            LabeledSwitch {
+                //% "Use Custom Watchface"
+                text: qsTrId("id-nightstand-custom-watchface")
                 width: parent.width
                 height: Dims.l(20)
                 opacity: nightstandEnabled.value ? 1.0 : 0.4
 		enabled: nightstandEnabled.value
-
-                MouseArea {
-                    id: mouseArea
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    onClicked: layerStack.push(nightstandWatchfaceLayer)
-                }
-
-                Rectangle {
-                    anchors.fill: parent
-                    color: "white"
-                    opacity: mouseArea.containsPress ? 0.2 : 0
-                }
-
-                Label {
-                    //% "Select watchface"
-                    text: qsTrId("id-nightstand-watchface")
-                    font.pixelSize: Dims.l(6)
-                    verticalAlignment: Text.AlignVCenter
-                    height: parent.height
-                    width: parent.width * 0.7143
-                    wrapMode: Text.Wrap
-                }
-                Icon {
-                    id: nextButton
-                    name: "ios-arrow-dropright"
-                    height: parent.height
-                    width: height
-                    anchors.right: parent.right
+                checked: nightstandTracksRegularWatchface.value
+                onCheckedChanged: {
+                    if (checked) {
+                        layerStack.push(nightstandWatchfaceLayer)
+                    } else {
+                        nightstandwatchface = regularwatchface
+                    }
                 }
             }
 

--- a/src/qml/NightstandPage.qml
+++ b/src/qml/NightstandPage.qml
@@ -41,7 +41,7 @@ Item {
     ConfigurationValue {
         id: nightstandEnabled
         key: "/desktop/asteroid/nightstand/enabled"
-        defaultValue: false
+        defaultValue: true
     }
 
     PageHeader {

--- a/src/qml/NightstandWatchfacePage.qml
+++ b/src/qml/NightstandWatchfacePage.qml
@@ -27,7 +27,6 @@ import Nemo.Time 1.0
 
 Item {
 
-    property alias displayAmbient: compositor.displayAmbient
     property string assetPath: "file:///usr/share/asteroid-launcher/"
     property alias watchface: watchfaceNightstandSource.value
 
@@ -41,17 +40,6 @@ Item {
         id: wallpaperSource
         key: "/desktop/asteroid/background-filename"
         defaultValue: "file:///usr/share/asteroid-launcher/wallpapers/full/000-flatmesh.qml"
-    }
-
-    ConfigurationValue {
-        id: use12H
-        key: "/org/asteroidos/settings/use-12h-format"
-        defaultValue: false
-    }
-
-    QtObject {
-        id: compositor
-        property bool displayAmbient: false
     }
 
     WatchfaceSelector {

--- a/src/qml/NightstandWatchfacePage.qml
+++ b/src/qml/NightstandWatchfacePage.qml
@@ -34,7 +34,7 @@ Item {
     ConfigurationValue {
         id: watchfaceNightstandSource
         key: "/desktop/asteroid/nightstand/watchface"
-        defaultValue: assetPath + "watchfaces/005-analog-nordic.qml"
+        defaultValue: assetPath + "watchfaces/000-default-digital.qml"
     }
 
     ConfigurationValue {

--- a/src/qml/WatchfacePage.qml
+++ b/src/qml/WatchfacePage.qml
@@ -26,7 +26,6 @@ import Nemo.Configuration 1.0
 import Nemo.Time 1.0
 
 Item {
-    property alias displayAmbient: compositor.displayAmbient
     property string assetPath: "file:///usr/share/asteroid-launcher/"
     property alias watchface: watchfaceSource.value
 
@@ -40,17 +39,6 @@ Item {
         id: wallpaperSource
         key: "/desktop/asteroid/background-filename"
         defaultValue: "file:///usr/share/asteroid-launcher/wallpapers/full/000-flatmesh.qml"
-    }
-
-    ConfigurationValue {
-        id: use12H
-        key: "/org/asteroidos/settings/use-12h-format"
-        defaultValue: false
-    }
-
-    QtObject {
-        id: compositor
-        property bool displayAmbient: false
     }
 
     WatchfaceSelector {


### PR DESCRIPTION
This change was suggested by @eLtMosen and @dodoradio on Matrix chat.  It sets Nightstand mode to be turned ON by default and uses the same watchface as the regular watchface by default.  As the user changes the regular watchface, the nightstand watchface is also change UNLESS the user has selected a different watchface for nightstand mode.