### PR TITLE
Add uptime

### DIFF
--- a/i18n/asteroid-settings.ar.ts
+++ b/i18n/asteroid-settings.ar.ts
@@ -24,7 +24,7 @@
         <translation>غير متصل</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>الصوت %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>إغلاق</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>إعادة تشغيل</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>اختر واجهة الساعة</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>معرف البناء</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>الاسم الرمزي</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>اسم المضيف</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>عنوان الشبكة</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>المعرف التسلسلي</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>الرقم التسلسلي</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>إجمالي مساحة القرص</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>مساحة القرص المتوفرة</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>حجم الشاشة</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>إصدار النواة</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>إصدار Qt</translation>
     </message>

--- a/i18n/asteroid-settings.az.ts
+++ b/i18n/asteroid-settings.az.ts
@@ -24,7 +24,7 @@
         <translation>Bağlantı yoxdur</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>%1% Səs</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Söndürün</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Yenidən başladın</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Saat üzünü seçin</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>ID Quraşdırma</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Kod adı</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Host adı</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Seriya nömrəsi</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Ümumi disk sahəsi</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Mövcud disk sahəsi</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Ekran ölçüsü</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Kernel versiyası</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Qt versiyası</translation>
     </message>

--- a/i18n/asteroid-settings.ca.ts
+++ b/i18n/asteroid-settings.ca.ts
@@ -166,6 +166,14 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
@@ -210,19 +218,59 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Qt version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/asteroid-settings.cs.ts
+++ b/i18n/asteroid-settings.cs.ts
@@ -166,6 +166,14 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
@@ -210,19 +218,59 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Qt version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/asteroid-settings.da.ts
+++ b/i18n/asteroid-settings.da.ts
@@ -24,7 +24,7 @@
         <translation>Ikke forbundet</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Lydstyrke %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Sluk</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Genstart</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.de_DE.ts
+++ b/i18n/asteroid-settings.de_DE.ts
@@ -24,7 +24,7 @@
         <translation>Nicht verbunden</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Lautstärke %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation>Beenden</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Ausschalten</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Neustart</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Zifferblatt wählen</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>Buildnummer</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Codename</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Hostname</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Seriennummer</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Gesamter Festplattenspeicher</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Verfügbarer Festplattenspeicher</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Anzeigegröße</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Kernel-Version</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Qt-Version</translation>
     </message>

--- a/i18n/asteroid-settings.el.ts
+++ b/i18n/asteroid-settings.el.ts
@@ -166,6 +166,14 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
@@ -210,19 +218,59 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Qt version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/asteroid-settings.en_GB.ts
+++ b/i18n/asteroid-settings.en_GB.ts
@@ -24,7 +24,7 @@
         <translation>Not connected</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation>Power</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Power Off</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Reboot</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Select watchface</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>Build ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Codename</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Host name</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Serial number</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Total disk space</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Available disk space</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Display size</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Kernel version</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Qt version</translation>
     </message>

--- a/i18n/asteroid-settings.eo.ts
+++ b/i18n/asteroid-settings.eo.ts
@@ -24,7 +24,7 @@
         <translation>Ne konektita</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Laŭto %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Malstartigi</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Restartigi</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.es.ts
+++ b/i18n/asteroid-settings.es.ts
@@ -24,7 +24,7 @@
         <translation>No conectado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Volumen %1&#xa0;%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Seleccione la esfera del reloj</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>Identificador de la compilación</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Nombre clave</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Nombre del host</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Espacio total en el disco</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Espacio disponible en el disco</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Tamaño de la pantalla</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Versión del kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Versión Qt</translation>
     </message>

--- a/i18n/asteroid-settings.es_AR.ts
+++ b/i18n/asteroid-settings.es_AR.ts
@@ -24,7 +24,7 @@
         <translation>Desconectado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Volumen %1 %</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.fa.ts
+++ b/i18n/asteroid-settings.fa.ts
@@ -24,7 +24,7 @@
         <translation>وصل‌نشده</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>حجم صدا %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>خاموش</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>راه‌اندازی دوباره</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>گزینش صفحهٔ ساعت</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>شناسهً ساخت</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>نام رمزی</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>نام میزبان</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>مک بی‌سیم</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>شماره سریال</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>مجموع فضای دیسک</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>فضای دیسک موجود</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>اندازهٔ نمایشگر</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>پ</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>ب</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>نگارش کرنل</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>نگارش Qt</translation>
     </message>

--- a/i18n/asteroid-settings.fi.ts
+++ b/i18n/asteroid-settings.fi.ts
@@ -24,7 +24,7 @@
         <translation>EI yhdistetty</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Äänenvoimakkuus %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Sammuta</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Käynnistä uudelleen</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.fr.ts
+++ b/i18n/asteroid-settings.fr.ts
@@ -24,7 +24,7 @@
         <translation>Non connecté</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Éteindre</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Redémarrer</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Sélectionner le cadran</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>Référence de compilation</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Nom de code</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Nom de l&apos;appareil</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>MAC WIFI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Numéro de série</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Espace disque total</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Espace disque disponible</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Taille écran</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>L</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Version du noyau</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Version de Qt</translation>
     </message>

--- a/i18n/asteroid-settings.gl.ts
+++ b/i18n/asteroid-settings.gl.ts
@@ -24,7 +24,7 @@
         <translation>Non conectado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Seleccionala esfera do reloxo</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>Identificación da compilación</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Nome en clave</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Nome do anfitrión</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Espazo total no disco</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Espazo dispoñible no disco</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Tamaño da pantalla</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Versión do kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Versión de Qt</translation>
     </message>

--- a/i18n/asteroid-settings.he.ts
+++ b/i18n/asteroid-settings.he.ts
@@ -24,7 +24,7 @@
         <translation>מנותק</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <oldsource>Sound %1%</oldsource>
         <translation>עצמת שמע %1%</translation>
@@ -169,12 +169,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>כיבוי</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>הפעלה מחדש</translation>
     </message>
@@ -216,77 +216,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>בחירת פני השעון</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>מזהה בנייה</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>שם קוד</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>שם מארח</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>כתובת חומרה אלחוטית</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>מס׳ ברזל</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>מס׳ סידורי</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>נפח כונן כולל</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>מקום פנוי בכונן</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>גודל התצוגה</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>רוחב</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>גובה</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>גרסת ליבה</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>גרסת Qt</translation>
     </message>

--- a/i18n/asteroid-settings.hi.ts
+++ b/i18n/asteroid-settings.hi.ts
@@ -24,7 +24,7 @@
         <translation>जुड़ा नहीं है</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>वॉल्यूम %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>बिजली बंद है</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>रीबूट</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>वॉचफेस चुनें</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>बिल्ड आई डी</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>कोड नाम</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>होस्ट  का नाम</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>व्लान लैन</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>आई एम ई आई</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>सीरियल नंबर</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>डिस्क का कुल जगह</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>डिस्क का उपलब्ध जगह</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>प्रदर्शन का आकार</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>कर्नेल वर्जन</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>क्यू टी वर्जन</translation>
     </message>

--- a/i18n/asteroid-settings.hr.ts
+++ b/i18n/asteroid-settings.hr.ts
@@ -24,7 +24,7 @@
         <translation>Nije spojen</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Glasnoća %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Isključi</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Ponovo pokreni</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.hu.ts
+++ b/i18n/asteroid-settings.hu.ts
@@ -166,6 +166,14 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
@@ -210,19 +218,59 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Qt version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/asteroid-settings.id.ts
+++ b/i18n/asteroid-settings.id.ts
@@ -24,7 +24,7 @@
         <translation>Terputus</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Matikan</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Nyalakan Ulang</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.it.ts
+++ b/i18n/asteroid-settings.it.ts
@@ -166,6 +166,14 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
@@ -210,20 +218,60 @@
         <translation>Dimensione schermo</translation>
     </message>
     <message>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
         <source>Kernel version</source>
         <translation>Versione del kernel</translation>
     </message>
     <message>
         <source>Qt version</source>
         <translation>Versione di Qt</translation>
+    </message>
+    <message>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.ja.ts
+++ b/i18n/asteroid-settings.ja.ts
@@ -24,7 +24,7 @@
         <translation>未接続</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>音量 %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>電源を切る</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>再起動</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.ka.ts
+++ b/i18n/asteroid-settings.ka.ts
@@ -24,7 +24,7 @@
         <translation>არაა დაკავშირებული</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>ხმის სიმაღლე %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>კვების გამორთვა</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>გადატვირთვა</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.ko.ts
+++ b/i18n/asteroid-settings.ko.ts
@@ -24,7 +24,7 @@
         <translation>연결되지 않음</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>음량 %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>종료</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>재시동</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>시계 모드 선택</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>빌드 ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>코드명</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>호스트 이름</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>일련 번호</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>총 디스크 공간</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>사용 가능한 디스크 공간</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>디스플레이 크기</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>커널 버전</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Qt 버전</translation>
     </message>

--- a/i18n/asteroid-settings.lb.ts
+++ b/i18n/asteroid-settings.lb.ts
@@ -24,7 +24,7 @@
         <translation>Net verbonnen</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Lautstäerkt %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Ausschalten</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Neistart</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.lt.ts
+++ b/i18n/asteroid-settings.lt.ts
@@ -24,7 +24,7 @@
         <translation>Neprisijungta</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Garsumas %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Išjungti</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Perkrauti</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Pasirinkite laikrodžio veidą</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>Versijos ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Kodinis pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Pagrindinio kompiuterio vardas</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Serijos numeris</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Iš viso vietos diske</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Turima disko vieta</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Ekrano dydis</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>Plotis</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>Aukštis</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Branduolio versija</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Qt versija</translation>
     </message>

--- a/i18n/asteroid-settings.mr.ts
+++ b/i18n/asteroid-settings.mr.ts
@@ -24,7 +24,7 @@
         <translation>न जोडलेले</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>आवाज %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>वीज बंद</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>रीबूट करा</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.ms.ts
+++ b/i18n/asteroid-settings.ms.ts
@@ -24,7 +24,7 @@
         <translation>Tidak Disambungkan</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Tahap bunyi %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Tutup Kuasa</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Mulakan Semula</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.nb_NO.ts
+++ b/i18n/asteroid-settings.nb_NO.ts
@@ -24,7 +24,7 @@
         <translation>Ikke tilkoblet</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Lydstyrke %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Skru av</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Omstart</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Velg urskive</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>Bygg-ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Kodenavn</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished">Vertsnavn</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN-MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Total diskplass</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Tilgjengelig diskplass</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Skjermstørrelse</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>B</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Kjerneversjon</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Qt-versjon</translation>
     </message>

--- a/i18n/asteroid-settings.nl_BE.ts
+++ b/i18n/asteroid-settings.nl_BE.ts
@@ -24,7 +24,7 @@
         <translation>Niet verbonden</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Geluid %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Uitschakelen</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Herstarten</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.nl_NL.ts
+++ b/i18n/asteroid-settings.nl_NL.ts
@@ -24,7 +24,7 @@
         <translation>Niet verbonden</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Geluid %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Uitschakelen</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Herstarten</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Selecteer horlogestijl</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Schermgrootte</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Kernel versie</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Qt versie</translation>
     </message>

--- a/i18n/asteroid-settings.pl.ts
+++ b/i18n/asteroid-settings.pl.ts
@@ -24,7 +24,7 @@
         <translation>Nie połączony</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Głośność %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Wyłącz</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Uruchom ponownie</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Wybierz tarczę zegarka</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>Identyfikator kompilacji</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Nazwa kodowa</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Nazwa urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Numer seryjny</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Całkowita przestrzeń dyskowa</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Dostępna przestrzeń dyskowa</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Rozmiar wyświetlacza</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Wersja jądra</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Wersja Qt</translation>
     </message>

--- a/i18n/asteroid-settings.pt.ts
+++ b/i18n/asteroid-settings.pt.ts
@@ -24,7 +24,7 @@
         <translation>Não ligado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Selecione a face do relógio</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>ID da compilação</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Nome do código</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Nome do host</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>MAC do WLAN</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Número de série</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Espaço total do disco</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Espaço de disco disponível</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Tamanho do ecrã</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>L</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Versão do kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Versão do Qt</translation>
     </message>

--- a/i18n/asteroid-settings.pt_BR.ts
+++ b/i18n/asteroid-settings.pt_BR.ts
@@ -24,7 +24,7 @@
         <translation>Não conectado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Selecionar face do relógio</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>ID da Build</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Codinome</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Nome do hospedeiro</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Número de série</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Espaço total de disco</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Espaço de disco disponível</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Tamanho da tela</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>L</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Versão do Kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Versão do QT</translation>
     </message>

--- a/i18n/asteroid-settings.pt_PT.ts
+++ b/i18n/asteroid-settings.pt_PT.ts
@@ -24,7 +24,7 @@
         <translation>Não ligado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Volume %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>ID da compilação</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Nome do código</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>MAC do WLAN</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Número de série</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Espaço total do disco</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Espaço de disco disponível</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Tamanho do ecrã</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>L</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Versão do kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Versão do Qt</translation>
     </message>

--- a/i18n/asteroid-settings.ro.ts
+++ b/i18n/asteroid-settings.ro.ts
@@ -24,7 +24,7 @@
         <translation>Neconectat</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Volum %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Oprire</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Repornire</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Selectează față de ceas</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>ID Build</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Nume de cod</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Nume gazdă</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>MAC WLAN</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Număr de serie</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Spațiu total</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Spațiu disponibil</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Mărime ecran</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>L</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>Î</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Versiune kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Versiune Qt</translation>
     </message>

--- a/i18n/asteroid-settings.ru.ts
+++ b/i18n/asteroid-settings.ru.ts
@@ -24,7 +24,7 @@
         <translation>Не соединён</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Громкость %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Выключить</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Перезагрузить</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Выбрать циферблат</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>ID сборки</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Кодовое имя</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Имя хоста</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Серийный номер</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Общее дисковое пространство</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Доступное дисковое пространство</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Размер дисплея</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>Ш</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>В</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Версия ядра</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Версия Qt</translation>
     </message>

--- a/i18n/asteroid-settings.sk.ts
+++ b/i18n/asteroid-settings.sk.ts
@@ -166,6 +166,14 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
@@ -210,20 +218,60 @@
         <translation>Veľkosť displeja</translation>
     </message>
     <message>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
         <source>Kernel version</source>
         <translation>Verzia jadra</translation>
     </message>
     <message>
         <source>Qt version</source>
         <translation>Verzia Qt</translation>
+    </message>
+    <message>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.sq.ts
+++ b/i18n/asteroid-settings.sq.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.sv.ts
+++ b/i18n/asteroid-settings.sv.ts
@@ -24,7 +24,7 @@
         <translation>Inte ansluten</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Volym %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Stäng av</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Starta om</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Välj urtavla</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>ByggID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Kodnamn</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Värdnamn</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Totalt diskutrymme</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Tillgängligt diskutrymme</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Skärmstorlek</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>B</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Kärnversion</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Qt-version</translation>
     </message>

--- a/i18n/asteroid-settings.ta.ts
+++ b/i18n/asteroid-settings.ta.ts
@@ -166,6 +166,14 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
@@ -210,19 +218,59 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Qt version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/asteroid-settings.te.ts
+++ b/i18n/asteroid-settings.te.ts
@@ -24,7 +24,7 @@
         <translation>కనెక్టెడ్ లేదు</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>శబ్దం %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>మూసివేయి</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>రీబూట్</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.th.ts
+++ b/i18n/asteroid-settings.th.ts
@@ -24,7 +24,7 @@
         <translation>ไม่เชื่อมต่อ</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>ระดับ %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>ปิด</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>รีบูต</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>เลือกหน้าปัดนาฬิกา</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>ไอดีของการสร้าง</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>ชื่อรหัส</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>ซื่อโฮส</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>ขนาดหน้าจอ</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.tr.ts
+++ b/i18n/asteroid-settings.tr.ts
@@ -166,6 +166,14 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
@@ -210,20 +218,60 @@
         <translation>Ekran boyutu</translation>
     </message>
     <message>
-        <source>W</source>
-        <translation>G</translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation>Y</translation>
-    </message>
-    <message>
         <source>Kernel version</source>
         <translation>Çekirdek sürümü</translation>
     </message>
     <message>
         <source>Qt version</source>
         <translation>Qt sürümü</translation>
+    </message>
+    <message>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.uk.ts
+++ b/i18n/asteroid-settings.uk.ts
@@ -24,7 +24,7 @@
         <translation>Не підключено</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Гучність %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Вимкнути</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Перезавантажити</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Виберіть циферблат</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>ID збірки</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Кодова назва</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Ім&apos;я хоста</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Серійний номер</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Всього місця на диску</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Доступне місце на диску</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Розмір дисплея</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Версія ядра</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Версія Qt</translation>
     </message>

--- a/i18n/asteroid-settings.vi.ts
+++ b/i18n/asteroid-settings.vi.ts
@@ -24,7 +24,7 @@
         <translation>Chưa kết nối</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>Âm lượng %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>Tắt nguồn</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>Khởi động lại</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Chọn mặt đồng hồ</translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation>Xây dựng ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation>Mật danh</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation>Tên máy chủ</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation>MAC của WLAN</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation>Số IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation>Mã số sê-ri</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation>Tổng dung lượng ổ đĩa</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation>Không gian đĩa có sẵn</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation>Kích thước hiển thị</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation>Phiên bản nhân Kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation>Phiên bản Qt</translation>
     </message>

--- a/i18n/asteroid-settings.zh_Hans.ts
+++ b/i18n/asteroid-settings.zh_Hans.ts
@@ -166,6 +166,14 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
@@ -210,20 +218,60 @@
         <translation>显示屏尺寸</translation>
     </message>
     <message>
-        <source>W</source>
-        <translation>W</translation>
-    </message>
-    <message>
-        <source>H</source>
-        <translation>H</translation>
-    </message>
-    <message>
         <source>Kernel version</source>
         <translation>内核版本</translation>
     </message>
     <message>
         <source>Qt version</source>
         <translation>Qt 版本</translation>
+    </message>
+    <message>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.zh_Hant.ts
+++ b/i18n/asteroid-settings.zh_Hant.ts
@@ -24,7 +24,7 @@
         <translation>未連線</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="36"/>
+        <location filename="../src/qml/SoundPage.qml" line="79"/>
         <source>Volume %1%</source>
         <translation>音量 %1%</translation>
     </message>
@@ -168,12 +168,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="49"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Power Off</source>
         <translation>關機</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="62"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Reboot</source>
         <translation>重新啟動</translation>
     </message>
@@ -215,77 +215,136 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader">
+        <location filename="../src/foo.qml" line="44"/>
+        <source>Reboot to Bootloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-warn">
+        <location filename="../src/foo.qml" line="50"/>
+        <source>Reboot AsteroidOS</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="59"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="60"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="62"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="64"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Total disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="65"/>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <source>%L1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
+        <source>%L1 GB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <source>%L1W x %L2H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>Uptime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
+        <source>%L1 days %L2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="66"/>
+        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>1,5,15 Minute loads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
+        <source>%L1, %L2, %L3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>Total memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
+        <source>%L1 MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>Free memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="109"/>
+        <source>%L1 MB (%L2 %)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Available disk space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
+        <location filename="../src/qml/AboutPage.qml" line="95"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>W</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <source>H</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="69"/>
+        <location filename="../src/qml/AboutPage.qml" line="96"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="70"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,10 +11,12 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.h ${CMAKE_C
 
 set(SRC
 	main.cpp
+	sysinfo.cpp
 	taptowake.cpp
 	tilttowake.cpp
 	volumecontrol.cpp)
 set(HEADERS
+	sysinfo.h
 	taptowake.h
 	tilttowake.h
 	volumecontrol.h)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 #include "volumecontrol.h"
 #include "tilttowake.h"
 #include "taptowake.h"
+#include "sysinfo.h"
 
 int main(int argc, char *argv[])
 {
@@ -36,6 +37,7 @@ int main(int argc, char *argv[])
     qmlRegisterType<VolumeControl>("org.asteroid.settings", 1, 0, "VolumeControl");
     qmlRegisterType<TiltToWake>("org.asteroid.settings", 1, 0, "TiltToWake");
     qmlRegisterType<TapToWake>("org.asteroid.settings", 1, 0, "TapToWake");
+    qmlRegisterType<SysInfo>("org.asteroid.settings", 1, 0, "SysInfo");
     view->setSource(QUrl("qrc:/qml/main.qml"));
     view->rootContext()->setContextProperty("qtVersion", QString(qVersion()));
     view->rootContext()->setContextProperty("kernelVersion", QString(buf.release));

--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -89,5 +89,10 @@ Flickable {
                 }
             }
         }
+        Item {
+            id: bottomSpacer
+            height: parent.width*0.1
+            width: height
+        }
     }
 }

--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -62,10 +62,11 @@ Flickable {
                 { label: qsTr("WLAN MAC"), text: about.wlanMacAddress },
                 { label: qsTr("IMEI"), text: about.imei },
                 { label: qsTr("Serial number"), text: about.serial },
-                { label: qsTr("Total disk space"), text: qsTr("%L1").arg(Math.round(about.totalDiskSpace() / 1e7)/100) + " GB" },
-                { label: qsTr("Available disk space"), text: qsTr("%L1").arg(Math.round(about.availableDiskSpace() / 1e7)/100)
-                            + " GB (" + (100.0 * about.availableDiskSpace() / about.totalDiskSpace()).toFixed(0) + "%)" },
-                { label: qsTr("Display size"), text: Dims.w(100) + qsTr("W") + " x " + Dims.h(100) + qsTr("H") },
+                { label: qsTr("Total disk space"), text: qsTr("%L1 GB").arg(Math.round(about.totalDiskSpace() / 1e7)/100) },
+                { label: qsTr("Available disk space"), text: qsTr("%L1 GB (%L2 %)").
+                    arg(Math.round(about.availableDiskSpace() / 1e7)/100).
+                    arg((100.0 * about.availableDiskSpace() / about.totalDiskSpace()).toFixed(0)) },
+                { label: qsTr("Display size"), text: qsTr("%L1W x %L2H").arg(Dims.w(100)).arg(Dims.h(100)) },
                 { label: qsTr("Kernel version"), text: kernelVersion },
                 { label: qsTr("Qt version"), text: qtVersion }
             ]

--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -19,6 +19,7 @@
 import QtQuick 2.9
 import org.asteroid.utils 1.0
 import org.asteroid.controls 1.0
+import org.asteroid.settings 1.0
 import org.nemomobile.systemsettings 1.0
 
 Flickable {
@@ -27,6 +28,31 @@ Flickable {
     }
     DiskUsage {
         id: diskUsage
+    }
+    SysInfo {
+        id: info
+    }
+
+    Item {
+        id: uptimeCounter
+        readonly property int secondsPerDay: 60 * 60 * 24
+
+        Timer {
+            interval: 1000
+            repeat: true
+            triggeredOnStart: true
+            running: true
+            onTriggered: info.refresh()
+        }
+        function days() {
+            return Math.floor(info.uptime / secondsPerDay)
+        }
+        function asString() {
+            var now = info.uptime
+            var days = Math.floor(now / secondsPerDay)
+            var date = new Date(1000 * (now - days * secondsPerDay))
+            return date.toISOString().substring(11, 19);
+        }
     }
 
     contentHeight: contentcolumn.implicitHeight
@@ -68,7 +94,22 @@ Flickable {
                     arg((100.0 * about.availableDiskSpace() / about.totalDiskSpace()).toFixed(0)) },
                 { label: qsTr("Display size"), text: qsTr("%L1W x %L2H").arg(Dims.w(100)).arg(Dims.h(100)) },
                 { label: qsTr("Kernel version"), text: kernelVersion },
-                { label: qsTr("Qt version"), text: qtVersion }
+                { label: qsTr("Qt version"), text: qtVersion },
+                { label: qsTr("Uptime"), text: qsTr("%L1 days %L2").
+                    arg(uptimeCounter.days()).
+                    arg(uptimeCounter.asString())
+                },
+                { label: qsTr("Threads"), text: qsTr("%L1").arg(info.threads) },
+                { label: qsTr("1,5,15 Minute loads"), text: qsTr("%L1, %L2, %L3").
+                    arg(info.loads[0].toFixed(2)).
+                    arg(info.loads[1].toFixed(2)).
+                    arg(info.loads[2].toFixed(2))
+                },
+                { label: qsTr("Total memory"), text: qsTr("%L1 MB").arg(Math.round(info.totalRam * info.memUnit / 1e6)) },
+                { label: qsTr("Free memory"), text: qsTr("%L1 MB (%L2 %)").
+                    arg(Math.round(info.freeRam * info.memUnit / 1e6)).
+                    arg((100.0 * info.freeRam / info.totalRam).toFixed(0))
+                }
             ]
             delegate: Column {
                 width: contentcolumn.width

--- a/src/sysinfo.cpp
+++ b/src/sysinfo.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 - Ed Beroset <beroset@ieee.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "sysinfo.h"
+
+SysInfo::SysInfo(QObject *parent) :
+    QObject(parent)
+{
+    sysinfo(&info);
+    copyLoads();
+}
+
+void SysInfo::copyLoads() {
+    static constexpr auto lf{1.0 / (1 << SI_LOAD_SHIFT)};
+    m_loads = { info.loads[0]*lf, info.loads[1]*lf, info.loads[2]*lf };
+}
+
+void SysInfo::refresh() {
+    auto oldinfo{info};
+    sysinfo(&info);
+    if (info.uptime != oldinfo.uptime) emit uptimeChanged();
+    if ((info.loads[0] != oldinfo.loads[0]) ||
+        (info.loads[1] != oldinfo.loads[1]) ||
+        (info.loads[2] != oldinfo.loads[2])) 
+    {
+        copyLoads();
+        emit loadsChanged();
+    }
+    if (info.totalram != oldinfo.totalram) emit totalramChanged();
+    if (info.freeram != oldinfo.freeram) emit freeramChanged();
+    if (info.sharedram != oldinfo.sharedram) emit sharedramChanged();
+    if (info.bufferram != oldinfo.uptime) emit uptimeChanged();
+    if (info.totalswap != oldinfo.totalswap) emit totalswapChanged();
+    if (info.freeswap != oldinfo.freeswap) emit freeswapChanged();
+    if (info.procs != oldinfo.procs) emit procsChanged();
+    if (info.totalhigh != oldinfo.totalhigh) emit totalhighChanged();
+    if (info.freehigh != oldinfo.freehigh) emit freehighChanged();
+
+}

--- a/src/sysinfo.h
+++ b/src/sysinfo.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023 - Ed Beroset <beroset@ieee.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef SYSINFO_H
+#define SYSINFO_H
+
+#include <sys/sysinfo.h>
+
+#include <QObject>
+#include <QtQml>
+
+class SysInfo : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(long uptime READ uptime NOTIFY uptimeChanged)
+    Q_PROPERTY(QList<qreal> loads READ loads NOTIFY loadsChanged)
+    Q_PROPERTY(unsigned long totalRam READ totalram NOTIFY totalramChanged)
+    Q_PROPERTY(unsigned long freeRam READ freeram NOTIFY freeramChanged)
+    Q_PROPERTY(unsigned long sharedRam READ sharedram NOTIFY sharedramChanged)
+    Q_PROPERTY(unsigned long bufferRam READ bufferram NOTIFY bufferramChanged)
+    Q_PROPERTY(unsigned long totalSwap READ totalswap NOTIFY totalswapChanged)
+    Q_PROPERTY(unsigned long freeSwap READ freeswap NOTIFY freeswapChanged)
+    Q_PROPERTY(unsigned threads READ procs NOTIFY procsChanged)
+    Q_PROPERTY(unsigned long totalHigh READ totalhigh NOTIFY totalhighChanged)
+    Q_PROPERTY(unsigned long freeHigh READ freehigh NOTIFY freehighChanged)
+    Q_PROPERTY(unsigned memUnit READ mem_unit CONSTANT)
+public:
+    SysInfo(QObject *parent = nullptr);
+    unsigned long uptime() const { return info.uptime; }
+    QList<qreal> loads() const { return m_loads; }
+    unsigned long totalram() const { return info.totalram; }
+    unsigned long freeram() const { return info.freeram; }
+    unsigned long sharedram() const { return info.sharedram; }
+    unsigned long bufferram() const { return info.bufferram; }
+    unsigned long totalswap() const { return info.totalswap; }
+    unsigned long freeswap() const { return info.freeswap; }
+    unsigned short procs() const { return info.procs; }
+    unsigned long totalhigh() const { return info.totalhigh; }
+    unsigned long freehigh() const { return info.freehigh; }
+    unsigned mem_unit() const { return info.mem_unit; }
+
+signals: 
+    void uptimeChanged();
+    void loadsChanged();
+    void totalramChanged();
+    void freeramChanged();
+    void sharedramChanged();
+    void bufferramChanged();
+    void totalswapChanged();
+    void freeswapChanged();
+    void procsChanged();
+    void totalhighChanged();
+    void freehighChanged();
+
+public slots:
+    void refresh();
+
+private:
+    void copyLoads();
+
+    struct sysinfo info;
+    QList<qreal> m_loads;
+};
+
+#endif // SYSINFO_H


### PR DESCRIPTION
Inspired by https://github.com/AsteroidOS/asteroid-settings/pull/69 and a comment from @kido I decided to implement this using a `sysinfo()` call which also gets us `freeram` and `totalram` without any additional work.  I also added some changes to make it easier to translate strings, such as the screen dimensions.  Right now it shows `400W x 400H` which use the English abbreviations for height and width, but it's now possible to translate that into other languages.  