### PR TITLE
Make timezone menu heirarchical

### DIFF
--- a/src/qml/TimezonePage.qml
+++ b/src/qml/TimezonePage.qml
@@ -44,10 +44,10 @@ Item {
                 if (tzAsList.length > (regionLevel + 1)) { //check if this item in the list has children
                     if (processedRegionList.indexOf(tzAsList[regionLevel]) < 0) {
                         processedRegionList.push(tzAsList[regionLevel]);
-                        timezoneModel.append({"visualName": tzAsList[regionLevel], "fullPath": region, "bottomLevel": false});
+                        timezoneModel.append({"visualName": tzAsList[regionLevel].replace("_"," ") + " ⋯", "name": tzAsList[regionLevel],"fullPath": region, "bottomLevel": false});
                     }
                 } else { //if this item doesn't have children - add it with a full name
-                    timezoneModel.append({"visualName": tzAsList[regionLevel], "fullPath": region, "bottomLevel": true});
+                    timezoneModel.append({"visualName": tzAsList[regionLevel].replace("_"," "), "name": tzAsList[regionLevel], "fullPath": region, "bottomLevel": true});
                 }
             } else {
                 //console.log("skipping ", region, " because it does not contain ", regionPath, " which is the region path");
@@ -94,7 +94,7 @@ Item {
                         function(error, message) { console.log('call failed', error, 'message:', message) }
                         );
                     } else {
-                        layerStack.push(timezoneLayer,{"regionLevel": root.regionLevel + 1, "regionPath": root.regionPath + visualName + "/", "selectedTz": root.selectedTz, "timezoneList": root.timezoneList})
+                        layerStack.push(timezoneLayer,{"regionLevel": root.regionLevel + 1, "regionPath": root.regionPath + model.name + "/", "selectedTz": root.selectedTz, "timezoneList": root.timezoneList})
                     }
                 }
             }

--- a/src/qml/TimezonePage.qml
+++ b/src/qml/TimezonePage.qml
@@ -83,17 +83,7 @@ Item {
             MouseArea {
                 anchors.fill: parent
                 onClicked: {
-                    if(model.bottomLevel) {
-                        var tzname = model.fullPath;
-                        console.log("Attempting to set timezone to ",tzname);
-                        timedateDbus.typedCall("SetTimezone", [
-                                { "type":"s", "value": tzname },
-                                { "type":"b", "value":"0" }
-                            ],
-                            function(result) { console.log('call completed with:', result) },
-                        function(error, message) { console.log('call failed', error, 'message:', message) }
-                        );
-                    } else {
+                    if(!model.bottomLevel) {
                         layerStack.push(timezoneLayer,{"regionLevel": root.regionLevel + 1, "regionPath": root.regionPath + model.name + "/", "selectedTz": root.selectedTz, "timezoneList": root.timezoneList})
                     }
                 }
@@ -110,18 +100,23 @@ Item {
         }
 
         onClicked: {
-            if(timezoneSpinner.currentIndex == root.currentIndex) {
-                root.pop();
+            if((root.regionPath + timezoneModel.get(timezoneSpinner.currentIndex).name) == root.selectedTz) {
+                app.backToMainMenu();
             } else {
-                var tzname = timezoneModel.get(timezoneSpinner.currentIndex).timezoneName;
-                console.log("Attempting to set timezone to ",tzname);
-                timedateDbus.typedCall("SetTimezone", [
-                        { "type":"s", "value": tzname },
-                        { "type":"b", "value":"0" }
-                    ],
-                    function(result) { console.log('call completed with:', result) },
-                   function(error, message) { console.log('call failed', error, 'message:', message) }
-                );
+                if(timezoneModel.get(timezoneSpinner.currentIndex).bottomLevel) {
+                    var tzname = timezoneModel.get(timezoneSpinner.currentIndex).fullPath;
+                    console.log("Attempting to set timezone to ",tzname);
+                    timedateDbus.typedCall("SetTimezone", [
+                            { "type":"s", "value": tzname },
+                            { "type":"b", "value":"0" }
+                        ],
+                        function(result) { console.log('call completed with:', result) },
+                    function(error, message) { console.log('call failed', error, 'message:', message) }
+                    );
+                    root.selectedTz = timezoneModel.get(timezoneSpinner.currentIndex).fullPath;
+                } else {
+                    layerStack.push(timezoneLayer,{"regionLevel": root.regionLevel + 1, "regionPath": root.regionPath + timezoneModel.get(timezoneSpinner.currentIndex).name + "/", "selectedTz": root.selectedTz})
+                }
             }
         }
     }

--- a/src/qml/TimezonePage.qml
+++ b/src/qml/TimezonePage.qml
@@ -45,7 +45,7 @@ Item {
                 if (tzAsList.length > (regionLevel + 1)) { //check if this item in the list has children
                     if (processedRegionList.indexOf(tzAsList[regionLevel]) < 0) {
                         processedRegionList.push(tzAsList[regionLevel]);
-                        timezoneModel.append({"visualName": tzAsList[regionLevel].replace("_"," ") + " ⋯", "name": tzAsList[regionLevel],"fullPath": region, "bottomLevel": false});
+                        timezoneModel.append({"visualName": "  " + tzAsList[regionLevel].replace("_"," ") + " ›", "name": tzAsList[regionLevel],"fullPath": region, "bottomLevel": false});
                         if(selectedTz.includes(root.regionPath + tzAsList[regionLevel])) {
                             timezoneSpinner.positionViewAtIndex(i, ListView.SnapPosition);
                         }

--- a/src/qml/TimezonePage.qml
+++ b/src/qml/TimezonePage.qml
@@ -37,6 +37,7 @@ Item {
 
     onTimezoneListChanged: {
         var processedRegionList = [];
+        var i = 0;
         timezoneList.forEach(function(region) {
             //console.log("processing ", region);
             if(region.includes(regionPath)) {
@@ -45,9 +46,17 @@ Item {
                     if (processedRegionList.indexOf(tzAsList[regionLevel]) < 0) {
                         processedRegionList.push(tzAsList[regionLevel]);
                         timezoneModel.append({"visualName": tzAsList[regionLevel].replace("_"," ") + " ⋯", "name": tzAsList[regionLevel],"fullPath": region, "bottomLevel": false});
+                        if(selectedTz.includes(root.regionPath + tzAsList[regionLevel])) {
+                            timezoneSpinner.positionViewAtIndex(i, ListView.SnapPosition);
+                        }
+                        i++;
                     }
                 } else { //if this item doesn't have children - add it with a full name
                     timezoneModel.append({"visualName": tzAsList[regionLevel].replace("_"," "), "name": tzAsList[regionLevel], "fullPath": region, "bottomLevel": true});
+                    if(selectedTz.includes(root.regionPath + tzAsList[regionLevel])) {
+                        timezoneSpinner.positionViewAtIndex(i, ListView.SnapPosition);
+                    }
+                    i++;
                 }
             } else {
                 //console.log("skipping ", region, " because it does not contain ", regionPath, " which is the region path");

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -169,4 +169,9 @@ Application {
             }
         }
     }
+    function backToMainMenu() {
+        while (layerStack.layers.length > 0) {
+            layerStack.pop(layerStack.currentLayer)
+        }
+    }
 }


### PR DESCRIPTION
The list will now show only the regions which sit on a certain level. For example, "America/Indiana/Indianapolis" is unified with all other "America" entries in the root menu; clicking on "America" will bring up a menu containing "Indiana" etc.

A slightly crude 'backToMainMenu()' method is added to the main page, so that all timezone pages can be popped with one call.