### PR TITLE
Rename Developer Mode to SSH Mode

### DIFF
--- a/i18n/asteroid-settings.ar.ts
+++ b/i18n/asteroid-settings.ar.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>وضع ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>وضع المطور</translation>
+        <source>SSH Mode</source>
+        <translation>وضع SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.ast.ts
+++ b/i18n/asteroid-settings.ast.ts
@@ -55,8 +55,8 @@
     </message>
     <message id="id-developer-mode">
         <location filename="../USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Mou de desendolcu</translation>
+        <source>SSH Mode</source>
+        <translation>Mou SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.az.ts
+++ b/i18n/asteroid-settings.az.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB Rejimi</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Yaradıcı Rejimi</translation>
+        <source>SSH Mode</source>
+        <translation>SSH Rejimi</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.ca.ts
+++ b/i18n/asteroid-settings.ca.ts
@@ -35,10 +35,6 @@
         <source>ADB Mode</source>
         <translation>Mode ADB</translation>
     </message>
-    <message id="id-developer-mode">
-        <source>Developer Mode</source>
-        <translation>Mode de desenvolupador</translation>
-    </message>
     <message id="id-mtp-mode">
         <source>MTP Mode</source>
         <translation>Mode MTP</translation>
@@ -165,6 +161,10 @@
     <message id="id-nightstand-custom-watchface">
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ssh-mode">
+        <source>SSH Mode</source>
+        <translation>Mode SSH</translation>
     </message>
 </context>
 <context>

--- a/i18n/asteroid-settings.ckb.ts
+++ b/i18n/asteroid-settings.ckb.ts
@@ -40,8 +40,8 @@
         <translation>شێوازی ADB</translation>
     </message>
     <message id="id-developer-mode">
-        <source>Developer Mode</source>
-        <translation>شێوازی گەشەپێدەر</translation>
+        <source>SSH Mode</source>
+        <translation>شێوازی SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <source>MTP Mode</source>

--- a/i18n/asteroid-settings.cs.ts
+++ b/i18n/asteroid-settings.cs.ts
@@ -35,10 +35,6 @@
         <source>ADB Mode</source>
         <translation>Režim ADB</translation>
     </message>
-    <message id="id-developer-mode">
-        <source>Developer Mode</source>
-        <translation>Vývojářský režim</translation>
-    </message>
     <message id="id-mtp-mode">
         <source>MTP Mode</source>
         <translation>MTP režim</translation>
@@ -165,6 +161,10 @@
     <message id="id-nightstand-custom-watchface">
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ssh-mode">
+        <source>SSH Mode</source>
+        <translation>Režim SSH</translation>
     </message>
 </context>
 <context>

--- a/i18n/asteroid-settings.da.ts
+++ b/i18n/asteroid-settings.da.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB-tilstand</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Udviklertilstand</translation>
+        <source>SSH Mode</source>
+        <translation>SSH-tilstand</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.de_DE.ts
+++ b/i18n/asteroid-settings.de_DE.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB-Modus</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Entwicklermodus</translation>
+        <source>SSH Mode</source>
+        <translation>SSH-Modus</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.el.ts
+++ b/i18n/asteroid-settings.el.ts
@@ -35,10 +35,6 @@
         <source>ADB Mode</source>
         <translation>Τρόπος Λειτουργίας ADB</translation>
     </message>
-    <message id="id-developer-mode">
-        <source>Developer Mode</source>
-        <translation>Τρόπος Λειτουργίας Προγραμματιστή</translation>
-    </message>
     <message id="id-mtp-mode">
         <source>MTP Mode</source>
         <translation>Τρόπος Λειτουργίας MTP</translation>
@@ -165,6 +161,10 @@
     <message id="id-nightstand-custom-watchface">
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ssh-mode">
+        <source>SSH Mode</source>
+        <translation>Τρόπος Λειτουργίας SSH</translation>
     </message>
 </context>
 <context>

--- a/i18n/asteroid-settings.en_GB.ts
+++ b/i18n/asteroid-settings.en_GB.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB Mode</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Developer Mode</translation>
+        <source>SSH Mode</source>
+        <translation>SSH Mode</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.eo.ts
+++ b/i18n/asteroid-settings.eo.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB-reĝimo</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Programista reĝimo</translation>
+        <source>SSH Mode</source>
+        <translation>SSH-reĝimo</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.es.ts
+++ b/i18n/asteroid-settings.es.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Modo desarrollador</translation>
+        <source>SSH Mode</source>
+        <translation>Modo SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.es_AR.ts
+++ b/i18n/asteroid-settings.es_AR.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Modo desarrollo</translation>
+        <source>SSH Mode</source>
+        <translation>Modo SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.fa.ts
+++ b/i18n/asteroid-settings.fa.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>پل توسعهٔ اندروید</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>حالت توسعه‌دهنده</translation>
+        <source>SSH Mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.fi.ts
+++ b/i18n/asteroid-settings.fi.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB Tila</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Kehittäjätila</translation>
+        <source>SSH Mode</source>
+        <translation>SSH Tila</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.fr.ts
+++ b/i18n/asteroid-settings.fr.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Mode ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Mode Développeur</translation>
+        <source>SSH Mode</source>
+        <translation>Mode SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.gl.ts
+++ b/i18n/asteroid-settings.gl.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Modo desenvolvedor</translation>
+        <source>SSH Mode</source>
+        <translation>Modo SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.he.ts
+++ b/i18n/asteroid-settings.he.ts
@@ -49,10 +49,10 @@
         <source>ADB Mode</source>
         <translation>מצב ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>מצב פיתוח</translation>
+        <source>SSH Mode</source>
+        <translation>מצב SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.hi.ts
+++ b/i18n/asteroid-settings.hi.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ए डी बी मोड</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>डेवलपर मोड</translation>
+        <source>SSH Mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.hr.ts
+++ b/i18n/asteroid-settings.hr.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB modus</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Modus za razvijatelje</translation>
+        <source>SSH Mode</source>
+        <translation>SSH modus</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.hu.ts
+++ b/i18n/asteroid-settings.hu.ts
@@ -35,10 +35,6 @@
         <source>ADB Mode</source>
         <translation>ADB használata</translation>
     </message>
-    <message id="id-developer-mode">
-        <source>Developer Mode</source>
-        <translation>Fejlesztői beállítások</translation>
-    </message>
     <message id="id-mtp-mode">
         <source>MTP Mode</source>
         <translation>MTP használata</translation>
@@ -165,6 +161,10 @@
     <message id="id-nightstand-custom-watchface">
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ssh-mode">
+        <source>SSH Mode</source>
+        <translation>SSH használata</translation>
     </message>
 </context>
 <context>

--- a/i18n/asteroid-settings.id.ts
+++ b/i18n/asteroid-settings.id.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Mode ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Mode Pengembang</translation>
+        <source>SSH Mode</source>
+        <translation>Mode SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.it.ts
+++ b/i18n/asteroid-settings.it.ts
@@ -35,10 +35,6 @@
         <source>ADB Mode</source>
         <translation>Modalità ADB</translation>
     </message>
-    <message id="id-developer-mode">
-        <source>Developer Mode</source>
-        <translation>Modalità sviluppatore</translation>
-    </message>
     <message id="id-mtp-mode">
         <source>MTP Mode</source>
         <translation>Modalità MTP</translation>
@@ -165,6 +161,10 @@
     <message id="id-nightstand-custom-watchface">
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ssh-mode">
+        <source>SSH Mode</source>
+        <translation>Modalità SSH</translation>
     </message>
 </context>
 <context>

--- a/i18n/asteroid-settings.ja.ts
+++ b/i18n/asteroid-settings.ja.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADBモード</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>開発者モード</translation>
+        <source>SSH Mode</source>
+        <translation>SSHモード</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.ka.ts
+++ b/i18n/asteroid-settings.ka.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB მეთოდი</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>დეველოპერის მეთოდი</translation>
+        <source>SSH Mode</source>
+        <translation>SSH მეთოდი</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.ko.ts
+++ b/i18n/asteroid-settings.ko.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB 모드</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>개발자 모드</translation>
+        <source>SSH Mode</source>
+        <translation>SSH 모드</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.lb.ts
+++ b/i18n/asteroid-settings.lb.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation></translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation></translation>
+        <source>SSH Mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.lt.ts
+++ b/i18n/asteroid-settings.lt.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB rėžimas</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Kūrėjo rėžimas</translation>
+        <source>SSH Mode</source>
+        <translation>SSH rėžimas</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.mr.ts
+++ b/i18n/asteroid-settings.mr.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>एडीबी मोड</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>विकासक मोड</translation>
+        <source>SSH Mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.ms.ts
+++ b/i18n/asteroid-settings.ms.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Mod ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Mod Pembangun</translation>
+        <source>SSH Mode</source>
+        <translation>Mod SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.nb_NO.ts
+++ b/i18n/asteroid-settings.nb_NO.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB-modus</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Utviklermodus</translation>
+        <source>SSH Mode</source>
+        <translation>SSH-modus</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.nl_BE.ts
+++ b/i18n/asteroid-settings.nl_BE.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB-modus</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Ontwikkelaarsmodus</translation>
+        <source>SSH Mode</source>
+        <translation>SSH-modus</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.nl_NL.ts
+++ b/i18n/asteroid-settings.nl_NL.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB-modus</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Ontwikkelaarsmodus</translation>
+        <source>SSH Mode</source>
+        <translation>SSH-modus</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.pl.ts
+++ b/i18n/asteroid-settings.pl.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Tryb ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Tryb Dewelopera</translation>
+        <source>SSH Mode</source>
+        <translation>Tryb SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.pt.ts
+++ b/i18n/asteroid-settings.pt.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Modo de ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Modo de Programador</translation>
+        <source>SSH Mode</source>
+        <translation>Modo de SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.pt_BR.ts
+++ b/i18n/asteroid-settings.pt_BR.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Modo desenvolvedor</translation>
+        <source>SSH Mode</source>
+        <translation>Modo SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.pt_PT.ts
+++ b/i18n/asteroid-settings.pt_PT.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Modo de ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Modo de Programador</translation>
+        <source>SSH Mode</source>
+        <translation>Modo de SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.ro.ts
+++ b/i18n/asteroid-settings.ro.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Mod ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Mod Dezvoltator</translation>
+        <source>SSH Mode</source>
+        <translation>Mod SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.ru.ts
+++ b/i18n/asteroid-settings.ru.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Режим ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Режим разработчика</translation>
+        <source>SSH Mode</source>
+        <translation>Режим SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.rue.ts
+++ b/i18n/asteroid-settings.rue.ts
@@ -50,8 +50,8 @@
     </message>
     <message id="id-developer-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Режим Створителя</translation>
+        <source>SSH Mode</source>
+        <translation>ADB режим</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.sk.ts
+++ b/i18n/asteroid-settings.sk.ts
@@ -35,10 +35,6 @@
         <source>ADB Mode</source>
         <translation>Mód ADB</translation>
     </message>
-    <message id="id-developer-mode">
-        <source>Developer Mode</source>
-        <translation>Možnosti pre vývojárov</translation>
-    </message>
     <message id="id-mtp-mode">
         <source>MTP Mode</source>
         <translation>Mód MTP</translation>
@@ -165,6 +161,10 @@
     <message id="id-nightstand-custom-watchface">
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ssh-mode">
+        <source>SSH Mode</source>
+        <translation>Mód SSH</translation>
     </message>
 </context>
 <context>

--- a/i18n/asteroid-settings.sq.ts
+++ b/i18n/asteroid-settings.sq.ts
@@ -48,9 +48,9 @@
         <source>ADB Mode</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
+        <source>SSH Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-mtp-mode">

--- a/i18n/asteroid-settings.sv.ts
+++ b/i18n/asteroid-settings.sv.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB-läge</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Utvecklarläge</translation>
+        <source>SSH Mode</source>
+        <translation>SSH-läge</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.ta.ts
+++ b/i18n/asteroid-settings.ta.ts
@@ -35,10 +35,6 @@
         <source>ADB Mode</source>
         <translation>ADB முறை</translation>
     </message>
-    <message id="id-developer-mode">
-        <source>Developer Mode</source>
-        <translation>உருவாக்குநர் முறை</translation>
-    </message>
     <message id="id-mtp-mode">
         <source>MTP Mode</source>
         <translation>MTP முறை</translation>
@@ -165,6 +161,10 @@
     <message id="id-nightstand-custom-watchface">
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ssh-mode">
+        <source>SSH Mode</source>
+        <translation>SSH முறை</translation>
     </message>
 </context>
 <context>

--- a/i18n/asteroid-settings.te.ts
+++ b/i18n/asteroid-settings.te.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ఎడిబి మోడ్</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>డెవలపర్ మోడ్</translation>
+        <source>SSH Mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.th.ts
+++ b/i18n/asteroid-settings.th.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>โหมด ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>โหมดผู้พัฒนา</translation>
+        <source>SSH Mode</source>
+        <translation>โหมด SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.tr.ts
+++ b/i18n/asteroid-settings.tr.ts
@@ -35,10 +35,6 @@
         <source>ADB Mode</source>
         <translation>ADB Kipi</translation>
     </message>
-    <message id="id-developer-mode">
-        <source>Developer Mode</source>
-        <translation>Geliştirici Kipi</translation>
-    </message>
     <message id="id-mtp-mode">
         <source>MTP Mode</source>
         <translation>MTP Kipi</translation>
@@ -165,6 +161,10 @@
     <message id="id-nightstand-custom-watchface">
         <source>Custom watchface</source>
         <translation>Özel saat yüzü</translation>
+    </message>
+    <message id="id-ssh-mode">
+        <source>SSH Mode</source>
+        <translation>SSH Kipi</translation>
     </message>
 </context>
 <context>

--- a/i18n/asteroid-settings.uk.ts
+++ b/i18n/asteroid-settings.uk.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB режим</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Режим розробника</translation>
+        <source>SSH Mode</source>
+        <translation>SSH режим</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.vec.ts
+++ b/i18n/asteroid-settings.vec.ts
@@ -50,8 +50,8 @@
     </message>
     <message id="id-developer-mode">
         <location filename="../USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Magnera desviłupador</translation>
+        <source>SSH Mode</source>
+        <translation>Magnera SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.vi.ts
+++ b/i18n/asteroid-settings.vi.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>Chế độ ADB</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>Chế độ nhà phát triển</translation>
+        <source>SSH Mode</source>
+        <translation>Chế độ SSH</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/i18n/asteroid-settings.zh_Hans.ts
+++ b/i18n/asteroid-settings.zh_Hans.ts
@@ -35,10 +35,6 @@
         <source>ADB Mode</source>
         <translation>ADB 模式</translation>
     </message>
-    <message id="id-developer-mode">
-        <source>Developer Mode</source>
-        <translation>开发者模式</translation>
-    </message>
     <message id="id-mtp-mode">
         <source>MTP Mode</source>
         <translation>MTP 模式</translation>
@@ -165,6 +161,10 @@
     <message id="id-nightstand-custom-watchface">
         <source>Custom watchface</source>
         <translation>自定义表盘</translation>
+    </message>
+    <message id="id-ssh-mode">
+        <source>SSH Mode</source>
+        <translation>SSH 模式</translation>
     </message>
 </context>
 <context>

--- a/i18n/asteroid-settings.zh_Hant.ts
+++ b/i18n/asteroid-settings.zh_Hant.ts
@@ -48,10 +48,10 @@
         <source>ADB Mode</source>
         <translation>ADB 模式</translation>
     </message>
-    <message id="id-developer-mode">
+    <message id="id-ssh-mode">
         <location filename="../src/qml/USBPage.qml" line="39"/>
-        <source>Developer Mode</source>
-        <translation>開發者模式</translation>
+        <source>SSH Mode</source>
+        <translation>SSH 模式</translation>
     </message>
     <message id="id-mtp-mode">
         <location filename="../src/qml/USBPage.qml" line="41"/>

--- a/src/qml/USBPage.qml
+++ b/src/qml/USBPage.qml
@@ -36,7 +36,7 @@ Item {
         //% "ADB Mode"
         ListElement { title: qsTrId("id-adb-mode"); mode: "adb_mode" }
         //% "SSH Mode"
-        ListElement { title: qsTrId("id-ssh-mode"); mode: "ssh_mode" }
+        ListElement { title: qsTrId("id-ssh-mode"); mode: "developer_mode" }
         //% "MTP Mode"
         ListElement { title: qsTrId("id-mtp-mode"); mode: "mtp_mode" }
     }
@@ -71,7 +71,7 @@ Item {
     Component.onCompleted: {
         usbmodedDbus.typedCall('get_config', [], function (mode) {
             if     (mode === "mtp_mode")       usbModeLV.positionViewAtIndex(3, ListView.SnapPosition)
-            else if(mode === "ssh_mode") usbModeLV.positionViewAtIndex(2, ListView.SnapPosition)
+            else if(mode === "developer_mode") usbModeLV.positionViewAtIndex(2, ListView.SnapPosition)
             else if(mode === "adb_mode")       usbModeLV.positionViewAtIndex(1, ListView.SnapPosition)
             else  /*mode === "charging_only"*/ usbModeLV.positionViewAtIndex(0, ListView.SnapPosition)
         });

--- a/src/qml/USBPage.qml
+++ b/src/qml/USBPage.qml
@@ -35,8 +35,8 @@ Item {
         ListElement { title: qsTrId("id-charging-only"); mode: "charging_only" }
         //% "ADB Mode"
         ListElement { title: qsTrId("id-adb-mode"); mode: "adb_mode" }
-        //% "Developer Mode"
-        ListElement { title: qsTrId("id-developer-mode"); mode: "developer_mode" }
+        //% "SSH Mode"
+        ListElement { title: qsTrId("id-ssh-mode"); mode: "ssh_mode" }
         //% "MTP Mode"
         ListElement { title: qsTrId("id-mtp-mode"); mode: "mtp_mode" }
     }
@@ -70,10 +70,10 @@ Item {
 
     Component.onCompleted: {
         usbmodedDbus.typedCall('get_config', [], function (mode) {
-            if     (mode == "mtp_mode")       usbModeLV.positionViewAtIndex(3, ListView.SnapPosition)
-            else if(mode == "developer_mode") usbModeLV.positionViewAtIndex(2, ListView.SnapPosition)
-            else if(mode == "adb_mode")       usbModeLV.positionViewAtIndex(1, ListView.SnapPosition)
-            else  /*mode == "charging_only"*/ usbModeLV.positionViewAtIndex(0, ListView.SnapPosition)
+            if     (mode === "mtp_mode")       usbModeLV.positionViewAtIndex(3, ListView.SnapPosition)
+            else if(mode === "ssh_mode") usbModeLV.positionViewAtIndex(2, ListView.SnapPosition)
+            else if(mode === "adb_mode")       usbModeLV.positionViewAtIndex(1, ListView.SnapPosition)
+            else  /*mode === "charging_only"*/ usbModeLV.positionViewAtIndex(0, ListView.SnapPosition)
         });
     }
 


### PR DESCRIPTION
This depends on 
- Rename of the Mode on the website https://github.com/AsteroidOS/asteroidos.org/pull/337

~a PR in asteroid build repo to rename the usb-moded files.~

