### PR TITLE
Change date icon to newly created one

### DIFF
--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -77,7 +77,7 @@ Application {
                 ListItem {
                     //% "Date"
                     title: qsTrId("id-date-page")
-                    iconName: "ios-calendar-outline"
+                    iconName: "ios-date-outline"
                     onClicked: layerStack.push(dateLayer)
                 }
                 ListItem {


### PR DESCRIPTION
Adding a 31 to the Date icon to distinguish it a bit from the agenda icon

Contributes to https://github.com/AsteroidOS/asteroid-icons-ion/issues/13
Depends on adding the actual icon via https://github.com/AsteroidOS/asteroid-icons-ion/pull/17

![ionic9](https://user-images.githubusercontent.com/15074193/234378812-4ef6583e-889c-4657-8fe4-439a34b42402.jpg)

