### PR TITLE
Change default nightstand watchface

### DIFF
--- a/src/qml/NightstandWatchfacePage.qml
+++ b/src/qml/NightstandWatchfacePage.qml
@@ -34,7 +34,7 @@ Item {
     ConfigurationValue {
         id: watchfaceNightstandSource
         key: "/desktop/asteroid/nightstand/watchface"
-        defaultValue: assetPath + "watchfaces/005-analog-nordic.qml"
+        defaultValue: assetPath + "watchfaces/002-analog-70s-classic.qml"
     }
 
     ConfigurationValue {


### PR DESCRIPTION
This fixes a bug introduced by a recent change that changed which watchfaces were bundled by default.  This fixes https://github.com/AsteroidOS/asteroid-launcher/issues/140