### PR TITLE
Nightstand: Add support for using the regular watchface

### DIFF
--- a/i18n/asteroid-settings.ar.ts
+++ b/i18n/asteroid-settings.ar.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>منضدة السرير</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>إعدادات</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>تمكين</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>السطوع</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>التأخير</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>اختر واجهة الساعة</translation>

--- a/i18n/asteroid-settings.az.ts
+++ b/i18n/asteroid-settings.az.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Tənzimləmələr</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Aktivləşdirin</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Parlaqlıq</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Gecikmə</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Saat üzünü seçin</translation>

--- a/i18n/asteroid-settings.ca.ts
+++ b/i18n/asteroid-settings.ca.ts
@@ -162,6 +162,10 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.cs.ts
+++ b/i18n/asteroid-settings.cs.ts
@@ -162,6 +162,10 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.da.ts
+++ b/i18n/asteroid-settings.da.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Indstillinger</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Lysstyrke</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.de_DE.ts
+++ b/i18n/asteroid-settings.de_DE.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Nachttisch</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Einstellungen</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Aktivieren</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Helligkeit</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Verzögerung</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Zifferblatt wählen</translation>

--- a/i18n/asteroid-settings.el.ts
+++ b/i18n/asteroid-settings.el.ts
@@ -162,6 +162,10 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.en_GB.ts
+++ b/i18n/asteroid-settings.en_GB.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Nightstand</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Settings</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Enable</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brightness</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Delay</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation>Custom watchface</translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Select watchface</translation>

--- a/i18n/asteroid-settings.eo.ts
+++ b/i18n/asteroid-settings.eo.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Agordoj</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Brilo</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.es.ts
+++ b/i18n/asteroid-settings.es.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Mesa de noche</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Configuración</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Activar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brillo</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Retraso</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Seleccione la esfera del reloj</translation>

--- a/i18n/asteroid-settings.es_AR.ts
+++ b/i18n/asteroid-settings.es_AR.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Ajustes</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Brillo</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.fa.ts
+++ b/i18n/asteroid-settings.fa.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>پایهٔ شبانه</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>تنظیمات</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>به کار انداختن</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>روشنایی</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>تأخیر</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>گزینش صفحهٔ ساعت</translation>

--- a/i18n/asteroid-settings.fi.ts
+++ b/i18n/asteroid-settings.fi.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Asetukset</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Kirkkaus</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.fr.ts
+++ b/i18n/asteroid-settings.fr.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Table de nuit</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Paramètres</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Activer</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Luminosité</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Retard</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Sélectionner le cadran</translation>

--- a/i18n/asteroid-settings.gl.ts
+++ b/i18n/asteroid-settings.gl.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Mesita de noite</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Axustes</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Activar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brillo</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Atraso</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Seleccionala esfera do reloxo</translation>

--- a/i18n/asteroid-settings.he.ts
+++ b/i18n/asteroid-settings.he.ts
@@ -135,7 +135,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>שידה</translation>
     </message>
@@ -187,24 +187,29 @@
         <translation>הגדרות</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>הפעלה</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>בהירות</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>השהיה</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>בחירת פני השעון</translation>

--- a/i18n/asteroid-settings.hi.ts
+++ b/i18n/asteroid-settings.hi.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>रात्रिस्तंभ</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>सेटिंग्स</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>चालून करे</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>चमक</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>देरी</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>वॉचफेस चुनें</translation>

--- a/i18n/asteroid-settings.hr.ts
+++ b/i18n/asteroid-settings.hr.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Postavke</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Svjetlina</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.hu.ts
+++ b/i18n/asteroid-settings.hu.ts
@@ -162,6 +162,10 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.id.ts
+++ b/i18n/asteroid-settings.id.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Pengaturan</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Kecerahan</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.it.ts
+++ b/i18n/asteroid-settings.it.ts
@@ -162,6 +162,10 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Seleziona il quadrante</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ja.ts
+++ b/i18n/asteroid-settings.ja.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>設定</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">輝度</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.ka.ts
+++ b/i18n/asteroid-settings.ka.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>პარამეტრები</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">სიკაშკაშე</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.ko.ts
+++ b/i18n/asteroid-settings.ko.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>나이트스탠드</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>설정</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>활성화</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>밝기</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>지연</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>시계 모드 선택</translation>

--- a/i18n/asteroid-settings.lb.ts
+++ b/i18n/asteroid-settings.lb.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Astellungen</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Hellegkeet</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.lt.ts
+++ b/i18n/asteroid-settings.lt.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Naktinis staliukas</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Nustatymai</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Įjungti</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Ryškumas</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Atidėjimas</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Pasirinkite laikrodžio veidą</translation>

--- a/i18n/asteroid-settings.mr.ts
+++ b/i18n/asteroid-settings.mr.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>सेटिंग्ज</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">उज्ज्वलता</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.ms.ts
+++ b/i18n/asteroid-settings.ms.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Tetapan</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Kecerahan</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.nb_NO.ts
+++ b/i18n/asteroid-settings.nb_NO.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished">Nattbord</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Innstillinger</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished">Skru på</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Lysstyrke</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished">Forsinkelse</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Velg urskive</translation>

--- a/i18n/asteroid-settings.nl_BE.ts
+++ b/i18n/asteroid-settings.nl_BE.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Instellingen</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Helderheid</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.nl_NL.ts
+++ b/i18n/asteroid-settings.nl_NL.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Instellingen</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Helderheid</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.pl.ts
+++ b/i18n/asteroid-settings.pl.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Ustawienia</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Włącz</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Jasność</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Opóźnienie</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Wybierz tarczę zegarka</translation>

--- a/i18n/asteroid-settings.pt.ts
+++ b/i18n/asteroid-settings.pt.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Definições</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Ativar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brilho</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Atraso</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Selecione a face do relógio</translation>

--- a/i18n/asteroid-settings.pt_BR.ts
+++ b/i18n/asteroid-settings.pt_BR.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Modo criado-mudo</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Configurações</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Habilitar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brilho</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Atraso</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Selecionar face do relógio</translation>

--- a/i18n/asteroid-settings.pt_PT.ts
+++ b/i18n/asteroid-settings.pt_PT.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Definições</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Ativar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Brilho</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Atraso</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.ro.ts
+++ b/i18n/asteroid-settings.ro.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Noptieră</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Setări</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Pornește</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Luminozitate</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Întârziere</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Selectează față de ceas</translation>

--- a/i18n/asteroid-settings.ru.ts
+++ b/i18n/asteroid-settings.ru.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished">Ночной вид</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Настройки</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Включить</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Яркость</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Задержка</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Выбрать циферблат</translation>

--- a/i18n/asteroid-settings.sk.ts
+++ b/i18n/asteroid-settings.sk.ts
@@ -162,6 +162,10 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Zvoliť ciferník</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.sq.ts
+++ b/i18n/asteroid-settings.sq.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.sv.ts
+++ b/i18n/asteroid-settings.sv.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Inställningar</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Ljusstyrka</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.ta.ts
+++ b/i18n/asteroid-settings.ta.ts
@@ -162,6 +162,10 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.te.ts
+++ b/i18n/asteroid-settings.te.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>సెట్టింగ్స్</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">ప్రకాశం</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/i18n/asteroid-settings.th.ts
+++ b/i18n/asteroid-settings.th.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>ตั้งค่า</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>ใช้งาน</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">ความสว่าง</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>เลื่อนเวลา</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>เลือกหน้าปัดนาฬิกา</translation>

--- a/i18n/asteroid-settings.tr.ts
+++ b/i18n/asteroid-settings.tr.ts
@@ -162,6 +162,10 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Saat yüzünü seç</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.uk.ts
+++ b/i18n/asteroid-settings.uk.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Нічний вид</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Налаштування</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Увімкнути</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Яскравість</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Затримка</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Виберіть циферблат</translation>

--- a/i18n/asteroid-settings.vi.ts
+++ b/i18n/asteroid-settings.vi.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Đầu giường</translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>Cài đặt</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation>Bật</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Độ sáng</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Trì hoãn</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Chọn mặt đồng hồ</translation>

--- a/i18n/asteroid-settings.zh_Hans.ts
+++ b/i18n/asteroid-settings.zh_Hans.ts
@@ -162,6 +162,10 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>选择表盘</translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.zh_Hant.ts
+++ b/i18n/asteroid-settings.zh_Hant.ts
@@ -134,7 +134,7 @@
     </message>
     <message id="id-nightstand-page">
         <location filename="../src/qml/main.qml" line="108"/>
-        <location filename="../src/qml/NightstandPage.qml" line="49"/>
+        <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
@@ -186,24 +186,29 @@
         <translation>設定</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="64"/>
+        <location filename="../src/qml/NightstandPage.qml" line="70"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="77"/>
+        <location filename="../src/qml/NightstandPage.qml" line="83"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">亮度</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="97"/>
+        <location filename="../src/qml/NightstandPage.qml" line="103"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="137"/>
+        <source>Custom watchface</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="134"/>
+        <location filename="../src/qml/NightstandPage.qml" line="166"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>

--- a/src/qml/NightstandPage.qml
+++ b/src/qml/NightstandPage.qml
@@ -44,6 +44,12 @@ Item {
         defaultValue: false
     }
 
+    ConfigurationValue {
+        id: nightstandUseCustomWatchface
+        key: "/desktop/asteroid/nightstand/use-custom-watchface"
+        defaultValue: false
+    }
+
     PageHeader {
         id: title
         text: qsTrId("id-nightstand-page")
@@ -113,8 +119,34 @@ Item {
             Item {
                 width: parent.width
                 height: Dims.l(20)
+
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: nightstandUseCustomWatchface.value = !nightstandUseCustomWatchface.value
+                    Rectangle {
+                        anchors.fill: parent
+                        color: "white"
+                        opacity: parent.containsPress ? 0.2 : 0
+                    }
+                }
+
+                LabeledSwitch {
+                    anchors.fill: parent
+                    //% "Custom watchface"
+                    text: qsTrId("id-nightstand-custom-watchface")
+                    checked: nightstandUseCustomWatchface.value
+                    opacity: nightstandEnabled.value ? 1.0 : 0.4
+                    onCheckedChanged: nightstandUseCustomWatchface.value = checked
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: Dims.l(20)
                 opacity: nightstandEnabled.value ? 1.0 : 0.4
                 enabled: nightstandEnabled.value
+                visible: nightstandUseCustomWatchface.value
 
                 MouseArea {
                     id: mouseArea

--- a/src/qml/NightstandPage.qml
+++ b/src/qml/NightstandPage.qml
@@ -71,7 +71,7 @@ Item {
             Column {
                 width: parent.width
                 opacity: nightstandEnabled.value ? 1.0 : 0.4
-		enabled: nightstandEnabled.value
+                enabled: nightstandEnabled.value
                 Label {
                     //% "Brightness"
                     text: qsTrId("id-nightstand-brightness")
@@ -91,7 +91,7 @@ Item {
             Column {
                 width: parent.width
                 opacity: nightstandEnabled.value ? 1.0 : 0.4
-		enabled: nightstandEnabled.value
+                enabled: nightstandEnabled.value
                 Label {
                     //% "Delay"
                     text: qsTrId("id-nightstand-delay")
@@ -114,7 +114,7 @@ Item {
                 width: parent.width
                 height: Dims.l(20)
                 opacity: nightstandEnabled.value ? 1.0 : 0.4
-		enabled: nightstandEnabled.value
+                enabled: nightstandEnabled.value
 
                 MouseArea {
                     id: mouseArea


### PR DESCRIPTION
This follows up on the work done by @beroset in https://github.com/AsteroidOS/asteroid-settings/pull/59.

Essentially it adds support for using the same watchface for both nightstand mode and regular mode.

It implements a watchface tracking mode to ensure that the nightstand watchface matches the regular watchface whenever a different regular watchface is selected.