### PR TITLE
Use globe-outline icon for Time zone and swap Language icon to earth-outline

### DIFF
--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -82,13 +82,13 @@ Application {
                 ListItem {
                     //% "Time zone"
                     title: qsTrId("id-timezone-page")
-                    iconName: "ios-flag-outline"
+                    iconName: "ios-globe-outline"
                     onClicked: layerStack.push(timezoneLayer)
                 }
                 ListItem {
                     //% "Language"
                     title: qsTrId("id-language-page")
-                    iconName: "ios-globe-outline"
+                    iconName: "ios-earth-outline"
                     onClicked: layerStack.push(languageLayer)
                 }
                 ListItem {


### PR DESCRIPTION
Depends on adding the earth-outline icon in asteroid-icons-ion repository
https://github.com/AsteroidOS/asteroid-icons-ion/pull/12

Fixes https://github.com/AsteroidOS/asteroid-settings/issues/73

- Use globe-outline icon for Time zone since it suggests zones on a globe
- Use new earth-outline icon for Language

![ionic6](https://user-images.githubusercontent.com/15074193/234127805-27fe2a3e-8133-480f-b378-ee8d841f6a21.jpg)
