### PR TITLE
Move main library file to CMAKE_INSTALL_LIBDIR and add a launch script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,13 @@ ecm_find_qmlmodule(org.nemomobile.systemsettings 1.0)
 
 add_subdirectory(src)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-settings.in
+	${CMAKE_BINARY_DIR}/asteroid-settings
+	@ONLY)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-settings
+	DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 build_translations(i18n)
 generate_desktop(${CMAKE_SOURCE_DIR} asteroid-settings)
 

--- a/asteroid-settings.desktop.template
+++ b/asteroid-settings.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-settings
+Exec=asteroid-settings
 Icon=ios-settings-outline
 X-Asteroid-Center-Color=#0044A6
 X-Asteroid-Outer-Color=#00010C

--- a/asteroid-settings.in
+++ b/asteroid-settings.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-settings.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(asteroid-settings ${SRC} ${HEADERS} resources.qrc
     ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.h 
     ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.cpp
 )
-set_target_properties(asteroid-settings PROPERTIES PREFIX "" SUFFIX "")
+set_target_properties(asteroid-settings PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-settings PRIVATE
 	Qt5::Qml
@@ -37,4 +37,4 @@ target_link_libraries(asteroid-settings PRIVATE
 	AsteroidApp)
 
 install(TARGETS asteroid-settings
-	DESTINATION ${CMAKE_INSTALL_BINDIR})
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Previously the main program file was installed to /usr/bin, mistakingly giving the impression it could be executed as is. However it isn't a binary but a library that gets executed through invoker. To prevent confusion move it to /usr/lib and add a launch script to /usr/bin instead which launches it through invoker