### PR TITLE
Add uptime to about

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 #include "volumecontrol.h"
 #include "tilttowake.h"
 #include "taptowake.h"
+#include "process.h"
 
 int main(int argc, char *argv[])
 {
@@ -36,6 +37,7 @@ int main(int argc, char *argv[])
     qmlRegisterType<VolumeControl>("org.asteroid.settings", 1, 0, "VolumeControl");
     qmlRegisterType<TiltToWake>("org.asteroid.settings", 1, 0, "TiltToWake");
     qmlRegisterType<TapToWake>("org.asteroid.settings", 1, 0, "TapToWake");
+    qmlRegisterType<Process>("Process", 1, 0, "Process");
     view->setSource(QUrl("qrc:/qml/main.qml"));
     view->rootContext()->setContextProperty("qtVersion", QString(qVersion()));
     view->rootContext()->setContextProperty("kernelVersion", QString(buf.release));

--- a/src/process.h
+++ b/src/process.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023 - Timo Könnecke <koennecke@mosushi.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Based on a code from nemo-qml-plugin-systemsettings under the following license.
+ *
+ * Copyright (C) 2013 Jolla Ltd. <pekka.vuorela@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include <QProcess>
+#include <QVariant>
+
+class Process : public QProcess {
+    Q_OBJECT
+
+public:
+    Process(QObject *parent = 0) : QProcess(parent) { }
+
+    Q_INVOKABLE void start(const QString &program, const QVariantList &arguments) {
+        QStringList args;
+
+        // convert QVariantList from QML to QStringList for QProcess
+
+        for (int i = 0; i < arguments.length(); i++)
+            args << arguments[i].toString();
+
+        QProcess::start(program, args);
+    }
+
+    Q_INVOKABLE QByteArray readAll() {
+        return QProcess::readAll();
+    }
+};

--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -19,6 +19,7 @@
 import QtQuick 2.9
 import org.asteroid.utils 1.0
 import org.asteroid.controls 1.0
+import Process 1.0
 import org.nemomobile.systemsettings 1.0
 
 Flickable {
@@ -27,6 +28,19 @@ Flickable {
     }
     DiskUsage {
         id: diskUsage
+    }
+
+    Process {
+        id: process
+        onReadyRead: uptime.text = readAll();
+    }
+
+    Timer {
+        interval: 1000
+        repeat: true
+        triggeredOnStart: true
+        running: true
+        onTriggered: process.start("/bin/cat", [ "/proc/uptime" ]);
     }
 
     contentHeight: contentcolumn.implicitHeight
@@ -54,6 +68,11 @@ Flickable {
             opacity: 0.8
             anchors.horizontalCenter: parent.horizontalCenter
         }
+
+        Text {
+            id: uptime
+        }
+
         Repeater {
             model: [
                 { label: qsTr("Build ID"), text: DeviceInfo.buildID },


### PR DESCRIPTION
- Expose the Qt [QProcess](http://doc.qt.io/qt-5/qprocess.html) class
- Register the Process class in main.cpp
- Add readAll() call, a timer to update every second and dummy text field for PoC purpose.

Compiling the changes works with no issues.
When however deploying to a watch, the settings app does not start and journal shows `undefined symbol: _ZTI7Process`
@beroset hinted at how to find out which symbol that is by using 
```
$ echo _ZTI7Process | c++filt                                                         
typeinfo for Process
```
Showing that QProcess is missing on the watches.
This PR as an incentive to add the QProcess class, since we could easily add all the missing wishlist feature by using cli commands and readAll() 
https://github.com/AsteroidOS/asteroid-settings/issues/33