### PR TITLE
translation: Update translations.

### DIFF
--- a/i18n/asteroid-settings.ar.ts
+++ b/i18n/asteroid-settings.ar.ts
@@ -69,31 +69,31 @@
         <translation>استخدم فهرنهايت:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>الوقت</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>التاريخ</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>اللغة</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>بلوتوث</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>العرض</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>انقر للاستيقاظ</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>الصوت</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>منضدة السرير</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>الوحدات</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>الخلفية</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>المظهر</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>الواجهة</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>يو اس بي</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>إغلاق</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>إعادة تشغيل</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>حول</translation>
     </message>

--- a/i18n/asteroid-settings.az.ts
+++ b/i18n/asteroid-settings.az.ts
@@ -69,31 +69,31 @@
         <translation>Farengeyt istifadə edin:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Vaxt</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Tarix</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Dil</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Displey</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Toxunaraq oyandırın</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Səs</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Vahidlər</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Divar kağızı</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Saat görünüşü</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Başladıcı</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Söndürün</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Yenidən başladın</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Haqqında</translation>
     </message>

--- a/i18n/asteroid-settings.ca.ts
+++ b/i18n/asteroid-settings.ca.ts
@@ -166,6 +166,10 @@
         <source>SSH Mode</source>
         <translation>Mode SSH</translation>
     </message>
+    <message id="id-timezone-page">
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.cs.ts
+++ b/i18n/asteroid-settings.cs.ts
@@ -166,6 +166,10 @@
         <source>SSH Mode</source>
         <translation>Režim SSH</translation>
     </message>
+    <message id="id-timezone-page">
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.da.ts
+++ b/i18n/asteroid-settings.da.ts
@@ -69,31 +69,31 @@
         <translation>Brug Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Tidspunkt</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Sprog</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Skærm</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Lyd</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Enheder</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Baggrund</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Udseende på ur</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Sluk</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Genstart</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Om</translation>
     </message>

--- a/i18n/asteroid-settings.de_DE.ts
+++ b/i18n/asteroid-settings.de_DE.ts
@@ -69,31 +69,31 @@
         <translation>Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Uhrzeit</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Bildschirm</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Tippen zum Aufwachen</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation>Zeitzone</translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Ton</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Nachttisch</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Einheiten</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Hintergrundbild</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Ziffernblatt</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Starter</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Ausschalten</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Neustart</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Über</translation>
     </message>

--- a/i18n/asteroid-settings.el.ts
+++ b/i18n/asteroid-settings.el.ts
@@ -166,6 +166,10 @@
         <source>SSH Mode</source>
         <translation>Τρόπος Λειτουργίας SSH</translation>
     </message>
+    <message id="id-timezone-page">
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.en_GB.ts
+++ b/i18n/asteroid-settings.en_GB.ts
@@ -69,31 +69,31 @@
         <translation>Use Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Time</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Display</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Tap-to-wake</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation>Time zone</translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Sound</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Nightstand</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Units</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Wallpaper</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Watchface</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Launcher</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Power Off</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Reboot</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>About</translation>
     </message>

--- a/i18n/asteroid-settings.eo.ts
+++ b/i18n/asteroid-settings.eo.ts
@@ -69,31 +69,31 @@
         <translation>Uzi farenhejtan:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Tempo</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Lingvo</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bludento</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Ekrano</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Sono</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unuoj</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Fono</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Lanĉilo</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Malstartigi</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Restartigi</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Pri</translation>
     </message>

--- a/i18n/asteroid-settings.es.ts
+++ b/i18n/asteroid-settings.es.ts
@@ -69,31 +69,31 @@
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Pantalla</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Tocar para encender</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation>Zona horaria</translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Sonido</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Mesa de noche</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Fondo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Esfera</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Lanzadores</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>

--- a/i18n/asteroid-settings.es_AR.ts
+++ b/i18n/asteroid-settings.es_AR.ts
@@ -69,31 +69,31 @@
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Sonido</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Fondo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Carátula</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>

--- a/i18n/asteroid-settings.fa.ts
+++ b/i18n/asteroid-settings.fa.ts
@@ -69,31 +69,31 @@
         <translation>استفاده از فارنهایت:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>زمان</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>زبان</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>بلوتوث</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>صفحهٔ نمایش</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>ضربه برای بیداری</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>صدا</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>پایهٔ شبانه</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>واحدها</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>کاغذدیواری</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>صفحهٔ ساعت</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>اجراگر</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>یواِس‌بی</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>خاموش</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>راه‌اندازی دوباره</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>درباره</translation>
     </message>

--- a/i18n/asteroid-settings.fi.ts
+++ b/i18n/asteroid-settings.fi.ts
@@ -69,31 +69,31 @@
         <translation>Käytä Fahrenheitia:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Aika</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Päiväys</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Kieli</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Näyttö</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Napauta herättääksesi puhelin</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Ääni</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Yksiköt</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Taustakuva</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Kellotaulu</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Sovellusten käynnistysohjelma</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Sammuta</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Käynnistä uudelleen</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Tietoa</translation>
     </message>

--- a/i18n/asteroid-settings.fr.ts
+++ b/i18n/asteroid-settings.fr.ts
@@ -69,31 +69,31 @@
         <translation>Fahrenheit :</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Heure</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Langue</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Afficher</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Tapoter-pour-réveiller</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation>Zone horaire</translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Son</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Table de nuit</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unités</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Fond d&apos;écran</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Cadrans</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Lanceur</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Éteindre</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Redémarrer</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>À propos</translation>
     </message>

--- a/i18n/asteroid-settings.gl.ts
+++ b/i18n/asteroid-settings.gl.ts
@@ -69,31 +69,31 @@
         <translation>Empregar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Pantalla</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Tocar para despertar</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Son</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Mesita de noite</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Imaxe do fondo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Esfera do reloxo</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Iniciador</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>

--- a/i18n/asteroid-settings.he.ts
+++ b/i18n/asteroid-settings.he.ts
@@ -70,31 +70,31 @@
         <translation>שימוש בפרנהייט:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>שעה</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>תאריך</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>שפה</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>תצוגה</translation>
     </message>
@@ -128,56 +128,62 @@
         <source>Tap-to-wake</source>
         <translation>לגעת כדי להעיר</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>צליל</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>שידה</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>יחידות</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>תמונת רקע</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>פני השעון</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>משגר</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>כיבוי</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>הפעלה מחדש</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>על אודות</translation>
     </message>

--- a/i18n/asteroid-settings.hi.ts
+++ b/i18n/asteroid-settings.hi.ts
@@ -69,31 +69,31 @@
         <translation>फारेनहाइट का प्रयोग करो</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>समय</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>तारीख</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>ब्लूटूथ</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>डिस्प्ले</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>टैप-टु-वेक</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>ध्वनि</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>रात्रिस्तंभ</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>यूनिट</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>वॉलपेपर</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>वॉचफेस</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>लांचर</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>यु एस बी</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>बिजली बंद है</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>रीबूट</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>एस्टेरोइड ओ. एस. के बारे में</translation>
     </message>

--- a/i18n/asteroid-settings.hr.ts
+++ b/i18n/asteroid-settings.hr.ts
@@ -69,31 +69,31 @@
         <translation>Koristi Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Vrijeme</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Jezik</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Ekran</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Dodirni-za-buđenje</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Zvuk</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Mjerne jedinice</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Pozadina</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Pozadina sata</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Pokretač</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Isključi</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Ponovo pokreni</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Informacije</translation>
     </message>

--- a/i18n/asteroid-settings.hu.ts
+++ b/i18n/asteroid-settings.hu.ts
@@ -166,6 +166,10 @@
         <source>SSH Mode</source>
         <translation>SSH használata</translation>
     </message>
+    <message id="id-timezone-page">
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.id.ts
+++ b/i18n/asteroid-settings.id.ts
@@ -69,31 +69,31 @@
         <translation>Gunakan Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Waktu</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Tanggal</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Bahasa</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Layar</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Ketuk untuk membangunkan</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Suara</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unit</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Gambar latar</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>tampilan jam</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Peluncur</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Matikan</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Nyalakan Ulang</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Tentang</translation>
     </message>

--- a/i18n/asteroid-settings.it.ts
+++ b/i18n/asteroid-settings.it.ts
@@ -166,6 +166,10 @@
         <source>SSH Mode</source>
         <translation>Modalità SSH</translation>
     </message>
+    <message id="id-timezone-page">
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ja.ts
+++ b/i18n/asteroid-settings.ja.ts
@@ -69,31 +69,31 @@
         <translation>華氏(℉)表記:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>日付</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>サウンド</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>単位</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>壁紙</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>ウォッチフェイス</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>電源を切る</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>再起動</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>情報</translation>
     </message>

--- a/i18n/asteroid-settings.ka.ts
+++ b/i18n/asteroid-settings.ka.ts
@@ -69,31 +69,31 @@
         <translation>გამოყენებულ იქნას ფარენჰეიტის შკალა:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>დრო</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>თარიღი</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>ენა</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>ბლუთუზი</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>ხმა</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>ერთეულები</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>ფონი</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>მაჯისსაათის სახე</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>კვების გამორთვა</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>გადატვირთვა</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>AsteroidOS შესახებ</translation>
     </message>

--- a/i18n/asteroid-settings.ko.ts
+++ b/i18n/asteroid-settings.ko.ts
@@ -69,31 +69,31 @@
         <translation>화씨를 사용:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>시간</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>날짜</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>블루투스</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>화면</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>탭할 때 화면 켜기</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>소리</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>나이트스탠드</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>단위</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>배경화면</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>시계화면</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>런처</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>종료</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>재시동</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>정보</translation>
     </message>

--- a/i18n/asteroid-settings.lb.ts
+++ b/i18n/asteroid-settings.lb.ts
@@ -69,31 +69,31 @@
         <translation>Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Auerzäit</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Sprooch</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation></translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unitéiten</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Hannergrond</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Zifferblat</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Ausschalten</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Neistart</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Iwwer</translation>
     </message>

--- a/i18n/asteroid-settings.lt.ts
+++ b/i18n/asteroid-settings.lt.ts
@@ -69,31 +69,31 @@
         <translation>Naudoti Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Laikas</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Kalba</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Ekranas</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Paliesti, kas pabustų</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Garsas</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Naktinis staliukas</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Vienetai</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Ekrano paveikslėlis</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Ciferblatas</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Paleidimo priemonė</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Išjungti</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Perkrauti</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Apie</translation>
     </message>

--- a/i18n/asteroid-settings.mr.ts
+++ b/i18n/asteroid-settings.mr.ts
@@ -69,31 +69,31 @@
         <translation>फॅरनहाइट वापरा:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>वेळ</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>दिनांक</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>ब्लूटुथ</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>प्रदर्शन</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>टॅप टू वेक</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>आवाज</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>युनिट</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>वॉलपेपर</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>वॉचफेस</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>लाँचर</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>युएसबी</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>वीज बंद</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>रीबूट करा</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>बद्दल</translation>
     </message>

--- a/i18n/asteroid-settings.ms.ts
+++ b/i18n/asteroid-settings.ms.ts
@@ -69,31 +69,31 @@
         <translation>Guna Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Masa</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Tarikh</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Bahasa</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Paparan</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Ketik untuk bangun</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Bunyi</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unit</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Paparan</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Muka jam</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Tutup Kuasa</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Mulakan Semula</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Mengenai</translation>
     </message>

--- a/i18n/asteroid-settings.nb_NO.ts
+++ b/i18n/asteroid-settings.nb_NO.ts
@@ -69,31 +69,31 @@
         <translation>Bruk fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Klokke</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Blåtann</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation type="unfinished">Skjerm</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation type="unfinished">Trykk for å vekke</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Lyd</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished">Nattbord</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Enheter</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Bakgrunn</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Klokkeskive</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Oppstarter</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Skru av</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Omstart</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Om</translation>
     </message>

--- a/i18n/asteroid-settings.nl_BE.ts
+++ b/i18n/asteroid-settings.nl_BE.ts
@@ -69,31 +69,31 @@
         <translation>Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Tijd</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Scherm</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Drukken om te ontwaken</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation>Tijd zone</translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Geluid</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Eenheden</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Achtergrond</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Horlogestijl</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Uitschakelen</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Herstarten</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Over</translation>
     </message>

--- a/i18n/asteroid-settings.nl_NL.ts
+++ b/i18n/asteroid-settings.nl_NL.ts
@@ -69,31 +69,31 @@
         <translation>Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Tijd</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Scherm</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Drukken om te ontwaken</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation>Tijdzone</translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Geluid</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Eenheden</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Achtergrond</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Horlogestijl</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Uitschakelen</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Herstarten</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Over</translation>
     </message>

--- a/i18n/asteroid-settings.pl.ts
+++ b/i18n/asteroid-settings.pl.ts
@@ -69,31 +69,31 @@
         <translation>Użyj Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Czas</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Język</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Wyświetlacz</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Dotknij, aby wybudzić</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Dźwięk</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Jednostki</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Tapeta</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Wygląd zegarka</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Ekran główny</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Wyłącz</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Uruchom ponownie</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>O urządzeniu</translation>
     </message>

--- a/i18n/asteroid-settings.pt.ts
+++ b/i18n/asteroid-settings.pt.ts
@@ -69,31 +69,31 @@
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Ecrã</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Tocar para acordar</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Som</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Modo criado-mudo</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Imagem de fundo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Mostrador</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Lançador</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>

--- a/i18n/asteroid-settings.pt_BR.ts
+++ b/i18n/asteroid-settings.pt_BR.ts
@@ -69,31 +69,31 @@
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Tela</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Tocar para acordar</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Som</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Modo criado-mudo</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Papel de parede</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Mostrador</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Lançador</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>

--- a/i18n/asteroid-settings.pt_PT.ts
+++ b/i18n/asteroid-settings.pt_PT.ts
@@ -69,31 +69,31 @@
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Ecrã</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Tocar para acordar</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Som</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Imagem de fundo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Mostrador</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Lançador</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>

--- a/i18n/asteroid-settings.ro.ts
+++ b/i18n/asteroid-settings.ro.ts
@@ -69,31 +69,31 @@
         <translation>Utilizați Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Timp</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Dată</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Limbă</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Ecran</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Atingeți pentru a trezi</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Sunet</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Noptieră</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Unităţi</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Imagine fundal</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Faţă ceas</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Lansator</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Oprire</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Repornire</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Despre</translation>
     </message>

--- a/i18n/asteroid-settings.ru.ts
+++ b/i18n/asteroid-settings.ru.ts
@@ -69,31 +69,31 @@
         <translation>Использовать градусы Фаренгейта:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Время</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Язык</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Дисплей</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Пробуждение по касанию</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Звук</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished">Ночной вид</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Единицы</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Обои</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Циферблат</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Лаунчер</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Выключить</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Перезагрузить</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>О продукте</translation>
     </message>

--- a/i18n/asteroid-settings.sk.ts
+++ b/i18n/asteroid-settings.sk.ts
@@ -166,6 +166,10 @@
         <source>SSH Mode</source>
         <translation>Mód SSH</translation>
     </message>
+    <message id="id-timezone-page">
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.sq.ts
+++ b/i18n/asteroid-settings.sq.ts
@@ -69,31 +69,31 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.sv.ts
+++ b/i18n/asteroid-settings.sv.ts
@@ -69,31 +69,31 @@
         <translation>Använd Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Tid</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Skärm</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Tryck-för-att-väcka</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Ljud</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Nattduksbord</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Enheter</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Bakgrundsbild</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Klockansikte</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Startare</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Stäng av</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Starta om</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Om</translation>
     </message>

--- a/i18n/asteroid-settings.ta.ts
+++ b/i18n/asteroid-settings.ta.ts
@@ -166,6 +166,10 @@
         <source>SSH Mode</source>
         <translation>SSH முறை</translation>
     </message>
+    <message id="id-timezone-page">
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.te.ts
+++ b/i18n/asteroid-settings.te.ts
@@ -69,31 +69,31 @@
         <translation>ఫరెన్హెఇట్ ను వాడు:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>సమయం</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>తేది</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>భాష</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>బ్లూటూత్</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>ప్రదర్శన</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>మేల్కొలపడానికి నొక్కండి</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>శబ్దం</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>యూనిట్స్</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>వాల్పేపర్</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>గడియారముఖం</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>యుఎస్బి</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>మూసివేయి</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>రీబూట్</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>గురించి</translation>
     </message>

--- a/i18n/asteroid-settings.th.ts
+++ b/i18n/asteroid-settings.th.ts
@@ -69,31 +69,31 @@
         <translation>ใช้ฟาเรนไฮต์:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>เวลา</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>วันเดือนปี</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>ภาษา</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>บลูทูธ</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>แสดงผล</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>แตะเพื่อปลุก</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>เสียง</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>หน่วย</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>วอลเปเปอร์</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>หน้าปัด</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>ตัวเรียกใช้</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>ปิด</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>รีบูต</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>เกี่ยวกับ</translation>
     </message>

--- a/i18n/asteroid-settings.tr.ts
+++ b/i18n/asteroid-settings.tr.ts
@@ -166,6 +166,10 @@
         <source>SSH Mode</source>
         <translation>SSH Kipi</translation>
     </message>
+    <message id="id-timezone-page">
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.uk.ts
+++ b/i18n/asteroid-settings.uk.ts
@@ -69,31 +69,31 @@
         <translation>Використовувати градус Фаренгейта:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Час</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Дисплей</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Пробудження дотиком</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Звук</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Нічний вид</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Одиниці</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Шпалери</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Циферблат</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Лаунчер</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Вимкнути</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Перезавантажити</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Про</translation>
     </message>

--- a/i18n/asteroid-settings.vi.ts
+++ b/i18n/asteroid-settings.vi.ts
@@ -69,31 +69,31 @@
         <translation>Sử dụng Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>Thời gian</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>Ngày</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>Ngôn ngữ</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>Hiển thị</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation>Nhấn để đánh thức</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>Âm thanh</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation>Đầu giường</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>Đơn vị</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>Hình nền</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>Mặt đồng hồ</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation>Trình khởi động</translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>Tắt nguồn</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>Khởi động lại</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>Giới thiệu</translation>
     </message>

--- a/i18n/asteroid-settings.zh_Hans.ts
+++ b/i18n/asteroid-settings.zh_Hans.ts
@@ -166,6 +166,10 @@
         <source>SSH Mode</source>
         <translation>SSH 模式</translation>
     </message>
+    <message id="id-timezone-page">
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.zh_Hant.ts
+++ b/i18n/asteroid-settings.zh_Hant.ts
@@ -69,31 +69,31 @@
         <translation>使用華氏溫標:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="71"/>
-        <location filename="../src/qml/TimePage.qml" line="40"/>
+        <location filename="../src/qml/main.qml" line="72"/>
+        <location filename="../src/qml/TimePage.qml" line="41"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="77"/>
+        <location filename="../src/qml/DatePage.qml" line="32"/>
+        <location filename="../src/qml/main.qml" line="78"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message id="id-language-page">
         <location filename="../src/qml/LanguagePage.qml" line="31"/>
-        <location filename="../src/qml/main.qml" line="83"/>
+        <location filename="../src/qml/main.qml" line="90"/>
         <source>Language</source>
         <translation>語言</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="89"/>
+        <location filename="../src/qml/main.qml" line="96"/>
         <source>Bluetooth</source>
         <translation>藍牙</translation>
     </message>
     <message id="id-display-page">
         <location filename="../src/qml/DisplayPage.qml" line="39"/>
-        <location filename="../src/qml/main.qml" line="95"/>
+        <location filename="../src/qml/main.qml" line="102"/>
         <source>Display</source>
         <translation>顯示</translation>
     </message>
@@ -127,56 +127,62 @@
         <source>Tap-to-wake</source>
         <translation type="unfinished">點擊喚醒</translation>
     </message>
+    <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="84"/>
+        <location filename="../src/qml/TimezonePage.qml" line="35"/>
+        <source>Time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="101"/>
+        <location filename="../src/qml/main.qml" line="108"/>
         <source>Sound</source>
         <translation>音效</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="108"/>
+        <location filename="../src/qml/main.qml" line="115"/>
         <location filename="../src/qml/NightstandPage.qml" line="55"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="114"/>
+        <location filename="../src/qml/main.qml" line="121"/>
         <location filename="../src/qml/UnitsPage.qml" line="26"/>
         <source>Units</source>
         <translation>單位</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="120"/>
+        <location filename="../src/qml/main.qml" line="127"/>
         <source>Wallpaper</source>
         <translation>桌布</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="126"/>
+        <location filename="../src/qml/main.qml" line="133"/>
         <source>Watchface</source>
         <translation>錶面</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="132"/>
+        <location filename="../src/qml/main.qml" line="139"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="138"/>
+        <location filename="../src/qml/main.qml" line="145"/>
         <location filename="../src/qml/USBPage.qml" line="29"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/main.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="151"/>
         <source>Power Off</source>
         <translation>關機</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/main.qml" line="150"/>
+        <location filename="../src/qml/main.qml" line="157"/>
         <source>Reboot</source>
         <translation>重新啟動</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="156"/>
+        <location filename="../src/qml/main.qml" line="163"/>
         <source>About</source>
         <translation>關於</translation>
     </message>


### PR DESCRIPTION
Provides translations for `Time zone` for English and Dutch.

Generated using: `lupdate-qt5 -no-obsolete src/* i18n/*.h -ts i18n/*.ts`

![aos-settings-tz](https://user-images.githubusercontent.com/7857908/233856047-7befb211-ced9-4d48-b5ed-2fbfd16acac4.jpg)
