### PR TITLE
Redesign sound settings icon and page

### DIFF
--- a/src/qml/SoundPage.qml
+++ b/src/qml/SoundPage.qml
@@ -19,9 +19,17 @@ import QtQuick 2.9
 import QtMultimedia 5.8
 import org.asteroid.controls 1.0
 import org.asteroid.settings 1.0
+import Nemo.Configuration 1.0
+
 
 Item {
     VolumeControl { id: volumeControl }
+
+    ConfigurationValue {
+        id: preMuteLevel
+
+        key: "/desktop/asteroid/pre-mute-level"
+    }
 
     property int soundMute: 0
 
@@ -31,7 +39,7 @@ Item {
         anchors.verticalCenterOffset: -Dims.h(13)
         color: "black"
         radius: width/2
-        opacity: soundMute > 0 ? 0.2 : 0.4
+        opacity: preMuteLevel.value > 0 ? 0.2 : 0.4
         width: parent.height*0.25
         height: width
 
@@ -41,13 +49,13 @@ Item {
             anchors.fill: parent
             onClicked: {
                 // Is muted?
-                if (soundMute > 0) {
+                if (preMuteLevel.value > 0) {
                     // Restore pre mute volume value
-                    volumeControl.volume = soundMute
-                    soundMute = 0
+                    volumeControl.volume = preMuteLevel.value
+                    preMuteLevel.value = 0
                 } else {
                     // Store volume value before muting
-                    soundMute = volumeControl.volume
+                    preMuteLevel.value = volumeControl.volume
                     volumeControl.volume = "0"
                 }
             }
@@ -60,7 +68,7 @@ Item {
         height: width
         anchors.fill: soundBackground
         anchors.margins: Dims.l(3)
-        name: soundMute > 0 ? "ios-sound-indicator-mute" :
+        name: preMuteLevel.value > 0 ? "ios-sound-indicator-mute" :
                               volumeControl.volume > "70" ? "ios-sound-indicator-high" :
                                                             volumeControl.volume > "30" ? "ios-sound-indicator-mid" :
                                                                                           volumeControl.volume > "0" ? "ios-sound-indicator-low" : "ios-sound-indicator-off"

--- a/src/qml/SoundPage.qml
+++ b/src/qml/SoundPage.qml
@@ -94,6 +94,12 @@ Item {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Dims.h(10)
         onClicked: {
+            //Un-mute if muted
+            if (preMuteLevel.value > 0) {
+                // Restore pre mute volume value
+                volumeControl.volume = preMuteLevel.value
+                preMuteLevel.value = 0
+            }
             var newVal = volumeControl.volume - 10
             if(newVal < 0) newVal = 0
             volumeControl.volume = newVal
@@ -107,6 +113,12 @@ Item {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Dims.h(10)
         onClicked: {
+            //Un-mute if muted
+            if (preMuteLevel.value > 0) {
+                // Restore pre mute volume value
+                volumeControl.volume = preMuteLevel.value
+                preMuteLevel.value = 0
+            }
             var newVal = volumeControl.volume + 10
             if(newVal > 100) newVal = 100
             volumeControl.volume = newVal

--- a/src/qml/SoundPage.qml
+++ b/src/qml/SoundPage.qml
@@ -28,7 +28,9 @@ Item {
         height: width
         anchors.centerIn: parent
         anchors.verticalCenterOffset: -Dims.h(15)
-        name: "ios-volume-up"
+        name: volumeControl.volume > "70" ? "ios-sound-indicator-high" :
+                                           volumeControl.volume > "30" ? "ios-sound-indicator-mid" :
+                                                                         volumeControl.volume > "0" ? "ios-sound-indicator-low" : "ios-sound-indicator-off"
     }
 
     Label {

--- a/src/qml/SoundPage.qml
+++ b/src/qml/SoundPage.qml
@@ -23,14 +23,47 @@ import org.asteroid.settings 1.0
 Item {
     VolumeControl { id: volumeControl }
 
+    property int soundMute: 0
+
+    Rectangle {
+        id: soundBackground
+        anchors.centerIn: parent
+        anchors.verticalCenterOffset: -Dims.h(13)
+        color: "black"
+        radius: width/2
+        opacity: soundMute > 0 ? 0.2 : 0.4
+        width: parent.height*0.25
+        height: width
+
+        MouseArea {
+            id: muteButton
+
+            anchors.fill: parent
+            onClicked: {
+                // Is muted?
+                if (soundMute > 0) {
+                    // Restore pre mute volume value
+                    volumeControl.volume = soundMute
+                    soundMute = 0
+                } else {
+                    // Store volume value before muting
+                    soundMute = volumeControl.volume
+                    volumeControl.volume = "0"
+                }
+            }
+
+        }
+    }
+
     Icon {
         width: Dims.w(25)
         height: width
-        anchors.centerIn: parent
-        anchors.verticalCenterOffset: -Dims.h(15)
-        name: volumeControl.volume > "70" ? "ios-sound-indicator-high" :
-                                           volumeControl.volume > "30" ? "ios-sound-indicator-mid" :
-                                                                         volumeControl.volume > "0" ? "ios-sound-indicator-low" : "ios-sound-indicator-off"
+        anchors.fill: soundBackground
+        anchors.margins: Dims.l(3)
+        name: soundMute > 0 ? "ios-sound-indicator-mute" :
+                              volumeControl.volume > "70" ? "ios-sound-indicator-high" :
+                                                            volumeControl.volume > "30" ? "ios-sound-indicator-mid" :
+                                                                                          volumeControl.volume > "0" ? "ios-sound-indicator-low" : "ios-sound-indicator-off"
     }
 
     Label {

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -107,7 +107,7 @@ Application {
                 ListItem {
                     //% "Sound"
                     title: qsTrId("id-sound-page")
-                    iconName: "ios-volume-up"
+                    iconName: "ios-sound-outline"
                     onClicked: layerStack.push(soundLayer)
                     visible: DeviceInfo.hasSpeaker
                 }


### PR DESCRIPTION
- Implements a dconf value to track the preMuteVolume so that it can be restored system wide on un-mute
- Sound settings page icon changed to a large outline speaker in same size like the other icons in that listview
- Icon in sound page is now a mute toggle button and shows the volume in 4 stages
- Made the sound settings page design consistent with the bluetooth settings page
- Volume increase/decrease buttons un-mute when pressed while muted.

Depends on actually adding the icons in https://github.com/AsteroidOS/asteroid-icons-ion/pull/16
Contributes to completing https://github.com/AsteroidOS/asteroid-settings/issues/76

https://user-images.githubusercontent.com/15074193/234376496-695ff4e0-afff-4f57-8642-ac89c8c07ae1.mp4

The new sound settings icon

![ionic10](https://user-images.githubusercontent.com/15074193/234378958-0ac47db4-23d0-4f86-9996-9bb2dfa039ca.jpg)
