### PR TITLE
Improve legibility of the settings main page

### DIFF
--- a/src/qml/ListItem.qml
+++ b/src/qml/ListItem.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
+ *               2015 - Florent Revest <revestflo@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,45 +17,87 @@
  */
 
 import QtQuick 2.9
+import QtGraphicalEffects 1.15
 import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
 
 Item {
     id: gridItem
+
     property alias title: label.text
     property alias iconName: icon.name
     signal clicked()
 
     width: parent.width
-    height: Dims.h(16)
-
-    Icon {
-        id: icon
-        width: parent.height
-        height: width
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.leftMargin: Dims.w(15)
-    }
-    Label {
-        id: label
-        font.pixelSize: Dims.l(6)
-        horizontalAlignment: Text.AlignHCenter
-        anchors.leftMargin: Dims.w(12)
-        anchors.left: icon.right
-        anchors.verticalCenter: parent.verticalCenter
-    }
+    height: Dims.h(21)
 
     MouseArea {
         id: mouseArea
+
         anchors.fill: parent
-        hoverEnabled: true
         onClicked: gridItem.clicked()
     }
 
     Rectangle {
+        id: highlightPress
+
         anchors.fill: parent
-        color: "white"
+        color: "#ffffff"
         opacity: mouseArea.containsPress ? 0.2 : 0
+        Behavior on opacity {
+            NumberAnimation {
+                duration: 150;
+                easing.type: Easing.Linear
+            }
+        }
+    }
+
+    Item {
+        id: shadowArea
+
+        anchors.fill: parent
+
+        layer {
+            enabled: true
+            mipmap : true
+            samples: 2
+            effect: DropShadow {
+                cached: true
+                transparentBorder: true
+                horizontalOffset: 2
+                verticalOffset: 2
+                radius: 3.0
+                samples: 7
+                color: "#70000000"
+            }
+        }
+
+        Icon {
+            id: icon
+
+            width: parent.height - Dims.h(6)
+            height: width
+
+            anchors {
+                verticalCenter: parent.verticalCenter
+                left: parent.left
+                leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(18) : Dims.w(12)
+            }
+        }
+
+        Label {
+            id: label
+
+            anchors {
+                leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(6) : Dims.w(10)
+                left: icon.right
+                verticalCenter: parent.verticalCenter
+            }
+            font {
+                pixelSize: Dims.l(9)
+                styleName: "SemiCondensed Light"
+            }
+        }
     }
 }
 

--- a/src/qml/ListItem.qml
+++ b/src/qml/ListItem.qml
@@ -57,21 +57,6 @@ Item {
 
         anchors.fill: parent
 
-        layer {
-            enabled: true
-            mipmap : true
-            samples: 2
-            effect: DropShadow {
-                cached: true
-                transparentBorder: true
-                horizontalOffset: 2
-                verticalOffset: 2
-                radius: 3.0
-                samples: 7
-                color: "#70000000"
-            }
-        }
-
         Icon {
             id: icon
 

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -48,6 +48,7 @@ Application {
 
     LayerStack {
         id: layerStack
+
         firstPage: firstPageComponent
     }
 
@@ -64,7 +65,7 @@ Application {
                 id: settingsColumn
                 anchors.fill: parent
 
-                Item { width: parent.width; height: Dims.h(10); visible: DeviceInfo.hasRoundScreen }
+                Item { width: parent.width; height: DeviceInfo.hasRoundScreen ? Dims.h(6) : Dims.h(2) }
 
                 ListItem {
                     //% "Time"
@@ -158,7 +159,7 @@ Application {
                     onClicked: layerStack.push(aboutLayer)
                 }
 
-                Item { width: parent.width; height: Dims.h(10); visible: DeviceInfo.hasRoundScreen }
+                Item { width: parent.width; height: DeviceInfo.hasRoundScreen ? Dims.h(6) : Dims.h(2) }
             }
         }
     }


### PR DESCRIPTION
- Increase listitem height from Dims 16 to Dims 21 for better touch UX
- Add dropshadow for crisper font display
- Increase font size
- Change to SemiCondensed Light font for shorter run width
- Resize ion-icons to match the line width of the Light Noto Sans font
- Animate the highlight bar to fade in and out in 150ms
- Attempt performance improvement using layers and multisampling limited to the shadowArea tree
- Position icon centered between title and left screen border on square screens

Fixes https://github.com/AsteroidOS/asteroid-settings/issues/34

![settings-new5](https://user-images.githubusercontent.com/15074193/232346970-3c52b8e2-c71a-4894-a942-20f1efc7d1b1.jpg)
![settings-new4](https://user-images.githubusercontent.com/15074193/232346977-8da1bfba-1723-42cf-be5b-23c1d637e070.jpg)
