### PR TITLE
Add watchface settings page

### DIFF
--- a/src/qml/WatchfaceSelector.qml
+++ b/src/qml/WatchfaceSelector.qml
@@ -109,7 +109,7 @@ Item {
 
                         z: 2
                         visible: !previewPng.previewExists
-                        active: visible
+                        active: visible || (watchface === folderModel.folder + "/" + fileName)
                         anchors.centerIn: parent
                         width: Math.min(parent.width, parent.height)
                         height: width
@@ -119,7 +119,11 @@ Item {
 
                     MouseArea {
                         anchors.fill: parent
-                        onClicked: watchface = folderModel.folder + "/" + fileName
+                        onClicked: if ((watchface === folderModel.folder + "/" + fileName) && (typeof previewQml.item.settingsPage !== "undefined")) {
+				 layerStack.push(previewQml.item.settingsPage) 
+			} else {
+                        	watchface = folderModel.folder + "/" + fileName
+			}
                     }
 
                     Image {
@@ -151,6 +155,26 @@ Item {
                     }
                 }
 
+                Icon {
+                    name: "ios-settings-outline"
+
+                    z: 100
+                    width: parent.width*0.8
+                    height: width
+                    visible: (watchface === folderModel.folder + "/" + fileName) && (typeof previewQml.item.settingsPage !== "undefined")
+                    anchors.centerIn: parent
+                    layer.enabled: visible
+                    opacity: visible ? 0.4 : 0
+                    Behavior on opacity { NumberAnimation { duration: 100 } }
+                    layer.effect: DropShadow {
+                        transparentBorder: true
+                        horizontalOffset: 2
+                        verticalOffset: 2
+                        radius: 8.0
+                        samples: 17
+                        color: "#88000000"
+                    }
+                }
                 Rectangle {
                     id: textContainer
                     anchors { 

--- a/src/qml/WatchfaceSelector.qml
+++ b/src/qml/WatchfaceSelector.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
+ * Copyright (C) 2023 - Arseniy Movshev <dodoradio@outlook.com>
+ *               2022 - Timo Könnecke <github.com/eLtMosen>
  *               2022 - Darrel Griët <dgriet@gmail.com>
  *               2015 - Florent Revest <revestflo@gmail.com>
  *
@@ -150,36 +151,28 @@ Item {
                     }
                 }
 
-                Icon {
-                    name: "ios-checkmark-circle"
-
-                    z: 100
-                    width: parent.width * .3
-                    height: width
-                    visible: watchface === folderModel.folder + "/" + fileName
-                    anchors {
+                Rectangle {
+                    id: textContainer
+                    anchors { 
                         bottom: parent.bottom
-                        bottomMargin: DeviceInfo.hasRoundScreen ?
-                                          -parent.height * .03 :
-                                          -parent.height * .08
-                        horizontalCenter: parent.horizontalCenter
-                        horizontalCenterOffset: index % 2 ?
-                                                    DeviceInfo.hasRoundScreen ?
-                                                        -parent.height * .45 :
-                                                        -parent.height * .40 :
-                                                        DeviceInfo.hasRoundScreen ?
-                                                            parent.height * .45 :
-                                                            parent.height * .40
+                        left: parent.left
+                        right: parent.right
+                        margins: parent.width*0.05
                     }
-
-                    layer.enabled: visible
-                    layer.effect: DropShadow {
-                        transparentBorder: true
-                        horizontalOffset: 2
-                        verticalOffset: 2
-                        radius: 8.0
-                        samples: 17
-                        color: "#88000000"
+                    radius: height*0.4
+                    height: parent.height*0.17
+                    color: "#000000"
+                    opacity: 0.6
+                    visible: watchface === folderModel.folder + "/" + fileName
+                    Marquee {
+                        text: fileName.replace(".qml","")
+                        color: "#FFFFFF"
+                        anchors {
+                            fill: parent
+                            leftMargin: parent.width*0.05
+                            rightMargin: parent.width*0.05
+                        }
+                        font.pixelSize: parent.height*0.7
                     }
                 }
             }


### PR DESCRIPTION
This allows the watchface to ship an embedded settings page.
To make use of this, watchface qml file must have `property Component settingsPage` referencing the `id` of the `Component` which contains the settings page qml.
The watchface page only shows the 'gear' icon when this property is present, which serves as an indicator that the current watchface has a settings page. This can be accessed with another tap.
The gear icon appears with a short delay, as the watchface must be loaded before the `settingsPage` property can be checked.

an example implementation of such a watchface can be found here: https://dodorad.io/uploads/analog-classy-roman.qml

This also adds the watchface filename to the selector

The visuals of these two commits might need some tweaking. On a first glance, for example, the way that the gear icon and text overlap isn't very pretty. 
![IMG_20230521_112308~2](https://github.com/AsteroidOS/asteroid-settings/assets/41231427/35a5d230-52d4-4e5e-9a08-7b3b36b2ca34)

There is still some discussion about whether this is the best way to implement watchface settings, so this is still a draft for now. 

