### PR TITLE
Add Wifi Settings

### DIFF
--- a/i18n/asteroid-settings.ar.ts
+++ b/i18n/asteroid-settings.ar.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>تشغيل البلوتوث</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>إطفاء البلوتوث</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>متصل</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>غير متصل</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>مستوى الصوت</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>شحن فقط</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>وضع ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>وضع SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>وضع MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>استخدم صيغة ١٢ ساعة:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>استخدم فهرنهايت:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>الوقت</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>التاريخ</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>اللغة</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>بلوتوث</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>العرض</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>السطوع</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>سطوع تلقائي</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>دائمة الظهور</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">الحماية من الاحتراق</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>إمالة للإيقاظ</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>انقر للاستيقاظ</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>المنطقة الزمنية</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>الصوت</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>منضدة السرير</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>الوحدات</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>الخلفية</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>المظهر</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>الواجهة</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>يو اس بي</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>الطاقة</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>إغلاق</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>إعادة تشغيل</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>محمّل إقلاع</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>حول</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>تمكين</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>السطوع</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>التأخير</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>واجهة شاشة مخصصة</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>اختر واجهة الساعة</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">السطوع</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">بلوتوث</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">إعادة تشغيل</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">متصل</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">غير متصل</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>معرف البناء</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>الاسم الرمزي</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>اسم المضيف</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>عنوان الشبكة</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>المعرف التسلسلي</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>الرقم التسلسلي</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">إجمالي مساحة القرص</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>وقت التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>٪ L1 يوم٪ L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>الخيوط</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>مجهود 1،5،15 دقيقة</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>الذاكرة الاجمالية</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>الذاكرة المتاحة</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>% L1 ميغابايت (% L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">مساحة القرص المتوفرة</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>حجم الشاشة</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>إصدار النواة</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>إصدار Qt</translation>
     </message>

--- a/i18n/asteroid-settings.az.ts
+++ b/i18n/asteroid-settings.az.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth açıqdır</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth qapalıdır</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Qoşuldu</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Bağlantı yoxdur</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Səs</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Yalnız doldurulur</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB Rejimi</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH Rejimi</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP Rejimi</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12 Saatlıq formatdan istifadə et:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Farengeyt istifadə edin:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Vaxt</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Tarix</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Dil</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Ekran</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Parlaqlıq</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Avtomatik parlaqlıq</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Həmişə açıq Ekran</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Ekran yanığı qorunması</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Əyərək oyandırın</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Toxunaraq oyandır</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Saat qurşağı</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Səs</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Vahidlər</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Divar kağızı</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Saat görünüşü</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Başladıcı</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Söndür</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Söndürün</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Yenidən başlat</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Haqqında</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Aktivləşdirin</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Parlaqlıq</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Gecikmə</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Saat ekranı seç</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Parlaqlıq</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Yenidən başlat</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,114 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Qoşuldu</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Bağlantı yoxdur</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Qurma ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Kod adı</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Host adı</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Seriya nömrəsi</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Ümumi disk sahəsi</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Ümumi yaddaş</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Boş yaddaş</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Mövcud disk sahəsi</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Ekran ölçüsü</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Kernel versiyası</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt versiyası</translation>
     </message>

--- a/i18n/asteroid-settings.be.ts
+++ b/i18n/asteroid-settings.be.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth укл</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth выкл</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Падключана</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Не падключана</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Гучнасць</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Толькі зарадка</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Рэжым ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Рэжым SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Рэжым MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12-гадзінны фармат:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Градус Фарэнгейта:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Час</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Дысплэй</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Яркасць</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Аўтаматычная яркасць</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Заўсёды на дысплэі</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Абарона ад выгарання</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Абуджэнне па нахілу</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Абуджэнне па націску</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Часавы пояс</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Гук</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Адзінкі</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Шпалеры</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Цыферблат</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Праграма запуску</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>Хуткія налады</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Сілкаванне</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Выключыць</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Перазагрузіць</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Загрузчык</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Інфармацыя</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Уключыць</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Яркасць</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Затрымка</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Наладжвальны цыферблат</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Выбар цыферблата</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>Кнопка блакіроўкі</translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Налады</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Яркасць</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>Вібрацыя</translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>Пераключэнне Wi-Fi</translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Выключыць гук</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Кінарэжым</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>Выключэнне</translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>Перазагрузка</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Музыка</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>Ліхтарык</translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation>Рад замацаваных</translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation>Рухомы рад</translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>Параметры</translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation>Індыкатар батарэі выраўнены па нізу?</translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation>Паказваць анімацыю зарадкі?</translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation>Націсніце, каб змяніць дызайн часцінак</translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation>Перадпрагляд батарэі</translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation>Уключыць колеры батарэі?</translation>
     </message>
@@ -371,118 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished">Налады</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Падключана</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Не падключана</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID зборкі</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Кодавая назва</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Імя хоста</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Серыйны нумар</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Усяго месца на дыску</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 ГБ</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 ГБ (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1Ш x %L2В</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Час працы</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 дзён %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Патокі</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.ca.ts
+++ b/i18n/asteroid-settings.ca.ts
@@ -4,380 +4,560 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth activat</translation>
     </message>
     <message id="id-bluetooth-off">
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth apagat</translation>
     </message>
     <message id="id-connected">
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Connectat</translation>
     </message>
     <message id="id-disconnected">
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>No connectat</translation>
     </message>
     <message id="id-sound-percentage">
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volum</translation>
     </message>
     <message id="id-adb-mode">
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Mode ADB</translation>
     </message>
-    <message id="id-mtp-mode">
-        <source>MTP Mode</source>
-        <translation>Mode MTP</translation>
-    </message>
     <message id="id-12h-format">
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Utilitzar format de 12h:</translation>
     </message>
     <message id="id-fahrenheit">
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Utilitzar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-sound-page">
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>So</translation>
     </message>
     <message id="id-units-page">
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unitats</translation>
     </message>
     <message id="id-wallpaper-page">
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Fons de pantalla</translation>
     </message>
     <message id="id-watchface-page">
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Caràtula</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Apaga</translation>
     </message>
     <message id="id-reboot-page">
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Reinicia</translation>
     </message>
     <message id="id-about-page">
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Quant a</translation>
     </message>
     <message id="id-app-launcher-name">
+        <location filename="asteroid-settings.desktop.h" line="6"/>
         <source>Settings</source>
         <translation>Paràmetres</translation>
     </message>
     <message id="id-charging-only">
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Només càrrega</translation>
     </message>
     <message id="id-display-page">
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Pantalla</translation>
     </message>
     <message id="id-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Brillantor</translation>
     </message>
     <message id="id-always-on-display">
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Pantalla sempre activa</translation>
     </message>
     <message id="id-tilt-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Inclineu per despertar</translation>
     </message>
     <message id="id-tap-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Toc per despertar</translation>
     </message>
     <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Protecció contra imatge fantasma</translation>
     </message>
     <message id="id-launcher-page">
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Iniciador</translation>
     </message>
     <message id="id-automatic-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Brillantor automàtica</translation>
     </message>
     <message id="id-nightstand-page">
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Tauleta de nit</translation>
     </message>
     <message id="id-nightstand-enable">
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Activa</translation>
     </message>
     <message id="id-nightstand-brightness">
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brillantor</translation>
     </message>
     <message id="id-nightstand-delay">
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Retard</translation>
     </message>
     <message id="id-nightstand-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Seleccioneu una caràtula</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Caràtula personalitzada</translation>
     </message>
     <message id="id-ssh-mode">
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Mode SSH</translation>
     </message>
     <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Fus horari</translation>
     </message>
     <message id="id-power-page">
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Engegada</translation>
     </message>
     <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Gestor d’arrencada</translation>
     </message>
     <message id="id-quickpanel-page">
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished">Paràmetres</translation>
     </message>
     <message id="id-toggle-brightness">
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Brillantor</translation>
     </message>
     <message id="id-toggle-bluetooth">
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Reiniciar</translation>
     </message>
     <message id="id-particle-design">
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-music">
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation></translation>
     </message>
     <message id="id-off">
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Connectat</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">No connectat</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Id de la compilació</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nom en codi</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nom de l’amfitrió</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>MAC WLAN</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Número de sèrie</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Espai total en disc</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Espai disponible en disc</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Mida de la pantalla</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Versió del nucli</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Versió del Qt</translation>
     </message>
     <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1&#xa0;GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1&#xa0;GB (%L2&#xa0;%)</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W × %L2H</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Temps d’activitat</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dies %L2</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Fils</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Càrregues d&apos;1,5,15 minuts</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Memòria total</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1&#xa0;MB</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memòria disponible</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>

--- a/i18n/asteroid-settings.cs.ts
+++ b/i18n/asteroid-settings.cs.ts
@@ -4,380 +4,560 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth zapnuto</translation>
     </message>
     <message id="id-bluetooth-off">
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth vypnuto</translation>
     </message>
     <message id="id-connected">
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Připojeno</translation>
     </message>
     <message id="id-disconnected">
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Nepřipojeno</translation>
     </message>
     <message id="id-sound-percentage">
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Hlasitost</translation>
     </message>
     <message id="id-adb-mode">
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Režim ADB</translation>
     </message>
-    <message id="id-mtp-mode">
-        <source>MTP Mode</source>
-        <translation>Režim MTP</translation>
-    </message>
     <message id="id-12h-format">
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Použít 12 hodinový formát:</translation>
     </message>
     <message id="id-fahrenheit">
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Použít stupně Fahrenheita:</translation>
     </message>
     <message id="id-time-page">
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Čas</translation>
     </message>
     <message id="id-date-page">
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Jazyk</translation>
     </message>
     <message id="id-bluetooth-page">
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-sound-page">
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Zvuk</translation>
     </message>
     <message id="id-units-page">
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Jednotky</translation>
     </message>
     <message id="id-wallpaper-page">
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Pozadí</translation>
     </message>
     <message id="id-watchface-page">
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Ciferník</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Vypnout</translation>
     </message>
     <message id="id-reboot-page">
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Restart</translation>
     </message>
     <message id="id-about-page">
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>O systému</translation>
     </message>
     <message id="id-charging-only">
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Pouze nabíjení</translation>
     </message>
     <message id="id-display-page">
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Displej</translation>
     </message>
     <message id="id-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Jas</translation>
     </message>
     <message id="id-always-on-display">
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Vždy zapnutý displej</translation>
     </message>
     <message id="id-tilt-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Probuzení naklopením</translation>
     </message>
     <message id="id-tap-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Probuzení klepnutím</translation>
     </message>
     <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Ochrana proti popálení</translation>
     </message>
     <message id="id-launcher-page">
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Spouštěč</translation>
     </message>
     <message id="id-automatic-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Automatická úroveň jasu</translation>
     </message>
     <message id="id-nightstand-page">
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Noční režim na stojánku</translation>
     </message>
     <message id="id-nightstand-enable">
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Zapnout</translation>
     </message>
     <message id="id-nightstand-brightness">
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Jas</translation>
     </message>
     <message id="id-nightstand-delay">
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Prodleva</translation>
     </message>
     <message id="id-nightstand-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Vybrat ciferník</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Uživ. určený ciferník</translation>
     </message>
     <message id="id-ssh-mode">
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Režim SSH</translation>
     </message>
     <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Časové pásmo</translation>
     </message>
     <message id="id-power-page">
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Napájení</translation>
     </message>
     <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Zavaděč systému</translation>
     </message>
     <message id="id-quickpanel-page">
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>Rychlý panel</translation>
     </message>
     <message id="id-toggle-lock">
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>Tlačítko uzamčení</translation>
     </message>
     <message id="id-toggle-settings">
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Nastavení</translation>
     </message>
     <message id="id-toggle-brightness">
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Jas</translation>
     </message>
     <message id="id-toggle-bluetooth">
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>Vibrace</translation>
     </message>
     <message id="id-toggle-wifi">
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>WiFi vyp/zap.</translation>
     </message>
     <message id="id-toggle-sound">
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Ztlumit zvuk</translation>
     </message>
     <message id="id-toggle-cinema">
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Režim v kině</translation>
     </message>
     <message id="id-fixed-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation>Řádek napevno</translation>
     </message>
     <message id="id-sliding-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation>Posuvný řádek</translation>
     </message>
     <message id="id-battery-bottom">
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation>Ukazatel nabití zarovnaný dolů?</translation>
     </message>
     <message id="id-options">
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>Předvolby</translation>
     </message>
     <message id="id-battery-animation">
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation>Zobrazovat animaci nabíjení akumulátoru?</translation>
     </message>
     <message id="id-battery-colored">
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation>Obarvovat ukazatel nabití?</translation>
     </message>
     <message id="id-toggle-power-off">
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>Vypnout</translation>
     </message>
     <message id="id-toggle-reboot">
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>Restartovat</translation>
     </message>
     <message id="id-particle-design">
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation>Klepnutím přepínejte mezi designem částic</translation>
     </message>
     <message id="id-battery-preview">
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation>Náhled akumulátoru</translation>
     </message>
     <message id="id-toggle-music">
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Hudba</translation>
     </message>
     <message id="id-toggle-flashlight">
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>Svítilna</translation>
     </message>
     <message id="id-tap-to-cancel">
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation></translation>
     </message>
     <message id="id-off">
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-app-launcher-name">
+        <location filename="asteroid-settings.desktop.h" line="6"/>
         <source>Settings</source>
         <translation type="unfinished">Nastavení</translation>
+    </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Připojeno</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Nepřipojeno</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Identif. sestavení</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Kódový název</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Název stroje</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>MAC Wi-Fi rozhr.</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Sériové číslo</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Celkem kapacita úložiště</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Prostor dostupný na úložišti</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Velikost zobrazení</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Verze jádra systému</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Verze Qt</translation>
     </message>
     <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1Š x %L2V</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Doba od startu systému</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dnů %L2</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Vláken</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Vytížení v 1,5,15 minutách</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Celková oper. paměť</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Volná oper. paměť</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>

--- a/i18n/asteroid-settings.da.ts
+++ b/i18n/asteroid-settings.da.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth til</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth fra</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Forbundet</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Ikke forbundet</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Lydstyrke</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Kun opladning</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB-tilstand</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH-tilstand</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP-tilstand</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Brug 12-timer format:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Brug Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Tidspunkt</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Sprog</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Skærm</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Lysstyrke</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Automatisk lysstyrke</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Skærm altid tændt</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Beskyttelse mod fastbrænding</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Tilt-for-at-vågne</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tryk-for-at-vække</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Tidszone</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Lyd</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Natbord</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Enheder</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Baggrund</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Udseende på ur</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Launcher</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Strøm</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Sluk</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Genstart</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootloader</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Om</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Aktiver</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Lysstyrke</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Forsinke</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Tilpasset urskive</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Vælg urskive</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Lysstyrke</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Genstart</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,114 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Forbundet</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Ikke forbundet</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Kodenavn</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Værtsnavn</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Samlet diskplads</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Oppetid</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dage %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Tråde</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 minutters belastning</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Samlet hukommelse</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Ledig hukommelse</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Tilgængelig diskplads</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Skærmstørrelse</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Kerneversion</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.de_DE.ts
+++ b/i18n/asteroid-settings.de_DE.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth an</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth aus</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Verbunden</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Nicht verbunden</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Lautstärke</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Nur Aufladen</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB-Modus</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH-Modus</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP-Modus</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12-Stunden-Format verwenden:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Fahrenheit verwenden:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Uhrzeit</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Bildschirm</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Helligkeit</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation>Hoch</translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation>Mittel</translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation>Niedrig</translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Automatische Helligkeit</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Immer aktiver Bildschirm (AOD)</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation>Einbrennschutz</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Neigen zum Aufwachen</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tippen zum Aufwachen</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Zeitzone</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Ton</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Nachttisch</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Einheiten</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Hintergrundbild</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Ziffernblatt</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Starter</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>Schnellzugriff-Leiste</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Einschalten</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Ausschalten</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Neustart</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootlader</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation>Drücken bricht ab</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Über</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Aktivieren</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Helligkeit</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Verzögerung</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Benutzerdefiniertes Zifferblatt</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Zifferblatt wählen</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>Sperrtaste</translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Einstellungen</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Helligkeit</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>Vibration</translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>WLAN-Schalter</translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Tone Aus</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Kino Modus</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>Ausschalten</translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>Neustart</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Musik</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>Taschenlampe</translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation>Feste Reihe</translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation>Bewegliche Reihe</translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation>Batterieanzeige unten ausgerichtet?</translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation>Zeige animierte Batterieladeanzeige?</translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation>Tippe für nächstes Partikel Design</translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation>Batterie Vorschau</translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation>Farbige Batterie Anzeige?</translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Verbunden</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Nicht verbunden</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Build ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Codename</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Hostname</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Seriennummer</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Gesamter Festplattenspeicher</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Verfügbarkeitszeit</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 Tage %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Threads</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 Minuten Lasten</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Gesamtspeicher</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Freier Speicher</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Verfügbarer Festplattenspeicher</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Anzeigegröße</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Kernel-Version</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt-Version</translation>
     </message>

--- a/i18n/asteroid-settings.el.ts
+++ b/i18n/asteroid-settings.el.ts
@@ -4,380 +4,560 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth ενεργό</translation>
     </message>
     <message id="id-bluetooth-off">
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth κλειστό</translation>
     </message>
     <message id="id-connected">
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Συνδέθηκε</translation>
     </message>
     <message id="id-disconnected">
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Δε συνδέθηκε</translation>
     </message>
     <message id="id-sound-percentage">
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Ένταση ήχου</translation>
     </message>
     <message id="id-adb-mode">
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Τρόπος Λειτουργίας ADB</translation>
     </message>
-    <message id="id-mtp-mode">
-        <source>MTP Mode</source>
-        <translation>Τρόπος Λειτουργίας MTP</translation>
-    </message>
     <message id="id-12h-format">
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Χρήση 12ωρης ώρας:</translation>
     </message>
     <message id="id-fahrenheit">
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Χρήση κλίμακας Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Ώρα</translation>
     </message>
     <message id="id-date-page">
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Ημερομηνία</translation>
     </message>
     <message id="id-language-page">
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
     <message id="id-bluetooth-page">
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-sound-page">
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Ήχος</translation>
     </message>
     <message id="id-units-page">
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Μονάδες</translation>
     </message>
     <message id="id-wallpaper-page">
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Ταπετσαρία</translation>
     </message>
     <message id="id-watchface-page">
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Καντράν</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Απενεργοποίηση</translation>
     </message>
     <message id="id-reboot-page">
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Επανεκκίνηση</translation>
     </message>
     <message id="id-about-page">
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Σχετικά</translation>
     </message>
     <message id="id-charging-only">
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Μόνο φόρτιση</translation>
     </message>
     <message id="id-display-page">
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Απεικόνιση</translation>
     </message>
     <message id="id-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Φωτεινότητα</translation>
     </message>
     <message id="id-always-on-display">
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Πάντα στην οθόνη</translation>
     </message>
     <message id="id-tilt-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Ενεργοποίηση με περιστροφή</translation>
     </message>
     <message id="id-tap-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Ενεργοποίηση με πάτημα</translation>
     </message>
     <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Προστασία από εγκαύματα</translation>
     </message>
     <message id="id-launcher-page">
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Εκκινητής</translation>
     </message>
     <message id="id-automatic-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Αυτόματη φωτεινότητα</translation>
     </message>
     <message id="id-nightstand-page">
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Κομοδίνο</translation>
     </message>
     <message id="id-nightstand-enable">
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Ενεργοποίηση</translation>
     </message>
     <message id="id-nightstand-brightness">
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Φωτεινότητα</translation>
     </message>
     <message id="id-nightstand-delay">
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Καθυστέρηση</translation>
     </message>
     <message id="id-nightstand-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Επιλέξτε πρόσοψη ρολογιού</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Προσαρμοσμένη πρόσοψη ρολογιού</translation>
     </message>
     <message id="id-ssh-mode">
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Τρόπος Λειτουργίας SSH</translation>
     </message>
     <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Ζώνη ώρας</translation>
     </message>
     <message id="id-power-page">
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Δύναμη</translation>
     </message>
     <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootloader (φορτωτής εκκίνησης)</translation>
     </message>
     <message id="id-quickpanel-page">
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Φωτεινότητα</translation>
     </message>
     <message id="id-toggle-bluetooth">
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Επανεκκίνηση</translation>
     </message>
     <message id="id-particle-design">
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-music">
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation></translation>
     </message>
     <message id="id-off">
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-app-launcher-name">
+        <location filename="asteroid-settings.desktop.h" line="6"/>
         <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Συνδέθηκε</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Δε συνδέθηκε</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID κατασκευής</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Κωδική ονομασία</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Όνομα κεντρικού υπολογιστή</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Σειριακός αριθμός</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Συνολικός χώρος στο δίσκο</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Διαθέσιμος χώρος στο δίσκο</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Μέγεθος οθόνης</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Έκδοση πυρήνα</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Έκδοση Qt</translation>
     </message>
     <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Χρόνος διαθεσιμότητας</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 ημέρες %L2</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Νήματα</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Φορτία 1,5,15 λεπτών</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Συνολική μνήμη</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Ελεύθερη μνήμη</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>

--- a/i18n/asteroid-settings.en_GB.ts
+++ b/i18n/asteroid-settings.en_GB.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth on</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth off</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Connected</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Not connected</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volume</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Charging only</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB Mode</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH Mode</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP Mode</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Use 12H format:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Use Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Time</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Display</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Brightness</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation>Off</translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation>High</translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation>Medium</translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation>Low</translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Automatic brightness</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Always on Display</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation>Burn in protection</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Tilt-to-wake</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tap-to-wake</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Time zone</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Sound</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Nightstand</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Units</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Wallpaper</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Watchface</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Launcher</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>Quick Panel</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Power</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Power Off</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Reboot</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootloader</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation>Tap to cancel</translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>About</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Enable</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brightness</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Delay</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Custom watchface</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Select watchface</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>Lock Button</translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Settings</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Brightness</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>Vibration</translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>WiFi</translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Mute Sound</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Cinema Mode</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>Power off</translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>Reboot</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Music</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>Flashlight</translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation>Fixed Row</translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation>Sliding Row</translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation>Battery Meter aligned to bottom?</translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation>Show battery fill animations?</translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation>Tap to cycle particle design</translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation>Battery preview</translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation>Enable colored battery fill?</translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Connected</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Not connected</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Build ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Codename</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Host name</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Serial number</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Total disk space</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Uptime</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 days %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Threads</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 Minute loads</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Total memory</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Free memory</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Available disk space</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Display size</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Kernel version</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt version</translation>
     </message>

--- a/i18n/asteroid-settings.eo.ts
+++ b/i18n/asteroid-settings.eo.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bludento ŝaltita</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bludento malŝaltita</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Konektita</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Ne konektita</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Laŭteco</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Nur ŝargado</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB-reĝimo</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH-reĝimo</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP-reĝimo</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Uzu 12-horecon:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Uzi farenhejtan:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Tempo</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Lingvo</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bludento</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Ekrano</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Brilo</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Aŭtomate adapti brilon</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Ĉiam aktiva ekrano</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">enbrulada protekto</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Klini por veki</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tuŝi por veki</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Horzono</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Sono</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Noktotablo</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unuoj</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Fono</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Ciferplata aspekto</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Lanĉilo</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Energio</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Malstartigi</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Restartigi</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Ekŝarĝilo</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Pri</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Ebligi</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brileco</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Prokrastu</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Propra ciferplata aspekto</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Elekti ciferplata aspekto</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Brilo</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bludento</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Restartigi</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Konektita</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Ne konektita</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Konstrua ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Kodnomo</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Servilonomo</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Seria numero</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Tuta diskospaco</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Ŝaltita tempo</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 tagoj %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Fadenoj</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 Minutaj ŝarĝoj</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Tuta memoro</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Libera memoro</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Disponebla diskospaco</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Ekrana grando</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Kerna versio</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt versio</translation>
     </message>

--- a/i18n/asteroid-settings.es.ts
+++ b/i18n/asteroid-settings.es.ts
@@ -4,220 +4,220 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth encendido</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth apagado</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>No conectado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volumen</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Solo carga</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Modo SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Modo MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Usar formato 12&#xa0;h:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Pantalla</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Brillo</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Brillo automático</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Pantalla siempre encendida</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Protección contra imagen fantasma</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar para encender</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tocar para encender</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Huso horario</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Sonido</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Mesa de noche</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Fondo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Esfera</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Iniciador</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Energía</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Gestor de arranque</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
@@ -227,266 +227,337 @@
         <translation>Configuración</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Activar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brillo</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Retraso</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Esfera personalizada</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Seleccione la esfera del reloj</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished">Configuración</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Brillo</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Reiniciar</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Conectado</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">No conectado</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Id. de compilación</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nombre en clave</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nombre de anfitrión</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Espacio total en el disco</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W × %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Tiempo de actividad</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 días %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Hilos</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Cargas de 1,5,15 minutos</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Memoria total</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memoria libre</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Espacio de disco disponible</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Tamaño de la pantalla</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Versión del núcleo</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Versión de Qt</translation>
     </message>

--- a/i18n/asteroid-settings.es_AR.ts
+++ b/i18n/asteroid-settings.es_AR.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth activado</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth desactivado</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Desconectado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volumen</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Solo carga</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Modo SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Modo MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Usar formato 12h:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Pantalla</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Brillo</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Brillo automático</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Pantalla siempre activa</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Protección contra pantalla fantasma</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar para activar</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tocar para activar</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Zona horaria</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Sonido</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Mesita de luz</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Fondo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Carátula</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Lanzador</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Energía</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Cargador de arranque</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Activar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brillo</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Demora</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Carátula personalizada</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Elige una carátula</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Brillo</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Reiniciar</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Conectado</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Desconectado</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Id. de compilación</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nombre clave</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nombre del servidor</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>MAC WLAN</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Espacio en disco total</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Tiempo de actividad</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 días %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Hilos</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Cargas de 1, 5, 15 minutos</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Memoria total</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memoria libre</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Espacio en disco disponible</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Tamaño de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Versión del kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Versión de Qt</translation>
     </message>

--- a/i18n/asteroid-settings.fa.ts
+++ b/i18n/asteroid-settings.fa.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>بلوتوث روشن</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>بلوتوث خاموش</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>وصل شده</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>وصل نشده</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>حجم صدا</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>فقط شارژ شدن</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>پل توسعهٔ اندروید</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>حالت پوستهٔ امن</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>حالت انتقال رسانه</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>استفاده از قالب ۱۲ساعته:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>استفاده از فارنهایت:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>زمان</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>زبان</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>بلوتوث</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>صفحهٔ نمایش</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>روشنایی</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>روشنایی خودکار</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>صفحهٔ همواره روشن</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">محافظت از سوختن</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>چرخاندن برای بیداری</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>ضربه برای بیداری</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>ناحیهٔ زمانی</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>صدا</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>پایهٔ شبانه</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>واحدها</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>کاغذدیواری</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>صفحهٔ ساعت</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>اجراگر</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>تنظیمات سریع</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>یواِس‌بی</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>نیرو</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>خاموش</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>راه‌اندازی دوباره</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>بارکنندهٔ راه‌انداز</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>درباره</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>به کار انداختن</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>روشنایی</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>تأخیر</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>صفحهٔ ساعت شخصی</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>گزینش صفحهٔ ساعت</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>دکمهٔ قفل</translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>تنظیمات</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>روشنایی</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>بلوتوث</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>لرزش</translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>تغییر وضعیت وای‌فای</translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>خموشی صدا</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>حالت سینما</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>خاموش کردن</translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>راه‌اندازی دوباره</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>آهنگ</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>چراغ‌قوه</translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation>ردیف ثابت</translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation>ردیف لغزنده</translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>گزینه‌ها</translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation>باتری‌سنج در پایین؟</translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation>نمایش پویانمایی شارژ باتری؟</translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation>زدن برای دورهٔ طرّاحی ذره</translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation>پیش‌نمایش باتری</translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation>به کار انداختن باتری رنگی؟</translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished">تنظیمات</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">وصل شده</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">وصل نشده</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>شناسهً ساخت</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>نام رمزی</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>نام میزبان</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>مک بی‌سیم</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>شماره سریال</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">مجموع فضای دیسک</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 گ‌ب</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 گ‌ب (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1پ × %L2ب</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>زمان روشنی</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 روز %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>رشته‌ها</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>بار ۱،۵،۱۵ دقیقه</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1، %L2، %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>حافظهٔ کل</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 م‌ب</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>حافظهٔ آزاد</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 م‌ب (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">فضای دیسک موجود</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>اندازهٔ نمایشگر</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>نگارش کرنل</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>نگارش Qt</translation>
     </message>

--- a/i18n/asteroid-settings.fi.ts
+++ b/i18n/asteroid-settings.fi.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth päällä</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth pois</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Yhdistetty</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Ei yhteyttä</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Äänenvoimakkuus</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Vain lataus</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB Tila</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH Tila</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP Tila</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Käytä 12H muotoa:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Käytä Fahrenheitia:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Aika</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Päiväys</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Kieli</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Näyttö</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Kirkkaus</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Automaattinen kirkkaus</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Tyyni näyttö (ei sammu)</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Burn-in suojaus</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Nosta herättääksesi puhelin</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Napauta herättääksesi puhelin</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Aikavyöhyke</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Ääni</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Yöpöytä</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Yksiköt</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Taustakuva</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Kellotaulu</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Sovellusten käynnistysohjelma</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Virta</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Sammuta</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Käynnistä uudelleen</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Käynnistyksenlataaja</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Tietoa</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Ota käyttöön</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Kirkkaus</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Viive</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Mukautettu kellon ilme</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Valitse kellon ilme</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Kirkkaus</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Käynnistä uudelleen</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Yhdistetty</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Ei yhteyttä</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Koontitunnus</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Koodinimi</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Isäntänimi</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Sarjanumero</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Levytila yhteensä</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 Gt</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 Gt (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Käyttöaika</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 päivää %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Säikeet</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 minuutin kuormitus</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Muisti yhteensä</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 Mt</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Vapaa muisti</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 Mt (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Käytettävissä oleva levytila</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Näytön koko</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Ytimen versio</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt-versio</translation>
     </message>

--- a/i18n/asteroid-settings.fr.ts
+++ b/i18n/asteroid-settings.fr.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth activé</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth désactivé</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Connecté</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Non connecté</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volume</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Charge uniquement</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Mode ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Mode SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Mode MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Format 12H :</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Fahrenheit :</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Heure</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Langue</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Écran</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Luminosité</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Luminosité automatique</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Toujours allumé</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Prévention des brûlures d&apos;écran</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Incliner pour réveiller</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tapoter pour réveiller</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Fuseau horaire</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Son</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Table de nuit</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unités</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Fond d&apos;écran</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Cadran</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Lanceur</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>Panneau rapide</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Marche/Arrêt</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Éteindre</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Redémarrer</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Amorçage</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>À propos</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Activer</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Luminosité</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Délai</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Cadran personnalisé</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Sélectionner le cadran</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Paramètres</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Luminosité</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>Bascule Wifi</translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Couper le son</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Mode cinéma</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Redémarrer</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Musique</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>Lampe de poche</translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation>Jauge batterie alignée vers le bas&#x202f;?</translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation>Montrer l’animation de charge de la batterie&#x202f;?</translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation>Aperçu batterie</translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation>Activer batterie colorée&#x202f;?</translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished">Paramètres</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Connecté</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Non connecté</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Référence de compilation</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nom de code</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nom de l&apos;hôte</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>MAC WIFI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Numéro de série</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Espace disque total</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1L x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Temps de fonctionnement</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 jours %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Processus</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Charges de 1,5,15 minutes</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Mémoire totale</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Mémoire libre</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Espace disponible</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Taille d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Version du noyau</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Version de Qt</translation>
     </message>

--- a/i18n/asteroid-settings.gl.ts
+++ b/i18n/asteroid-settings.gl.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth activado</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth desactivado</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Non conectado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volume</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Só carrega</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Modo SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Modo MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Enpregar formato 12H:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Empregar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Pantalla</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Luminosidade</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Brillo automático</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Pantalla sempre acesa</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Protección contra queimaduras</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar para prender</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tocar para despertar</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Franxa horaria</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Son</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Mesita de noite</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Imaxe do fondo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Esfera do reloxo</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Iniciador</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Encendido</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Xestor de arranque</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Activar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brillo</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Atraso</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Esfera do reloxo personalizable</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Seleccionala esfera do reloxo</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Reiniciar</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Conectado</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Non conectado</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Identificación da compilación</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nome en clave</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nome do anfitrión</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Espazo total no disco</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Tempo de actividade</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 días %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Fíos</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Cargas de 1,5,15 minutos</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Memoria total</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memoria libre</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Espazo dispoñible no disco</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Tamaño da pantalla</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Versión do kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Versión de Qt</translation>
     </message>

--- a/i18n/asteroid-settings.he.ts
+++ b/i18n/asteroid-settings.he.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth פעיל</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth כבוי</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>מחובר</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>מנותק</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>עצמת שמע</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>טעינה בלבד</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>מצב ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>מצב SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>מצב התקן אחסון</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>תבנית 12 שעות:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>שימוש בפרנהייט:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>שעה</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>תאריך</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>שפה</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>תצוגה</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>בהירות</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>בהירות אוטומטית</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>תצוגה פעילה תמידית</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">הגנה מצריבה פנימית</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>להטות כדי להעיר</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>לגעת כדי להעיר</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>אזור זמן</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>צליל</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>שידה</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>יחידות</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>תמונת רקע</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>פני השעון</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>משגר</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>לוח מהיר</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>ניהול חשמל</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>כיבוי</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>הפעלה מחדש</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>מנהל הפעלה</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>על אודות</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>הפעלה</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>בהירות</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>השהיה</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>פני שעון בהתאמה אישית</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>בחירת פני השעון</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>כפתור נעילה</translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>הגדרות</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>בהירות</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>בלוטות׳</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>רטט</translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>מתג אלחוט</translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>השתקת שמע</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>מצב קולנוע</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>כיבוי</translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>הפעלה מחדש</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>מוזיקה</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>פנס</translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation>שורה קבועה</translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation>שורה מתחלפת</translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation>מד הסוללה מיושר למטה?</translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation>להציג הנפשת טעינת סוללה?</translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation>נגיעה תעבור בין עיצובי חלקיקים בלולאה</translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation>תצוגת סוללה מקדימה</translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation>להפעיל סוללה צבעונית?</translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished">הגדרות</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">מחובר</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">מנותק</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>מזהה בנייה</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>שם קוד</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>שם מארח</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>כתובת חומרה אלחוטית</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>מס׳ ברזל</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>מס׳ סידורי</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">נפח כונן כולל</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 ג״ב</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 ג״ב (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>‎%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>זמן פעילות</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 ימים %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>תהליכונים</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>עומס ב־1,5,15 דקות</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>‎%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>סך הכול זיכרון</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 מ״ב</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>זיכרון פנוי</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 מ״ב (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">מקום פנוי בכונן</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>גודל התצוגה</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>גרסת ליבה</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>גרסת Qt</translation>
     </message>

--- a/i18n/asteroid-settings.hi.ts
+++ b/i18n/asteroid-settings.hi.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>ब्लूटूथ चालू है</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>ब्लूटूथ बंद है</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>कनेक्टेड</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>कनेक्टेड नहीं है</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>वॉल्यूम</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>केवल चार्जिंग</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB मोड</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH मोड</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP मोड</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12 घंटे वाला फॉर्मेट का प्रयोग करो:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>फारेनहाइट का उपयोग करें:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>समय</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>दिनांक</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>ब्लूटूथ</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>डिस्प्ले</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>चमक</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>स्वचालित चमक</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>हमेशा डिस्प्ले ऑन (AOD)</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">डिस्प्ले जलने का बचाव</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>टिल्ट-टु-वेक</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>टैप-टु-वेक</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>टाइम ज़ोन</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>ध्वनि</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>रात्रिस्तंभ</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>यूनिट</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>वॉलपेपर</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>वॉचफेस</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>लांचर</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>पॉवर</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>पॉवर ऑफ</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>रीबूट</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>बूटलोडर</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>एस्टेरोइड ओ. एस. के बारे में</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>चालून करे</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>चमक</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>देरी</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>कस्टम वॉचफेस</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>वॉचफेस चुनें</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">चमक</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">ब्लूटूथ</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">रीबूट</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">कनेक्टेड</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">कनेक्टेड नहीं है</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>बिल्ड आई डी</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>कोड नाम</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>होस्ट का नाम</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>सीरियल नंबर</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">डिस्क का कुल जगह</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Uptime/अपटाइम</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 दिन %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Threads</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 मिनट का लोड</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>कुल मेमोरी</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>खाली मेमोरी</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">डिस्क का उपलब्ध जगह</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>डिस्प्ले साइज़</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Kernel version</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt version</translation>
     </message>

--- a/i18n/asteroid-settings.hr.ts
+++ b/i18n/asteroid-settings.hr.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth uključen</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth je isključen</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Spojen</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Nije spojen</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Glasnoća</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Samo punjenje</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB modus</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH modus</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP modus</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Koristi 12-satni format:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Koristi Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Vrijeme</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Jezik</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Ekran</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Svjetlina</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Automatska svjetlina</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Uvijek na ekranu</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Zaštita ekrana</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Nagni-za-buđenje</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Dodirni-za-buđenje</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Vremenska zona</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Zvuk</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Prikaz sata tijekom noćnog napajanja</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Jedinice</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Pozadina</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Pozadina sata</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Pokretač</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Uključi</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Isključi</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Ponovo pokreni</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Informacije</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Aktiviraj</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Svjetlina</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Odgoda</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Prilagođena pozadina sata</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Odaberi pozadinu sata</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Svjetlina</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Ponovo pokreni</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Spojen</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Nije spojen</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID izgradnje</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Kodno ime</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Ime hosta</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Serijski broj</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Ukupna memorija na disku</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1 Š × %L2 V</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Radno vrijeme</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dana %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Procesi</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Ukupna memorija</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Nepotrošena memorija</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Raspoloživa memorija na disku</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Veličina ekrana</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Verzija jezgre</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt-verzija</translation>
     </message>

--- a/i18n/asteroid-settings.hu.ts
+++ b/i18n/asteroid-settings.hu.ts
@@ -4,364 +4,560 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth bekapcsolva</translation>
     </message>
     <message id="id-bluetooth-off">
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth kikapcsolva</translation>
     </message>
     <message id="id-connected">
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Csatlakozva</translation>
     </message>
     <message id="id-disconnected">
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Nincs csatlakoztatva</translation>
     </message>
     <message id="id-sound-percentage">
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Hangerő %1%</translation>
     </message>
     <message id="id-adb-mode">
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB használata</translation>
     </message>
-    <message id="id-mtp-mode">
-        <source>MTP Mode</source>
-        <translation>MTP használata</translation>
-    </message>
     <message id="id-12h-format">
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Használja a 12 órás formátumot:</translation>
     </message>
     <message id="id-fahrenheit">
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Fahrenheit-skála használata:</translation>
     </message>
     <message id="id-time-page">
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Idő</translation>
     </message>
     <message id="id-date-page">
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message id="id-language-page">
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Nyelv</translation>
     </message>
     <message id="id-bluetooth-page">
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-sound-page">
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Hang</translation>
     </message>
     <message id="id-units-page">
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Mértékegységek</translation>
     </message>
     <message id="id-wallpaper-page">
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Háttérkép</translation>
     </message>
     <message id="id-watchface-page">
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Óra számlapja</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Kikapcsolás</translation>
     </message>
     <message id="id-reboot-page">
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Újraindítás</translation>
     </message>
     <message id="id-about-page">
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Az okosóráról</translation>
     </message>
     <message id="id-charging-only">
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Csak töltés</translation>
     </message>
     <message id="id-display-page">
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Kijelző</translation>
     </message>
     <message id="id-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation type="unfinished">Fényerő</translation>
     </message>
     <message id="id-always-on-display">
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tilt-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Felébresztés döntéssel</translation>
     </message>
     <message id="id-tap-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Ébresztés koppintással</translation>
     </message>
     <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-launcher-page">
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-page">
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-enable">
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Fényerő</translation>
     </message>
     <message id="id-nightstand-delay">
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-ssh-mode">
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH használata</translation>
     </message>
     <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-power-page">
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-quickpanel-page">
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Fényerő</translation>
     </message>
     <message id="id-toggle-bluetooth">
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Újraindítás</translation>
     </message>
     <message id="id-particle-design">
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-music">
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation></translation>
     </message>
     <message id="id-off">
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-app-launcher-name">
+        <location filename="asteroid-settings.desktop.h" line="6"/>
         <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Csatlakozva</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Nincs csatlakoztatva</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.ia.ts
+++ b/i18n/asteroid-settings.ia.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth activate</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth disactivate</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Connectite</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Disconnectite</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volumine</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Solmente cargar</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Modo SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Modo MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Usar formato de 12H:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Schermo</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Luminositate</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Luminositate automatic</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Schermo sempre active</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Protection contra ardituras</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar pro activar</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Toccar pro activar</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Fuso horari</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Sono</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Tabula de nocte</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unitates</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Fundo de schermo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Lanceator</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Arrestar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Reinitiar</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>A proposito de</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Activar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Luminositate</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Retardo</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Cadran personnalisé</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Luminositate</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Reinitiar</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Connectite</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Disconnectite</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID de compilation</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nomine de codice</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nomine de hospite</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Numero de serie</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Spatio total in disco</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Disponibilité</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dies %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Topicos</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Cargas de 1,5,15 minutas</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Memoria total</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memoria libere</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Spatio in disco disponibile</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Dimension de schermo</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Version de kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Version de Qt</translation>
     </message>

--- a/i18n/asteroid-settings.id.ts
+++ b/i18n/asteroid-settings.id.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth aktif</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth nonaktif</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Terhubung</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Terputus</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volume</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Hanya mengisi daya</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Mode ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Mode SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Mode MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Gunakan format 12j:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Gunakan Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Waktu</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Tanggal</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Bahasa</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Layar</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Kecerahan</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Kecerahan otomatis</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Selalu Dipajang</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Proteksi pembakaran</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>miringkan untuk bangun</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Ketuk untuk membangunkan</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Zona waktu</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Suara</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Dudukan malam</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unit</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Gambar latar</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>tampilan jam</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Peluncur</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>Panel Cepat</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Daya</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Matikan</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Nyalakan Ulang</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootloader</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Tentang</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Aktifkan</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Kecerahan</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Tunda</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Tampilan jam kustom</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Pilih tampilan jam</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>Tombol Kunci</translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Pengaturan</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Kecerahan</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>Getaran</translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>Sakelar Wifi</translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Bisukan Suara</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Mode Bioskop</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>Matikan</translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>Nyalakan Ulang</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Musik</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>Senter</translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation>Baris Tetap</translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation>Baris Geser</translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>Opsi</translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation>Indikator Baterai disejajarkan ke bawah?</translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation>Tampilkan animasi pengisian baterai?</translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation>Ketuk untuk berganti desain partikel</translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation>Pratinjau baterai</translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation>Aktifkan baterai berwarna?</translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished">Pengaturan</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Terhubung</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Terputus</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID build</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nama kode</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nama host</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>MAC WLAN</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Nomor seri</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Total ruang disk</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2%)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Waktu aktif</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 hari %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Thread</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Beban 1,5,15 menit</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Total memori</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memori bebas</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2%)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Ruang disk tersedia</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Ukuran layar</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Versi kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Versi Qt</translation>
     </message>

--- a/i18n/asteroid-settings.it.ts
+++ b/i18n/asteroid-settings.it.ts
@@ -4,380 +4,560 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth attivato</translation>
     </message>
     <message id="id-bluetooth-off">
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth disattivato</translation>
     </message>
     <message id="id-connected">
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Connesso</translation>
     </message>
     <message id="id-disconnected">
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Disconnesso</translation>
     </message>
     <message id="id-sound-percentage">
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volume</translation>
     </message>
     <message id="id-adb-mode">
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Modalità ADB</translation>
     </message>
-    <message id="id-mtp-mode">
-        <source>MTP Mode</source>
-        <translation>Modalità MTP</translation>
-    </message>
     <message id="id-12h-format">
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Usa il formato 12 ore:</translation>
     </message>
     <message id="id-fahrenheit">
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Usa Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Ora</translation>
     </message>
     <message id="id-date-page">
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
     <message id="id-bluetooth-page">
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-sound-page">
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Audio</translation>
     </message>
     <message id="id-units-page">
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unità</translation>
     </message>
     <message id="id-wallpaper-page">
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Sfondo</translation>
     </message>
     <message id="id-watchface-page">
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Quadrante</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Spegni</translation>
     </message>
     <message id="id-reboot-page">
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Riavvia</translation>
     </message>
     <message id="id-about-page">
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Info su</translation>
     </message>
     <message id="id-charging-only">
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Solo ricarica</translation>
     </message>
     <message id="id-display-page">
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Schermo</translation>
     </message>
     <message id="id-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Luminosità</translation>
     </message>
     <message id="id-always-on-display">
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Schermo sempre acceso</translation>
     </message>
     <message id="id-tilt-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinare-per-svegliarsi</translation>
     </message>
     <message id="id-tap-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tocca-per-riattivare</translation>
     </message>
     <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Protezione contro il &quot;burn-in&quot;</translation>
     </message>
     <message id="id-launcher-page">
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>App Launcher</translation>
     </message>
     <message id="id-automatic-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Luminosità automatica</translation>
     </message>
     <message id="id-nightstand-page">
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Modalità Comodino</translation>
     </message>
     <message id="id-nightstand-enable">
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Abilita</translation>
     </message>
     <message id="id-nightstand-brightness">
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Luminosità</translation>
     </message>
     <message id="id-nightstand-delay">
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Ritardo</translation>
     </message>
     <message id="id-nightstand-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Seleziona il quadrante</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Quadrante personalizzato</translation>
     </message>
     <message id="id-ssh-mode">
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Modalità SSH</translation>
     </message>
     <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Fuso orario</translation>
     </message>
     <message id="id-power-page">
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Alimentazione</translation>
     </message>
     <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootloader</translation>
     </message>
     <message id="id-quickpanel-page">
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Luminosità</translation>
     </message>
     <message id="id-toggle-bluetooth">
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Riavvia</translation>
     </message>
     <message id="id-particle-design">
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-music">
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation></translation>
     </message>
     <message id="id-off">
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-app-launcher-name">
+        <location filename="asteroid-settings.desktop.h" line="6"/>
         <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Connesso</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Disconnesso</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID Build</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nome in codice</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nome dell&apos;host</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>MAC WLAN</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Numero seriale</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Spazio totale sul disco</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Spazio disponibile sul disco</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Dimensione schermo</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Versione del kernel</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Versione di Qt</translation>
     </message>
     <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Tempo di utilizzo</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 giorni %L2</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Istanze</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Carico medio 1,5,15 minuti</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Memoria totale</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memoria libera</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>

--- a/i18n/asteroid-settings.ja.ts
+++ b/i18n/asteroid-settings.ja.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetoothオン</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetoothオフ</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>接続中</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>未接続</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">音量 %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>充電のみ</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADBモード</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSHモード</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTPモード</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12時間表記:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>華氏(℉)表記:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>日付</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>ディスプレイ</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>明るさ</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation type="unfinished">振ってスリープを解除</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>時間帯</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>サウンド</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>単位</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>壁紙</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>文字盤</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>電源を切る</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>再起動</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>情報</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">輝度</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">輝度</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">再起動</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,106 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">接続中</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">未接続</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.ka.ts
+++ b/i18n/asteroid-settings.ka.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>ბლუთუზი ჩართულია</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>ბლუთუზი გამორთულია</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>დაკავშირებული</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>არაა დაკავშირებული</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>ხმის სიმაღლე</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>მხოლოდ დამუხტვა</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB მეთოდი</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH მეთოდი</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP მეთოდი</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>გამოყენებულ იქნას 12 საათიანი ფორმატი:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>გამოყენებულ იქნას ფარენჰეიტის შკალა:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>დრო</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>თარიღი</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>ენა</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>ბლუთუზი</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>სიკაშკაშე</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>დახრით გაღვიძება</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>ხმა</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>ერთეულები</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>ფონი</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>მაჯისსაათის სახე</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>კვების გამორთვა</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>გადატვირთვა</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>შესახებ</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>სიკაშკაშე</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>სიკაშკაშე</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>ბლუთუზი</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>გადატვირთვა</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,106 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">დაკავშირებული</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">არაა დაკავშირებული</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.ko.ts
+++ b/i18n/asteroid-settings.ko.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>블루투스 켜짐</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>블루투스 꺼짐</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>연결됨</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>연결되지 않음</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>볼륨</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>충전 전용</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB 모드</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH 모드</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP 모드</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12시간제를 사용:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>화씨를 사용:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>시간</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>날짜</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>블루투스</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>화면</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>밝기</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>자동 밝기</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>항상 켜기</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">번인 보호</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>시계를 볼 때 화면 켜기</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>탭할 때 화면 켜기</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>시간대</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>소리</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>나이트스탠드</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>단위</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>배경화면</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>시계화면</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>런처</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>전원</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>종료</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>재시동</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>부트로더</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>정보</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>활성화</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>밝기</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>지연</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>시계화면 사용자 정의</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>시계 모드 선택</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">밝기</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">블루투스</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">재시동</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">연결됨</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">연결되지 않음</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>빌드 ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>코드명</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>호스트 이름</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>일련 번호</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">총 디스크 공간</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>가동시간</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 일 %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>쓰레드</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1, 5, 15 분 불러오기</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>총 메모리</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>사용 가능한 메모리</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">사용 가능한 디스크 공간</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>디스플레이 크기</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>커널 버전</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt 버전</translation>
     </message>

--- a/i18n/asteroid-settings.lb.ts
+++ b/i18n/asteroid-settings.lb.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation></translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth aus</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Verbonnen</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Net verbonnen</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Lautstäerkt %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Nëmmen oplueden</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation></translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP-Modus</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12-Stonnen-Format:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Auerzäit</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Sprooch</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation type="unfinished">Hellegkeet</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation></translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unitéiten</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Hannergrond</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Zifferblat</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Ausschalten</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Neistart</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Iwwer</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Hellegkeet</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Hellegkeet</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Neistart</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,106 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Verbonnen</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Net verbonnen</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.lt.ts
+++ b/i18n/asteroid-settings.lt.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth įjungtas</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth išjungtas</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Prisijungta</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Neprisijungta</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Garsumas</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Tik įkraunama</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB rėžimas</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH rėžimas</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP rėžimas</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Naudoti 12 valandų formatą:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Naudoti Fahrenheitą:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Laikas</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Kalba</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Ekranas</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Ryškumas</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Automatinis ryškumas</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Visada įjungtas ekranas</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Apsauga nuo ekrano išdegimo</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Pakreipti, kad pabustų</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Paliesti, kas pabustų</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Laiko zona</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Garsas</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Naktinis staliukas</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Vienetai</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Ekrano paveikslėlis</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Laikrodžio ekrano dizainas</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Paleidimo programa</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Baterija</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Išjungti</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Perkrauti</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Įkroviklis</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Apie</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Įjungti</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Ryškumas</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Atidėjimas</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Tinkinamas laikrodžio ekrano dizainas</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Pasirinkite laikrodžio ekrano dizainą</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Ryškumas</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Perkrauti</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Prisijungta</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Neprisijungta</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Versijos ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Kodinis pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Pagrindinio kompiuterio vardas</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Serijos numeris</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Iš viso vietos diske</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Veikimo trukmė</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dienos %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Gijos</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 minučių apkrovos</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Bendra atmintis</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Laisva atmintis</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Turima disko vieta</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Ekrano dydis</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Branduolio versija</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt versija</translation>
     </message>

--- a/i18n/asteroid-settings.mr.ts
+++ b/i18n/asteroid-settings.mr.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>ब्लूटूथ चालू</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>ब्लूटुथ बंद</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>जोडलेले</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>न जोडलेले</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>आवाज</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>फक्त चार्जिंग</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>एडीबी मोड</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>एमटीपी मोड</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12 तास स्वरूप वापरा:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>फॅरनहाइट वापरा:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>वेळ</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>दिनांक</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>ब्लूटुथ</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>प्रदर्शन</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>उज्ज्वलता</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>स्वयंचलित ब्राइटनेस</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>नेहमी प्रदर्शनावर</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">संरक्षणात बर्न करा</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>टिल्ट टू वेक</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>टॅप टू वेक</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>आवाज</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>युनिट</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>वॉलपेपर</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>वॉचफेस</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>लाँचर</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>युएसबी</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>वीज बंद</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>रीबूट करा</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>बद्दल</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">उज्ज्वलता</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>विलंब</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">उज्ज्वलता</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">ब्लूटुथ</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">रीबूट करा</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,106 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">जोडलेले</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">न जोडलेले</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>आयएमईआय</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>सिरीयल क्रमांक</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 दिवस %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.ms.ts
+++ b/i18n/asteroid-settings.ms.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth buka</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth tutup</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Disambungkan</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Tidak Disambungkan</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Tahap bunyi %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Cas sahaja</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Mod ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Mod SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Mod MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Guna format 12H:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Guna Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Masa</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Tarikh</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Bahasa</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Paparan</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Kecerahan</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Sentiasa Dipamerkan</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Pusing-untuk-bangun</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Ketik untuk bangun</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Bunyi</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unit</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Paparan</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Muka jam</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Tutup Kuasa</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Mulakan Semula</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Mengenai</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Kecerahan</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Kecerahan</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Mulakan Semula</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,106 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Disambungkan</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Tidak Disambungkan</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.nb_NO.ts
+++ b/i18n/asteroid-settings.nb_NO.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Blåtann på</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Blåtann av</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Tilkoblet</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Ikke tilkoblet</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Lydstyrke</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Kun lading</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB-modus</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH-modus</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP-modus</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Bruk tolvtimersformat:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Bruk fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Klokke</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Blåtann</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation type="unfinished">Skjerm</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation type="unfinished">Lysstyrke</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation type="unfinished">Automatisk lysstyrke</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation type="unfinished">Skjerm alltid påslått</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Innbrenningsbeskyttelse</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Skakke-vekking</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation type="unfinished">Trykk for å vekke</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Tidssone</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Lyd</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation type="unfinished">Nattbord</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Enheter</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Bakgrunn</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Klokkeskive</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Oppstarter</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation type="unfinished">Effekt</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Skru av</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Omstart</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Oppstartslaster</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Om</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation type="unfinished">Skru på</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">Lysstyrke</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation type="unfinished">Forsinkelse</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Egendefinert urskive</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Velg urskive</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Lysstyrke</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Blåtann</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Omstart</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Tilkoblet</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Ikke tilkoblet</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Bygg-ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Kodenavn</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation type="unfinished">Vertsnavn</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN-MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Total diskplass</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Oppetid</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dager %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Tråder</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation type="unfinished">1,5,15 minutters last</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Totalt minne</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Ledig minne</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Tilgjengelig diskplass</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Skjermstørrelse</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Kjerneversjon</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt-versjon</translation>
     </message>

--- a/i18n/asteroid-settings.nl_BE.ts
+++ b/i18n/asteroid-settings.nl_BE.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth aan</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth uit</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Verbonden</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Niet verbonden</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volume</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Alleen laden</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB-modus</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH-modus</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP-modus</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12-uursnotatie:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Tijd</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Scherm</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Helderheid</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Automatische helderheid</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Actief scherm</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Burn-in preventie</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Kantelen om te ontwaken</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Drukken om te ontwaken</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Tijd zone</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Geluid</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Nachtmodus</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Eenheden</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Achtergrond</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Horlogestijl</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Starter</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Vermogen</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Uitschakelen</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Herstarten</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootloader</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Over</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Inschakelen</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Helderheid</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Vertragen</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Aangepaste wijzerplaat</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Selecteer wijzerplaat</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Helderheid</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Herstarten</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Verbonden</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Niet verbonden</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Build-id</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Codenaam</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Hostnaam</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation type="unfinished">IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Totale schijfruimte</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Tijd ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dagen %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Draden</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1, 5, 15 minuten belasting</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Totaal geheugen</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Vrij geheugen</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Beschikbare schijfruimte</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Schermgrootte</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Kernelversie</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt-versie</translation>
     </message>

--- a/i18n/asteroid-settings.nl_NL.ts
+++ b/i18n/asteroid-settings.nl_NL.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth aan</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth uit</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Verbonden</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Niet verbonden</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volume</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Alleen laden</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB-modus</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH-modus</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP-modus</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12-uursnotatie:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Tijd</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Scherm</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Helderheid</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Automatische helderheid</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Actief scherm</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Burn-in preventie</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Kantelen om te ontwaken</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Drukken om te ontwaken</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Tijdzone</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Geluid</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Nachtkast</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Eenheden</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Achtergrond</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Horlogestijl</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Startprogramma</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Afsluiten</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Uitschakelen</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Herstarten</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootloader</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Over</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Inschakelen</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Helderheid</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Wachttijd</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Aangepaste wijzerplaat</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Kies wijzerplaat</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Helderheid</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Herstarten</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Verbonden</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Niet verbonden</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Build ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Codenaam</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Host naam</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Totale opslagruimte</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Bedrijfstijd</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dagen %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Threads</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 Minuten belasting</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Totaal geheugen</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Vrij geheugen</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Beschikbare opslagplaats</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Schermgrootte</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Kernel versie</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt versie</translation>
     </message>

--- a/i18n/asteroid-settings.oc.ts
+++ b/i18n/asteroid-settings.oc.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth activat</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth atudat</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Connectat</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Non connectat</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volum</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Carga solament</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Mòde ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Mòde SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Mòde MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Utilizar format 12h :</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Utilizar Fahrenheit :</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Ora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Lenga</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Ecran</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Luminositat</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Luminositat automatica</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Totjorn alucat</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Proteccion contra las cremaduras</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar per desrevelhar</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tocar per desrevelhar</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Fus orari</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Son</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Tauleta de nuèch</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unitats</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Fons d&apos;ecran</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Quadran</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Lançador</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>Opcionq rapidas</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Alucar</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Atudar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Reaviar</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Cargador d’amorsatge</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>A prepaus</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Activar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Luminositat</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Relambi</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Quadran personalizat</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Seleccionatz un quadran</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>Boton de verrolhatge</translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Paramètres</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Luminositat</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>Vibracion</translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>Interruptor Wifi</translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Amudir</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Mòde cinèma</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>Atudar</translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>Reaviar</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Musica</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>Lampa</translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation>Linha fixa</translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation>Linha lisanta</translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>Opcions</translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation>Indicador de batariá alinhat en bas ?</translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation>Afichar l&apos;animacion de carga de la batariá?</translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation>Tocar per percórrer lo dessenh de las particulas</translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation>Apercebut batariá</translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation>Activar la batariá colorada&#xa0;?</translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished">Paramètres</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Connectat</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Non connectat</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID de compilacion</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nom de còde</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nom d’òste</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>MAC WIFI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Numèro de seria</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Espaci disc total</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1&#xa0;Go</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1&#xa0;Go (%L2&#xa0;%)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W × %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Temps d’activitat</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 jorns %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Fils</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Cargas de 1, 5, 15 minutas</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Memòria totala</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1&#xa0;Mo</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memòria disponibla</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 Mo (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Espaci disponible</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Talha d’ecran</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Version del nuclèu</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Version de Qt</translation>
     </message>

--- a/i18n/asteroid-settings.pl.ts
+++ b/i18n/asteroid-settings.pl.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth włączony</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth wyłączony</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Połączono</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Nie połączony</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Głośność</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Tylko ładowanie</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Tryb ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Tryb SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Tryb MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Użyj formatu 12H:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Użyj Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Czas</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Język</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Wyświetlacz</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Jasność</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Automatyczna jasność</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Ekran zawsze włączony</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Ochrona przed wypaleniem</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Przechyl, aby wybudzić</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Dotknij, aby wybudzić</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Strefa czasowa</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Dźwięk</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Szafka nocna</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Jednostki</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Tapeta</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Tarcza</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Ekran główny</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Zasilanie</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Wyłącz</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Uruchom ponownie</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Program rozruchowy</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>O urządzeniu</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Włącz</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Jasność</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Opóźnienie</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Niestandardowa tarcza zegarka</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Wybierz tarczę</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Jasność</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Uruchom ponownie</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Połączono</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Nie połączony</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Numer kompilacji</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nazwa kodowa</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nazwa urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Numer seryjny</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Całkowita przestrzeń dyskowa</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Czas od uruchomienia</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dni %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Wątki</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1-, 5- i 15-minutowe obciążenia</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Całkowita pamięć</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Ilość wolnej pamięci</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Dostępna przestrzeń dyskowa</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Rozmiar wyświetlacza</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Wersja jądra</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Wersja Qt</translation>
     </message>

--- a/i18n/asteroid-settings.pt.ts
+++ b/i18n/asteroid-settings.pt.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth ligado</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth desligado</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Ligado</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Não ligado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volume</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Carregar apenas</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Modo de ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Modo de SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Modo de MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Usar formato de 12 horas:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Ecrã</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Brilho</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Brilho automático</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Ecrã sempre ligado</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Proteção de queimadura</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar para acordar</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tocar para acordar</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Fuso horário</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Som</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Modo criado-mudo</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Imagem de fundo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Mostrador</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Lançador</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Energia</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Carregador de inicialização</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Ativar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brilho</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Atraso</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Face do relógio personalizado</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Selecione a face do relógio</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>Botão de bloqueio</translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Configurações</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Brilho</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>Vibração</translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>Alternar Wi-Fi</translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Silenciar</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Modo de cinema</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>Opções</translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished">Configurações</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Ligado</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Não ligado</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID da compilação</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nome do código</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nome do host</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>MAC do WLAN</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Número de série</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Espaço total do disco</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1L x %L2A</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Tempo de funcionamento</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dias %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Tarefas</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Cargas de 1,5,15 minutos</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Memória total</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memória livre</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Espaço de disco disponível</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Tamanho do ecrã</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Versão do kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Versão do Qt</translation>
     </message>

--- a/i18n/asteroid-settings.pt_BR.ts
+++ b/i18n/asteroid-settings.pt_BR.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth ligado</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth desligado</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Não conectado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volume</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Apenas carregar</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Modo ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Modo SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Modo MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Usar formato 12h:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Tela</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Brilho</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Brilho automático</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Tela sempre ligada</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Proteção contra queima</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar para acordar</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tocar para acordar</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Fuso horário</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Som</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Modo criado-mudo</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Papel de parede</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Mostrador</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Lançador</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Energia</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Carregador de inicialização</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Habilitar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brilho</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Atraso</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Mostrador personalizado</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Selecionar face do relógio</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Brilho</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Reiniciar</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Conectado</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Não conectado</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID da Build</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Codinome</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nome do hospedeiro</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Número de série</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Espaço total de disco</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1L x %L2A</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Tempo de atividade</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dias %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Tarefas</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Cargas de 1, 5, 15 minutos</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Memória total</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memória livre</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Espaço de disco disponível</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Tamanho da tela</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Versão do Kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Versão do QT</translation>
     </message>

--- a/i18n/asteroid-settings.pt_PT.ts
+++ b/i18n/asteroid-settings.pt_PT.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth ligado</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth desligado</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Ligado</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Não ligado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volume</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Carregar apenas</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Modo de ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Modo de SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Modo de MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Usar formato de 12 horas:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Usar Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Ecrã</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Brilho</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Brilho automático</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Ecrã sempre ligado</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Proteção de queimadura</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Inclinar para acordar</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tocar para acordar</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Fuso horário</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Som</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Modo criado-mudo</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Imagem de fundo</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Mostrador</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Lançador</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Energia</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Carregador de inicialização</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Sobre</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Ativar</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Brilho</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Atraso</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Face do relógio personalizado</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Selecione a face do relógio</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>Botão de bloqueio</translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Configurações</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Brilho</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>Vibração</translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>Alternar Wi-Fi</translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Silenciar</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Modo de cinema</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>Opções</translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished">Configurações</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Ligado</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Não ligado</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID da compilação</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nome do código</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nome do host</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>MAC do WLAN</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Número de série</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Espaço total do disco</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1L x %L2A</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Tempo de funcionamento</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dias %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Tarefas</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Cargas de 1,5,15 minutos</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Memória total</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memória livre</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Espaço de disco disponível</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Tamanho do ecrã</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Versão do kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Versão do Qt</translation>
     </message>

--- a/i18n/asteroid-settings.ro.ts
+++ b/i18n/asteroid-settings.ro.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth pornit</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth oprit</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Conectat</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Neconectat</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Volum %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Doar încărcare</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Mod ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Mod SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Mod MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Utilizați formatul 12H:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Utilizați Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Timp</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Dată</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Limbă</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Ecran</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Luminozitate</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Luminozitate automată</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Întotdeauna pe ecran</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Protecție persistența imaginii</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Înclinați să se trezească</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Atingeți pentru a trezi</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Fus Orar</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Sunet</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Noptieră</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Unităţi</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Imagine fundal</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Faţă ceas</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Lansator</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Putere</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Oprire</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Repornire</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootloader</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Despre</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Pornește</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Luminozitate</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Întârziere</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Fata costumizata ceas</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Selectează față de ceas</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Luminozitate</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Repornire</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,114 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Conectat</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Neconectat</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID Build</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Nume de cod</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Nume gazdă</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>MAC WLAN</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Număr de serie</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Spațiu total</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Memorie totala</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memorie libera</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Spațiu disponibil</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Mărime ecran</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Versiune kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Versiune Qt</translation>
     </message>

--- a/i18n/asteroid-settings.ru.ts
+++ b/i18n/asteroid-settings.ru.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth включён</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth выключен</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Соединён</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Не соединён</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Громкость</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Только зарядка</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Режим ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Режим SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Режим MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Использовать 12-часовой формат:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Использовать градусы Фаренгейта:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Время</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Язык</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Дисплей</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Яркость</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Автоматическая яркость</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>AoD режим</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Защита от выгорания</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Пробуждение по наклону</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Пробуждение по касанию</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Часовой пояс</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Звук</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Прикроватный режим</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Единицы</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Обои</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Циферблат</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Лаунчер</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>Быстрая панель</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Питание</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Выключить</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Перезагрузить</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Загрузчик</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>О продукте</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Включить</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Яркость</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Задержка</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Пользовательский циферблат</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Выбрать циферблат</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>Заблокировать</translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Настройки</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Яркость</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>Вибрация</translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>Wi-Fi</translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Откл. звук</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Режим &quot;Кино&quot;</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>Выключить</translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>Перезагрузить</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Музыка</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>Фонарик</translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation>Фиксированный ряд</translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation>Скользящий ряд</translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>Опции</translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation>Индик. батареи внизу</translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation>Анимация зарядки</translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation>Нажми для смены дизайна</translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation>Статус батареи</translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation>Вкл. цвет. батар.</translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished">Настройки</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Соединён</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Не соединён</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID сборки</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Кодовое имя</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Имя хоста</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Серийный номер</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Общее дисковое пространство</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Время работы</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 дней %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Потоки</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 -минутная загрузка</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Всего RAM</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Свободно RAM</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Доступное дисковое пространство</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Размер дисплея</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Версия ядра</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Версия Qt</translation>
     </message>

--- a/i18n/asteroid-settings.sk.ts
+++ b/i18n/asteroid-settings.sk.ts
@@ -4,380 +4,560 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth zapnutý</translation>
     </message>
     <message id="id-bluetooth-off">
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth vypnutý</translation>
     </message>
     <message id="id-connected">
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Pripojené</translation>
     </message>
     <message id="id-disconnected">
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Nepripojené</translation>
     </message>
     <message id="id-sound-percentage">
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Objem</translation>
     </message>
     <message id="id-adb-mode">
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Mód ADB</translation>
     </message>
-    <message id="id-mtp-mode">
-        <source>MTP Mode</source>
-        <translation>Mód MTP</translation>
-    </message>
     <message id="id-12h-format">
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Používať 12 hodinový formát:</translation>
     </message>
     <message id="id-fahrenheit">
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Používať stupne Fahrenheita:</translation>
     </message>
     <message id="id-time-page">
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Čas</translation>
     </message>
     <message id="id-date-page">
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message id="id-language-page">
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Jazyk</translation>
     </message>
     <message id="id-bluetooth-page">
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-sound-page">
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Zvuk</translation>
     </message>
     <message id="id-units-page">
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Jednotky</translation>
     </message>
     <message id="id-wallpaper-page">
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Pozadie</translation>
     </message>
     <message id="id-watchface-page">
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Ciferník</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Vypnúť</translation>
     </message>
     <message id="id-reboot-page">
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Reštartovať</translation>
     </message>
     <message id="id-about-page">
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Informácie o Smartwatch</translation>
     </message>
     <message id="id-charging-only">
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Iba nabíjanie</translation>
     </message>
     <message id="id-display-page">
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Displej</translation>
     </message>
     <message id="id-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Jas</translation>
     </message>
     <message id="id-always-on-display">
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Vždy zapnutý displej</translation>
     </message>
     <message id="id-tilt-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Prebudenie naklonením</translation>
     </message>
     <message id="id-tap-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Prebudenie klepnutím</translation>
     </message>
     <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Ochrana pred vypaľovaním</translation>
     </message>
     <message id="id-launcher-page">
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Spúšťač</translation>
     </message>
     <message id="id-automatic-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Automatický jas</translation>
     </message>
     <message id="id-nightstand-page">
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Stojan</translation>
     </message>
     <message id="id-nightstand-enable">
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Povoliť</translation>
     </message>
     <message id="id-nightstand-brightness">
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Jas</translation>
     </message>
     <message id="id-nightstand-delay">
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Oneskorenie</translation>
     </message>
     <message id="id-nightstand-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Zvoliť ciferník</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Vlastný ciferník</translation>
     </message>
     <message id="id-ssh-mode">
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Mód SSH</translation>
     </message>
     <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Časové pásmo</translation>
     </message>
     <message id="id-power-page">
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Výkon</translation>
     </message>
     <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootovanie</translation>
     </message>
     <message id="id-quickpanel-page">
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Jas</translation>
     </message>
     <message id="id-toggle-bluetooth">
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Reštartovať</translation>
     </message>
     <message id="id-particle-design">
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-music">
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation></translation>
     </message>
     <message id="id-off">
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-app-launcher-name">
+        <location filename="asteroid-settings.desktop.h" line="6"/>
         <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Pripojené</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Nepripojené</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID zostavenia</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Kódové označenie</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Názov zariadenia</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Sériové číslo</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Celková kapacita úložiska</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Dostupné miesto na úložisku</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Veľkosť displeja</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Verzia jadra</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Verzia Qt</translation>
     </message>
     <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Čas behu</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dní %L2</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Vlákna</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 Minútové zaťaženia</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Celková pamäť</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Voľná pamäť</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>

--- a/i18n/asteroid-settings.sq.ts
+++ b/i18n/asteroid-settings.sq.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bletooth aktiv</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth joaktiv</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Lidhur</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Zgjidhur</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volumi</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Vetem mbush</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB Moda</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH Moda</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP Moda</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Përdor formatin 12-orësh:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Përdor Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Koha</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Gjuha</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Shfaq</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Drita</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Drita automatike</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Ekrani gjithmonë i aktivizuar</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Mbrojte nga ndezja</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Shtyp-për-Zgjim</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Zona e Kohës</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Zëri</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Njësit</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Prapavija</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Watchface</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Startuesi</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Rryma</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Ndalë</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Ristarto</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootloader</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Rreth nesh</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Aktivizo</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Drita</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Vonimi</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Watchface i përvetsuar</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Zgjedh një watchface</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Drita</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Ristarto</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Lidhur</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Zgjidhur</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID e Krijimit</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Emri kodues</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Emri i Mbajtësit</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Numri serial</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Hapsira totale e diskut</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Zgjuar që nga koha</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 ditësh %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 Minuta ngarkimi</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Memoria totale</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Memoria e lirë</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Hapsira e diskut ne disposicion</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Madhësia e Pamjes</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Kernel Versioni</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt version</translation>
     </message>

--- a/i18n/asteroid-settings.sv.ts
+++ b/i18n/asteroid-settings.sv.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Blåtand på</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Blåtand av</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Ansluten</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Inte ansluten</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volym</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Laddar enbart</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB-läge</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH-läge</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP-läge</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Använd 12h-format:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Använd Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Tid</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Skärm</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Ljus styrka</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Automatisk ljusstyrka</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Allid på-skärm</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Inbränningsskydd</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Skaka för att aktivera</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Tryck-för-att-väcka</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Tidszon</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Ljud</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Nattduksbord</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Enheter</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Bakgrundsbild</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Urtavla</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Appstartare</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Ström</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Stäng av</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Starta om</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootloader</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Om</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Aktivera</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Ljusstyrka</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Fördröjning</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Anpassad urtavla</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Välj urtavla</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>Lås knapp</translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Inställningar</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Ljusstyrka</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Stäng av ljudet</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Bio läge</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>Stäng av</translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>Starta om</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Musik</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>Ficklampa</translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished">Inställningar</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Ansluten</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Inte ansluten</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ByggID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Kodnamn</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Värdnamn</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Totalt diskutrymme</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1B x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Upptid</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 dagar %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Trådar</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 minuter last</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Totalt minne</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Fritt minne</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Tillgängligt diskutrymme</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Skärmstorlek</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Kärnversion</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt-version</translation>
     </message>

--- a/i18n/asteroid-settings.ta.ts
+++ b/i18n/asteroid-settings.ta.ts
@@ -4,380 +4,560 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>ப்ளூடூத் இயக்கத்தில்</translation>
     </message>
     <message id="id-bluetooth-off">
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>ப்ளூடூத் முடக்கத்தில்</translation>
     </message>
     <message id="id-connected">
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>இணைக்கப்பட்டது</translation>
     </message>
     <message id="id-disconnected">
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>இணைக்கப்படவில்லை</translation>
     </message>
     <message id="id-sound-percentage">
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>தொகுதி</translation>
     </message>
     <message id="id-adb-mode">
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB முறை</translation>
     </message>
-    <message id="id-mtp-mode">
-        <source>MTP Mode</source>
-        <translation>MTP முறை</translation>
-    </message>
     <message id="id-12h-format">
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12H முறை:</translation>
     </message>
     <message id="id-fahrenheit">
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>பாரன்ஹீட் முறை:</translation>
     </message>
     <message id="id-time-page">
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>நேரம்</translation>
     </message>
     <message id="id-date-page">
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>தேதி</translation>
     </message>
     <message id="id-language-page">
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>மொழி</translation>
     </message>
     <message id="id-bluetooth-page">
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>ப்ளூடுத்</translation>
     </message>
     <message id="id-sound-page">
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>ஒலி</translation>
     </message>
     <message id="id-units-page">
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>அலகுகள்</translation>
     </message>
     <message id="id-wallpaper-page">
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>சுவர்சித்திரம்</translation>
     </message>
     <message id="id-watchface-page">
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>கடிகார முகப்பு</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>யூ.எச்.பி</translation>
     </message>
     <message id="id-poweroff-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>மின்சக்தி நிறுத்து</translation>
     </message>
     <message id="id-reboot-page">
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>மீள்துவக்கு</translation>
     </message>
     <message id="id-about-page">
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>பற்றி</translation>
     </message>
     <message id="id-charging-only">
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>மின்னினைப்பில் மட்டும்</translation>
     </message>
     <message id="id-display-page">
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>காட்சி</translation>
     </message>
     <message id="id-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>பிரகாசம்</translation>
     </message>
     <message id="id-always-on-display">
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>எப்போதும் காட்சிக்கு</translation>
     </message>
     <message id="id-tilt-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>சாய்த்து-எழுந்திரு</translation>
     </message>
     <message id="id-tap-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>எழுந்திரு என்பதைத் தட்டவும்</translation>
     </message>
     <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">பாதுகாப்பில் எரிக்கவும்</translation>
     </message>
     <message id="id-launcher-page">
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>துவக்கி</translation>
     </message>
     <message id="id-automatic-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>தானியங்கி ஒளி</translation>
     </message>
     <message id="id-nightstand-page">
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>நைட்ச்டாண்ட்</translation>
     </message>
     <message id="id-nightstand-enable">
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>இயக்கு</translation>
     </message>
     <message id="id-nightstand-brightness">
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>ஒளி</translation>
     </message>
     <message id="id-nightstand-delay">
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>சுணக்கம்</translation>
     </message>
     <message id="id-nightstand-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>வாட்ச்ஃபேசைத் தேர்ந்தெடுக்கவும்</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>தனிப்பயன் கண்காணிப்பு</translation>
     </message>
     <message id="id-ssh-mode">
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH முறை</translation>
     </message>
     <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>நேர மண்டலம்</translation>
     </message>
     <message id="id-power-page">
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>விசை</translation>
     </message>
     <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>துவக்க ஏற்றி</translation>
     </message>
     <message id="id-quickpanel-page">
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-bluetooth">
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">ப்ளூடுத்</translation>
     </message>
     <message id="id-toggle-haptics">
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">மீள்துவக்கு</translation>
     </message>
     <message id="id-particle-design">
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-music">
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation></translation>
     </message>
     <message id="id-off">
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-app-launcher-name">
+        <location filename="asteroid-settings.desktop.h" line="6"/>
         <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">இணைக்கப்பட்டது</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">இணைக்கப்படவில்லை</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ஐடியை உருவாக்குங்கள்</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>குறியீட்டு பெயர்</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>புரவலன் பெயர்</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>வரிசை எண்</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">மொத்த வட்டு இடம்</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%எல் 1</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">கிடைக்கும் வட்டு இடம்</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>காட்சி அளவு</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>கர்னல் பதிப்பு</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>கியுடி பதிப்பு</translation>
     </message>
     <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%எல் 1 சிபி</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%எல் 1 சிபி ( %எல் 2 %)</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W ஃச் %L2H</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>விழித்திருந்நேரம்</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%எல் 1 நாட்கள் %எல் 2</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>நூல்கள்</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 நிமிட சுமைகள்</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>1, %இல்லை, %</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>மொத்த நினைவகம்</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%எல் 1 எம்பி</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>இலவச நினைவகம்</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 mb ( %இல்லை %)</translation>
     </message>

--- a/i18n/asteroid-settings.te.ts
+++ b/i18n/asteroid-settings.te.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation type="unfinished">బ్లూటూత్ ఆన్</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation type="unfinished">బ్లూటూత్ ఆఫ్</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>కనెక్టెడ్</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>కనెక్టెడ్ లేదు</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">శబ్దం %1%</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>ఛార్జింగ్ మాత్రమే</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ఎడిబి మోడ్</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>ఎంటిపి మోడ్</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12H ఫార్మాట్ ను వాడు:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>ఫరెన్హెఇట్ ను వాడు:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>సమయం</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>తేది</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>భాష</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>బ్లూటూత్</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>ప్రదర్శన</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>ప్రకాశం</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>ఎల్లప్పుడూ ప్రదర్శనలో ఉంటుంది</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>వంపు నుండి మేల్కొలపండి</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>మేల్కొలపడానికి నొక్కండి</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>శబ్దం</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>నైట్‌స్టాండ్</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>యూనిట్స్</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>వాల్పేపర్</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>గడియారముఖం</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>యుఎస్బి</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>శక్తి</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>మూసివేయి</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>రీబూట్</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>బూట్‌లోడర్</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>గురించి</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>ప్రారంభించు</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation type="unfinished">ప్రకాశం</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>ఆలస్యం</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>అనుకూల వాచ్‌ఫేస్</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>వాచ్‌ఫేస్‌ని ఎంచుకోండి</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">ప్రకాశం</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">బ్లూటూత్</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">రీబూట్</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,118 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">కనెక్టెడ్</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">కనెక్టెడ్ లేదు</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>బిల్డ్ ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>కోడ్ పేరు</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>హోస్ట్ పేరు</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN మాక్</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>ఐఎంఈఐ</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>క్రమ సంఖ్య</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">మొత్తం డిస్క్ స్థలం</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 జిబి</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2%)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>సమయము</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 రోజులు %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>దారాలు</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 నిమిషాల లోడ్లు</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%l1, %no, %l</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>మొత్తం మెమరీ</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/asteroid-settings.th.ts
+++ b/i18n/asteroid-settings.th.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>เปิดบลูทูธ</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>ปิดบลูทูธ</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>เชื่อมต่อ</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>ไม่เชื่อมต่อ</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>ปริมาณ</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>ชาร์จเท่านั้น</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>โหมด ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>โหมด SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>โหมด MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>ใช้รูปแบบ 12H:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>ใช้ฟาเรนไฮต์:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>เวลา</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>วันเดือนปี</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>ภาษา</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>บลูทูธ</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>แสดงผล</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>ความสว่าง</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>ความสว่างอัตโนมัติ</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>แสดงบนหน้าจอ</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">ป้องกันการเบิร์น</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>เอียงเพื่อปลุก</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>แตะเพื่อปลุก</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>เขตเวลา</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>เสียง</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>ข้างเตียง</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>หน่วย</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>วอลเปเปอร์</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>หน้าปัด</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>ตัวเรียกใช้</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>พลังงาน</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>ปิด</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>รีบูต</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>บูตโหลดเดอร์</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>เกี่ยวกับ</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>ใช้งาน</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>ความสว่าง</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>เลื่อนเวลา</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>ปรับแต่งหน้าปัด</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>เลือกหน้าปัดนาฬิกา</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">ความสว่าง</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">บลูทูธ</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">รีบูต</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">เชื่อมต่อ</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">ไม่เชื่อมต่อ</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ไอดีของการสร้าง</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>ชื่อรหัส</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>ซื่อโฮส</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>หมายเลขซีเรียล</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">พื้นที่ดิสก์รวม</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>เวลาทำงาน</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 วัน %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Threads</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>โหลด 1,5,15 นาที</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>หน่วยความจำรวม</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>พื้นที่ว่างของหน่วยความจำ</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">เนื้อที่ดิสก์ที่มีอยู่</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>ขนาดหน้าจอ</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>รุ่นเคอร์เนล</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>รุ่น Qt</translation>
     </message>

--- a/i18n/asteroid-settings.tr.ts
+++ b/i18n/asteroid-settings.tr.ts
@@ -4,380 +4,560 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth açık</translation>
     </message>
     <message id="id-bluetooth-off">
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth kapalı</translation>
     </message>
     <message id="id-connected">
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Bağlı</translation>
     </message>
     <message id="id-disconnected">
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Bağlı değil</translation>
     </message>
     <message id="id-sound-percentage">
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Ses</translation>
     </message>
     <message id="id-adb-mode">
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB Kipi</translation>
     </message>
-    <message id="id-mtp-mode">
-        <source>MTP Mode</source>
-        <translation>MTP Kipi</translation>
-    </message>
     <message id="id-12h-format">
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>12&apos;lik saat kullan:</translation>
     </message>
     <message id="id-fahrenheit">
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Fahrenhayt kullan:</translation>
     </message>
     <message id="id-time-page">
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Zaman</translation>
     </message>
     <message id="id-date-page">
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Tarih</translation>
     </message>
     <message id="id-language-page">
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Dil</translation>
     </message>
     <message id="id-bluetooth-page">
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-sound-page">
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Ses</translation>
     </message>
     <message id="id-units-page">
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Birimler</translation>
     </message>
     <message id="id-wallpaper-page">
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Duvar Kağıdı</translation>
     </message>
     <message id="id-watchface-page">
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Saat Kadranı</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Gücü Kapat</translation>
     </message>
     <message id="id-reboot-page">
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Yeniden Başlat</translation>
     </message>
     <message id="id-about-page">
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Hakkında</translation>
     </message>
     <message id="id-charging-only">
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Yalnızca şarj edim</translation>
     </message>
     <message id="id-display-page">
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Ekran</translation>
     </message>
     <message id="id-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Parlaklık</translation>
     </message>
     <message id="id-always-on-display">
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Sürekli açık ekran</translation>
     </message>
     <message id="id-tilt-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Eğerek uyandır</translation>
     </message>
     <message id="id-tap-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Dokunarak uyandır</translation>
     </message>
     <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Ekran yanığı koruması</translation>
     </message>
     <message id="id-launcher-page">
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Başlatıcı</translation>
     </message>
     <message id="id-automatic-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Otomatik parlaklık</translation>
     </message>
     <message id="id-nightstand-page">
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Komodin</translation>
     </message>
     <message id="id-nightstand-enable">
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Etkinleştir</translation>
     </message>
     <message id="id-nightstand-brightness">
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Parlaklık</translation>
     </message>
     <message id="id-nightstand-delay">
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Gecikme</translation>
     </message>
     <message id="id-nightstand-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Saat kadranı seç</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Özel saat kadranı</translation>
     </message>
     <message id="id-ssh-mode">
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH Kipi</translation>
     </message>
     <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Zaman Dilimi</translation>
     </message>
     <message id="id-power-page">
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Güç</translation>
     </message>
     <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Önyükleyici</translation>
     </message>
     <message id="id-quickpanel-page">
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>Hızlı Panel</translation>
     </message>
     <message id="id-toggle-lock">
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>Kilit Düğmesi</translation>
     </message>
     <message id="id-toggle-settings">
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Ayarlar</translation>
     </message>
     <message id="id-toggle-brightness">
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Parlaklık</translation>
     </message>
     <message id="id-toggle-bluetooth">
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>Titreşim</translation>
     </message>
     <message id="id-toggle-wifi">
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>Wifi Düğmesi</translation>
     </message>
     <message id="id-toggle-sound">
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Sesi Kıs</translation>
     </message>
     <message id="id-toggle-cinema">
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Sinema Kipi</translation>
     </message>
     <message id="id-fixed-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation>Sabit Satır</translation>
     </message>
     <message id="id-sliding-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation>Kayan Satır</translation>
     </message>
     <message id="id-battery-bottom">
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation>Pil Ölçer aşağıya mı koyulsun?</translation>
     </message>
     <message id="id-options">
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>Seçenekler</translation>
     </message>
     <message id="id-battery-animation">
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation>Pil değişimi canlandırılsın mı?</translation>
     </message>
     <message id="id-battery-colored">
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation>Renkli pil etkinleştirilsin mi?</translation>
     </message>
     <message id="id-toggle-power-off">
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>Gücü Kapat</translation>
     </message>
     <message id="id-toggle-reboot">
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>Yeniden Başlat</translation>
     </message>
     <message id="id-particle-design">
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation>Parça tasarımını değiştirmek için dokun</translation>
     </message>
     <message id="id-battery-preview">
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation>Pil ön izlemesi</translation>
     </message>
     <message id="id-toggle-music">
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Müzik</translation>
     </message>
     <message id="id-toggle-flashlight">
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>El feneri</translation>
     </message>
     <message id="id-tap-to-cancel">
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation></translation>
     </message>
     <message id="id-off">
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-app-launcher-name">
+        <location filename="asteroid-settings.desktop.h" line="6"/>
         <source>Settings</source>
         <translation type="unfinished">Ayarlar</translation>
+    </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Bağlı</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Bağlı değil</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>İnşa kimliği</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Kod adı</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Ana makine adı</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Seri numarası</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Toplam disk alanı</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Kullanılabilir disk alanı</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Ekran boyutu</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Çekirdek sürümü</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt sürümü</translation>
     </message>
     <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (% %L2)</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Çalışma zamanı</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 gün %L2</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>İş parçacığı</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 Dakika yükü</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Tüm bellek</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Boş bellek</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (% %L2)</translation>
     </message>

--- a/i18n/asteroid-settings.uk.ts
+++ b/i18n/asteroid-settings.uk.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth увімк</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth вимк</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Підключено</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Не підключено</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Гучність</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Тільки зарядка</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB режим</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH режим</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Режим MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Використовувати 12h формат:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Використовувати градус Фаренгейта:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Час</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Дисплей</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Яскравість</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Автоматична яскравість</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>AOD</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Захист від вигорання</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Пробудження нахилом</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Пробудження дотиком</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Часовий пояс</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Звук</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Нічний вид</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Одиниці</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Шпалери</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Циферблат</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Лаунчер</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>Швидка панель</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Живлення</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Вимкнути</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Перезавантажити</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Завантажувач</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Про</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Увімкнути</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Яскравість</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Затримка</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Користувацький циферблат</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Виберіть циферблат</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation>Кнопка блокування</translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation>Налаштування</translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation>Яскравість</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation>Вібрація</translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation>Перемикач Wi-Fi</translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation>Вимкнути звук</translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation>Режим «Кіно»</translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation>Вимкнути</translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>Перезавантажити</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation>Музика</translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation>Ліхтарик</translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation>Закріплений рядок</translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation>Рухомий рядок</translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation>Індикатор заряду вирівняно по низу?</translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation>Показувати анімацію наснаження батареї?</translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation>Торкніться для зміни дизайну частинок</translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation>Передперегляд батареї</translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation>Увімкнути кольорову батарею?</translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished">Налаштування</translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Підключено</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Не підключено</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>ID збірки</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Кодова назва</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Ім&apos;я хоста</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Серійний номер</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Всього місця на диску</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 ГБ</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 ГБ (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1Ш x %L2В</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Час роботи</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 днів %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Потоки</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1,5,15 Хвилинне навантаження</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Загальна пам’ять</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 МБ</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Вільна пам&apos;ять</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 МБ (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Доступне місце на диску</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Розмір дисплея</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Версія ядра</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Версія Qt</translation>
     </message>

--- a/i18n/asteroid-settings.vi.ts
+++ b/i18n/asteroid-settings.vi.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>Bluetooth đang bật</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>Bluetooth đang tắt</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>Đã kết nối</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>Chưa kết nối</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Âm lượng</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>Chỉ đang sạc</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>Chế độ ADB</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>Chế độ SSH</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>Chế độ MTP</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>Sử dụng định dạng 12H:</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>Sử dụng Fahrenheit:</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>Thời gian</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>Ngày</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>Ngôn ngữ</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>Hiển thị</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>Độ sáng</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>Độ sáng tự động</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>Màn hình luôn bật</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">Bảo vệ máy tính khỏi việc để lâu ngày</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>Nghiêng để đánh thức</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>Nhấn để đánh thức</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>Múi giờ</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>Âm thanh</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>Đầu giường</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>Đơn vị</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>Hình nền</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>Mặt đồng hồ</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>Trình khởi động</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>Năng lượng</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>Tắt nguồn</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>Khởi động lại</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>Bootloader</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>Giới thiệu</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>Bật</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>Độ sáng</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>Trì hoãn</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>Mặt đồng hồ tuỳ chỉnh</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>Chọn mặt đồng hồ</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">Độ sáng</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">Khởi động lại</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">Đã kết nối</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">Chưa kết nối</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>Xây dựng ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>Mật danh</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>Tên máy chủ</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>MAC của WLAN</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>Số IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>Mã số sê-ri</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">Tổng dung lượng ổ đĩa</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1W x %L2H</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>Thời gian hoạt động</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 ngày %L2</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>Luồng</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>Tải 1,5,15 phút</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>Tổng bộ nhớ</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>Bộ nhớ còn trống</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">Không gian đĩa có sẵn</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>Kích thước hiển thị</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>Phiên bản nhân Kernel</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Phiên bản Qt</translation>
     </message>

--- a/i18n/asteroid-settings.zh_Hans.ts
+++ b/i18n/asteroid-settings.zh_Hans.ts
@@ -4,380 +4,560 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>启用蓝牙</translation>
     </message>
     <message id="id-bluetooth-off">
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>关闭蓝牙</translation>
     </message>
     <message id="id-connected">
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>已连接</translation>
     </message>
     <message id="id-disconnected">
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>未连接</translation>
     </message>
     <message id="id-sound-percentage">
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>音量</translation>
     </message>
     <message id="id-adb-mode">
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB 模式</translation>
     </message>
-    <message id="id-mtp-mode">
-        <source>MTP Mode</source>
-        <translation>MTP 模式</translation>
-    </message>
     <message id="id-12h-format">
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>使用 12 小时制：</translation>
     </message>
     <message id="id-fahrenheit">
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>使用华氏度：</translation>
     </message>
     <message id="id-time-page">
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>时间</translation>
     </message>
     <message id="id-date-page">
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message id="id-language-page">
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message id="id-bluetooth-page">
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>蓝牙</translation>
     </message>
     <message id="id-sound-page">
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>声音</translation>
     </message>
     <message id="id-units-page">
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>单位</translation>
     </message>
     <message id="id-wallpaper-page">
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>壁纸</translation>
     </message>
     <message id="id-watchface-page">
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>表盘</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation>USB</translation>
     </message>
     <message id="id-poweroff-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>关机</translation>
     </message>
     <message id="id-reboot-page">
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>重启</translation>
     </message>
     <message id="id-about-page">
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message id="id-charging-only">
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>仅充电</translation>
     </message>
     <message id="id-display-page">
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>显示</translation>
     </message>
     <message id="id-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>亮度</translation>
     </message>
     <message id="id-always-on-display">
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>屏幕常亮</translation>
     </message>
     <message id="id-tilt-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>倾斜唤醒</translation>
     </message>
     <message id="id-tap-to-wake">
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>触摸唤醒</translation>
     </message>
     <message id="id-burn-in-protection">
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">烧屏保护</translation>
     </message>
     <message id="id-launcher-page">
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>启动器</translation>
     </message>
     <message id="id-automatic-brightness">
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>自动亮度</translation>
     </message>
     <message id="id-nightstand-page">
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>床头灯</translation>
     </message>
     <message id="id-nightstand-enable">
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>启用</translation>
     </message>
     <message id="id-nightstand-brightness">
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>亮度</translation>
     </message>
     <message id="id-nightstand-delay">
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>延迟</translation>
     </message>
     <message id="id-nightstand-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>选择表盘</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>自定义表盘</translation>
     </message>
     <message id="id-ssh-mode">
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH 模式</translation>
     </message>
     <message id="id-timezone-page">
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>时区</translation>
     </message>
     <message id="id-power-page">
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>电源</translation>
     </message>
     <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>线刷模式</translation>
     </message>
     <message id="id-quickpanel-page">
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-lock">
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">亮度</translation>
     </message>
     <message id="id-toggle-bluetooth">
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation>蓝牙</translation>
     </message>
     <message id="id-toggle-haptics">
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation>重启</translation>
     </message>
     <message id="id-particle-design">
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-music">
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-tap-to-cancel">
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation></translation>
     </message>
     <message id="id-off">
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-app-launcher-name">
+        <location filename="asteroid-settings.desktop.h" line="6"/>
         <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">已连接</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">未连接</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>内部版本号</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>代号</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>主机名</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>序列号</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">总磁盘空间</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">可用磁盘空间</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>显示屏尺寸</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>内核版本</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt 版本</translation>
     </message>
     <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB (%L2 %)</translation>
-    </message>
-    <message>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation>%L1 x %L2</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>开机时长</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation>%L1 天 %L2</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>线程数</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1、5、15 分钟内的负载</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>总内存</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>空闲内存</translation>
     </message>
     <message>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB (%L2 %)</translation>
     </message>

--- a/i18n/asteroid-settings.zh_Hant.ts
+++ b/i18n/asteroid-settings.zh_Hant.ts
@@ -4,365 +4,365 @@
 <context>
     <name></name>
     <message id="id-bluetooth-on">
-        <location filename="../src/qml/BluetoothPage.qml" line="28"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
         <source>Bluetooth on</source>
         <translation>藍牙已開啟</translation>
     </message>
     <message id="id-bluetooth-off">
-        <location filename="../src/qml/BluetoothPage.qml" line="30"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
         <source>Bluetooth off</source>
         <translation>藍牙已關閉</translation>
     </message>
     <message id="id-connected">
-        <location filename="../src/qml/BluetoothPage.qml" line="32"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
         <source>Connected</source>
         <translation>已連接</translation>
     </message>
     <message id="id-disconnected">
-        <location filename="../src/qml/BluetoothPage.qml" line="34"/>
+        <location filename="../src/qml/BluetoothPage.qml" line="36"/>
         <source>Not connected</source>
         <translation>未連線</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="72"/>
+        <location filename="../src/qml/SoundPage.qml" line="73"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>音量</translation>
     </message>
     <message id="id-charging-only">
-        <location filename="../src/qml/USBPage.qml" line="30"/>
+        <location filename="../src/qml/USBPage.qml" line="31"/>
         <source>Charging only</source>
         <translation>僅充電</translation>
     </message>
     <message id="id-adb-mode">
-        <location filename="../src/qml/USBPage.qml" line="32"/>
+        <location filename="../src/qml/USBPage.qml" line="35"/>
         <source>ADB Mode</source>
         <translation>ADB 模式</translation>
     </message>
     <message id="id-ssh-mode">
-        <location filename="../src/qml/USBPage.qml" line="34"/>
+        <location filename="../src/qml/USBPage.qml" line="33"/>
         <source>SSH Mode</source>
         <translation>SSH 模式</translation>
     </message>
-    <message id="id-mtp-mode">
-        <location filename="../src/qml/USBPage.qml" line="36"/>
-        <source>MTP Mode</source>
-        <translation>MTP 模式</translation>
-    </message>
     <message id="id-12h-format">
-        <location filename="../src/qml/UnitsPage.qml" line="48"/>
+        <location filename="../src/qml/UnitsPage.qml" line="50"/>
         <source>Use 12H format:</source>
         <translation>使用 12 小時格式：</translation>
     </message>
     <message id="id-fahrenheit">
-        <location filename="../src/qml/UnitsPage.qml" line="57"/>
+        <location filename="../src/qml/UnitsPage.qml" line="59"/>
         <source>Use Fahrenheit:</source>
         <translation>使用華氏溫標：</translation>
     </message>
     <message id="id-time-page">
-        <location filename="../src/qml/main.qml" line="128"/>
-        <location filename="../src/qml/TimePage.qml" line="109"/>
+        <location filename="../src/qml/main.qml" line="129"/>
+        <location filename="../src/qml/TimePage.qml" line="110"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
     <message id="id-date-page">
-        <location filename="../src/qml/DatePage.qml" line="97"/>
-        <location filename="../src/qml/main.qml" line="134"/>
+        <location filename="../src/qml/DatePage.qml" line="98"/>
+        <location filename="../src/qml/main.qml" line="135"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message id="id-language-page">
-        <location filename="../src/qml/LanguagePage.qml" line="64"/>
-        <location filename="../src/qml/main.qml" line="146"/>
+        <location filename="../src/qml/LanguagePage.qml" line="71"/>
+        <location filename="../src/qml/main.qml" line="147"/>
         <source>Language</source>
         <translation>語言</translation>
     </message>
     <message id="id-bluetooth-page">
-        <location filename="../src/qml/main.qml" line="158"/>
+        <location filename="../src/qml/main.qml" line="159"/>
         <source>Bluetooth</source>
         <translation>藍牙</translation>
     </message>
     <message id="id-display-page">
-        <location filename="../src/qml/DisplayPage.qml" line="171"/>
-        <location filename="../src/qml/main.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="175"/>
+        <location filename="../src/qml/main.qml" line="86"/>
         <source>Display</source>
         <translation>顯示</translation>
     </message>
     <message id="id-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="85"/>
+        <location filename="../src/qml/DisplayPage.qml" line="87"/>
         <source>Brightness</source>
         <translation>亮度</translation>
     </message>
     <message id="id-off">
-        <location filename="../src/qml/DisplayPage.qml" line="41"/>
+        <location filename="../src/qml/DisplayPage.qml" line="43"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-high">
-        <location filename="../src/qml/DisplayPage.qml" line="43"/>
+        <location filename="../src/qml/DisplayPage.qml" line="45"/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-medium">
-        <location filename="../src/qml/DisplayPage.qml" line="45"/>
+        <location filename="../src/qml/DisplayPage.qml" line="47"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-low">
-        <location filename="../src/qml/DisplayPage.qml" line="47"/>
+        <location filename="../src/qml/DisplayPage.qml" line="49"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-automatic-brightness">
-        <location filename="../src/qml/DisplayPage.qml" line="107"/>
+        <location filename="../src/qml/DisplayPage.qml" line="109"/>
         <source>Automatic brightness</source>
         <translation>自動亮度</translation>
     </message>
     <message id="id-always-on-display">
-        <location filename="../src/qml/DisplayPage.qml" line="118"/>
-        <location filename="../src/qml/NightstandPage.qml" line="154"/>
+        <location filename="../src/qml/DisplayPage.qml" line="120"/>
+        <location filename="../src/qml/NightstandPage.qml" line="155"/>
         <source>Always on Display</source>
         <translation>始終在顯示幕上</translation>
     </message>
     <message id="id-burn-in-protection">
-        <location filename="../src/qml/DisplayPage.qml" line="137"/>
+        <location filename="../src/qml/DisplayPage.qml" line="141"/>
         <source>Burn-in Protection</source>
         <oldsource>Burn in protection</oldsource>
         <translation type="unfinished">燒傷螢幕保護</translation>
     </message>
     <message id="id-tilt-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="151"/>
+        <location filename="../src/qml/DisplayPage.qml" line="155"/>
         <source>Tilt-to-wake</source>
         <translation>傾斜喚醒</translation>
     </message>
     <message id="id-tap-to-wake">
-        <location filename="../src/qml/DisplayPage.qml" line="162"/>
+        <location filename="../src/qml/DisplayPage.qml" line="166"/>
         <source>Tap-to-wake</source>
         <translation>點擊喚醒</translation>
     </message>
     <message id="id-timezone-page">
-        <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/TimezonePage.qml" line="144"/>
+        <location filename="../src/qml/main.qml" line="153"/>
+        <location filename="../src/qml/TimezonePage.qml" line="154"/>
         <source>Time zone</source>
         <translation>時區</translation>
     </message>
     <message id="id-sound-page">
-        <location filename="../src/qml/main.qml" line="103"/>
+        <location filename="../src/qml/main.qml" line="104"/>
         <source>Sound</source>
         <translation>音效</translation>
     </message>
     <message id="id-nightstand-page">
-        <location filename="../src/qml/main.qml" line="91"/>
-        <location filename="../src/qml/NightstandPage.qml" line="196"/>
+        <location filename="../src/qml/main.qml" line="92"/>
+        <location filename="../src/qml/NightstandPage.qml" line="200"/>
         <source>Nightstand</source>
         <translation>夜間待機模式</translation>
     </message>
     <message id="id-units-page">
-        <location filename="../src/qml/main.qml" line="140"/>
-        <location filename="../src/qml/UnitsPage.qml" line="65"/>
+        <location filename="../src/qml/main.qml" line="141"/>
+        <location filename="../src/qml/UnitsPage.qml" line="67"/>
         <source>Units</source>
         <translation>單位</translation>
     </message>
     <message id="id-wallpaper-page">
-        <location filename="../src/qml/main.qml" line="110"/>
+        <location filename="../src/qml/main.qml" line="111"/>
         <source>Wallpaper</source>
         <translation>桌布</translation>
     </message>
     <message id="id-watchface-page">
-        <location filename="../src/qml/main.qml" line="116"/>
+        <location filename="../src/qml/main.qml" line="117"/>
         <source>Watchface</source>
         <translation>錶面</translation>
     </message>
     <message id="id-launcher-page">
-        <location filename="../src/qml/main.qml" line="122"/>
+        <location filename="../src/qml/main.qml" line="123"/>
         <source>Launcher</source>
         <translation>啟動器</translation>
     </message>
     <message id="id-quickpanel-page">
-        <location filename="../src/qml/main.qml" line="97"/>
+        <location filename="../src/qml/main.qml" line="98"/>
         <source>Quick Panel</source>
         <translation>快速設定</translation>
     </message>
+    <message id="id-wifi-page">
+        <location filename="../src/qml/main.qml" line="165"/>
+        <source>WiFi</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-usb-page">
-        <location filename="../src/qml/main.qml" line="164"/>
-        <location filename="../src/qml/USBPage.qml" line="85"/>
+        <location filename="../src/qml/main.qml" line="171"/>
+        <location filename="../src/qml/USBPage.qml" line="90"/>
         <source>USB</source>
         <translation></translation>
     </message>
     <message id="id-power-page">
-        <location filename="../src/qml/main.qml" line="170"/>
-        <location filename="../src/qml/PowerPage.qml" line="96"/>
+        <location filename="../src/qml/main.qml" line="177"/>
+        <location filename="../src/qml/PowerPage.qml" line="98"/>
         <source>Power</source>
         <translation>電源</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="31"/>
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
         <source>Power Off</source>
         <translation>關機</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <location filename="../src/qml/PowerPage.qml" line="35"/>
         <source>Reboot</source>
         <translation>重新啟動</translation>
     </message>
     <message id="id-reboot-bootloader-page">
-        <location filename="../src/qml/PowerPage.qml" line="35"/>
+        <location filename="../src/qml/PowerPage.qml" line="37"/>
         <source>Bootloader</source>
         <oldsource>Reboot to bootloader</oldsource>
         <translation>啟動程式</translation>
     </message>
     <message id="id-tap-to-cancel">
-        <location filename="../src/qml/PowerPage.qml" line="65"/>
+        <location filename="../src/qml/PowerPage.qml" line="67"/>
         <source>Tap to cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
-        <location filename="../src/qml/main.qml" line="176"/>
+        <location filename="../src/qml/main.qml" line="183"/>
         <source>About</source>
         <translation>關於</translation>
     </message>
     <message id="id-nightstand-enable">
-        <location filename="../src/qml/NightstandPage.qml" line="91"/>
+        <location filename="../src/qml/NightstandPage.qml" line="92"/>
         <source>Enable</source>
         <translation>啟用</translation>
     </message>
     <message id="id-nightstand-brightness">
-        <location filename="../src/qml/NightstandPage.qml" line="112"/>
+        <location filename="../src/qml/NightstandPage.qml" line="113"/>
         <source>Brightness</source>
         <oldsource>Nightstand Brightness</oldsource>
         <translation>亮度</translation>
     </message>
     <message id="id-nightstand-delay">
-        <location filename="../src/qml/NightstandPage.qml" line="131"/>
+        <location filename="../src/qml/NightstandPage.qml" line="132"/>
         <source>Delay</source>
         <oldsource>Nightstand delay</oldsource>
         <translation>延遲</translation>
     </message>
     <message id="id-nightstand-custom-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="172"/>
+        <location filename="../src/qml/NightstandPage.qml" line="176"/>
         <source>Custom watchface</source>
         <translation>自訂錶盤</translation>
     </message>
     <message id="id-nightstand-watchface">
-        <location filename="../src/qml/NightstandPage.qml" line="183"/>
+        <location filename="../src/qml/NightstandPage.qml" line="187"/>
         <source>Select watchface</source>
         <oldsource>select nightstand watchface</oldsource>
         <translation>選擇錶盤</translation>
     </message>
     <message id="id-toggle-lock">
-        <location filename="../src/qml/QuickPanelPage.qml" line="108"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="109"/>
         <source>Lock Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-settings">
-        <location filename="../src/qml/QuickPanelPage.qml" line="110"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="111"/>
         <source>Settings</source>
         <oldsource>Settings Shortcut</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-brightness">
-        <location filename="../src/qml/QuickPanelPage.qml" line="112"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="113"/>
         <source>Brightness</source>
         <translation type="unfinished">亮度</translation>
     </message>
     <message id="id-toggle-bluetooth">
-        <location filename="../src/qml/QuickPanelPage.qml" line="114"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="115"/>
         <source>Bluetooth</source>
         <translation type="unfinished">藍牙</translation>
     </message>
     <message id="id-toggle-haptics">
-        <location filename="../src/qml/QuickPanelPage.qml" line="116"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="117"/>
         <source>Vibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-wifi">
-        <location filename="../src/qml/QuickPanelPage.qml" line="119"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="120"/>
         <source>Wifi Toggle</source>
         <oldsource>WiFi</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-sound">
-        <location filename="../src/qml/QuickPanelPage.qml" line="123"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="124"/>
         <source>Mute Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-cinema">
-        <location filename="../src/qml/QuickPanelPage.qml" line="126"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="127"/>
         <source>Cinema Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-power-off">
-        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="131"/>
         <source>Poweroff</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-reboot">
-        <location filename="../src/qml/QuickPanelPage.qml" line="132"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="133"/>
         <source>Reboot</source>
         <translation type="unfinished">重新啟動</translation>
     </message>
     <message id="id-toggle-music">
-        <location filename="../src/qml/QuickPanelPage.qml" line="134"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="135"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-toggle-flashlight">
-        <location filename="../src/qml/QuickPanelPage.qml" line="136"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="137"/>
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-fixed-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="155"/>
         <source>Fixed Row</source>
         <oldsource>Fixed Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sliding-row">
-        <location filename="../src/qml/QuickPanelPage.qml" line="190"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="250"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="261"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="293"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="344"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="191"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="251"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="262"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="294"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="345"/>
         <source>Sliding Row</source>
         <oldsource>Sliding Row</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-options">
-        <location filename="../src/qml/QuickPanelPage.qml" line="226"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="304"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="227"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="305"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-bottom">
-        <location filename="../src/qml/QuickPanelPage.qml" line="228"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="509"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="516"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="229"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="517"/>
         <source>Battery Meter aligned to bottom?</source>
         <oldsource>Battery aligned to bottom?</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-animation">
-        <location filename="../src/qml/QuickPanelPage.qml" line="232"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="510"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="518"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="233"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="519"/>
         <source>Show battery charge animation?</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-particle-design">
-        <location filename="../src/qml/QuickPanelPage.qml" line="234"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="531"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="235"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="532"/>
         <source>Tap to cycle particle design</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-preview">
-        <location filename="../src/qml/QuickPanelPage.qml" line="236"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="237"/>
         <source>Battery preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-battery-colored">
-        <location filename="../src/qml/QuickPanelPage.qml" line="230"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="511"/>
-        <location filename="../src/qml/QuickPanelPage.qml" line="520"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="231"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="512"/>
+        <location filename="../src/qml/QuickPanelPage.qml" line="521"/>
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -371,122 +371,193 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-wifi-password">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="214"/>
+        <source>Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-disconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="141"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connectionError">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="85"/>
+        <source></source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-autoconnect">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="154"/>
+        <source>Autoconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-removenetwork">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="163"/>
+        <source>Forget network</source>
+        <oldsource>Remove network</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-ssid">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="204"/>
+        <source>Name (SSID):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-identity">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="206"/>
+        <source>Name (Identity):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-passphrase">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="208"/>
+        <source>Passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-wps">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="210"/>
+        <source>WPS:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-username">
+        <location filename="../src/qml/WiFiConnectionDialog.qml" line="212"/>
+        <source>Username:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-on">
+        <location filename="../src/qml/WiFiPage.qml" line="93"/>
+        <source>WiFi on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-off">
+        <location filename="../src/qml/WiFiPage.qml" line="95"/>
+        <source>WiFi off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-connected">
+        <location filename="../src/qml/WiFiPage.qml" line="97"/>
+        <location filename="../src/qml/WiFiPage.qml" line="142"/>
+        <source>Connected</source>
+        <translation type="unfinished">已連接</translation>
+    </message>
+    <message id="id-wifi-disconnected">
+        <location filename="../src/qml/WiFiPage.qml" line="99"/>
+        <source>Not connected</source>
+        <translation type="unfinished">未連線</translation>
+    </message>
+    <message id="id-wifi-hiddennetwork">
+        <location filename="../src/qml/WiFiPage.qml" line="125"/>
+        <source>Hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-saved">
+        <location filename="../src/qml/WiFiPage.qml" line="145"/>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-available">
+        <location filename="../src/qml/WiFiPage.qml" line="148"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="84"/>
         <source>Build ID</source>
         <translation>建構 ID</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="83"/>
+        <location filename="../src/qml/AboutPage.qml" line="85"/>
         <source>Codename</source>
         <translation>代號</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="84"/>
+        <location filename="../src/qml/AboutPage.qml" line="86"/>
         <source>Host name</source>
         <translation>主機名稱</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="85"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>WLAN MAC</source>
         <translation>WLAN MAC</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="86"/>
+        <location filename="../src/qml/AboutPage.qml" line="88"/>
         <source>IMEI</source>
         <translation>IMEI</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="89"/>
         <source>Serial number</source>
         <translation>序號</translation>
     </message>
     <message>
-        <source>Total disk space</source>
-        <translation type="vanished">總磁碟空間</translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 GB (%L2 %)</source>
-        <translation type="vanished">%L1 GB（%L2 %）</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>%L1W x %L2H</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>Uptime</source>
         <translation>運作時間</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="91"/>
+        <location filename="../src/qml/AboutPage.qml" line="93"/>
         <source>%L1 days %L2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>%L1</source>
         <translation>%L1</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="95"/>
+        <location filename="../src/qml/AboutPage.qml" line="97"/>
         <source>Threads</source>
         <translation>執行緒數</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>1,5,15 Minute loads</source>
         <translation>1、5、15 分鐘負載</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="98"/>
         <source>%L1, %L2, %L3</source>
         <translation>%L1, %L2, %L3</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>Total memory</source>
         <translation>總記憶體</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="103"/>
         <source>%L1 MB</source>
         <translation>%L1 MB</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>Free memory</source>
         <translation>空閒記憶體</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="102"/>
+        <location filename="../src/qml/AboutPage.qml" line="104"/>
         <source>%L1 MB (%L2 %)</source>
         <translation>%L1 MB（%L2 %）</translation>
     </message>
     <message>
-        <source>Available disk space</source>
-        <translation type="vanished">可用磁碟空間</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/AboutPage.qml" line="88"/>
+        <location filename="../src/qml/AboutPage.qml" line="90"/>
         <source>Display size</source>
         <translation>顯示尺寸</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="89"/>
+        <location filename="../src/qml/AboutPage.qml" line="91"/>
         <source>Kernel version</source>
         <translation>核心版本</translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="90"/>
+        <location filename="../src/qml/AboutPage.qml" line="92"/>
         <source>Qt version</source>
         <translation>Qt 版本</translation>
     </message>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,8 @@ asteroid_app_qml_module(asteroid-settings
 	qml/WallpaperPage.qml
 	qml/WatchfacePage.qml
 	qml/WatchfaceSelector.qml
+	qml/WiFiConnectionDialog.qml
+	qml/WiFiPage.qml
 	qml/LauncherPage.qml
 	qml/USBPage.qml
 	qml/PowerPage.qml

--- a/src/qml/WiFiConnectionDialog.qml
+++ b/src/qml/WiFiConnectionDialog.qml
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2023 - Arseniy Movshev <dodoradio@outlook.com>
+ *               2022 - Ed Beroset <github.com/beroset>
+ *               2017-2022 - Chupligin Sergey <neochapay@gmail.com>
+ *               2021 - Darrel Griët <idanlcontact@gmail.com>
+ *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
+ *               2015 - Florent Revest <revestflo@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* A large proportion of this code has been referenced from Nemomobile-UX Glacier-Settings, published at https://github.com/nemomobile-ux/glacier-settings/blob/master/src/plugins/wifi/WifiSettings.qml
+ */
+
+import QtQuick
+import org.asteroid.controls
+import org.asteroid.utils
+import Connman
+import QtQuick.VirtualKeyboard
+
+Item {
+    id: dialogItem
+    property string servicePath
+    property NetworkService modelData: NetworkService {path: dialogItem.servicePath}
+    UserAgent {
+        id: userAgent
+        onUserInputRequested: (requestServicePath, fields) => {
+            dialogItem.servicePath = requestServicePath
+            dialogItem.sourceFields = fields
+        }
+        onErrorReported: {
+            console.log("Got error from model: " + error)
+        }
+    }
+    property var sourceFields: ({})
+    property var loginFields: ({})
+
+    onSourceFieldsChanged: () => { //keep any fields that already exist, add new ones, discard old ones
+        var fieldsBackup = loginFields
+        loginFields = {}
+        for (const [field, args] of Object.entries(sourceFields)) {
+            if(fieldsBackup[field]) {
+                loginFields[field] = fieldsBackup[field]
+                delete fieldsBackup[field]
+            } else {
+                loginFields[field] = loginField.createObject(loginFieldsColumn,{"fieldName": field, "fieldArgs": args})
+            }
+        }
+        for (const [field, fieldInstance] of Object.entries(fieldsBackup)) {
+            fieldInstance.destroy()
+        }
+    }
+
+    property real rowHeight: Dims.h(25)
+    property real rowMargin: Dims.w(15)
+
+    InputPanel {
+        id: inputPanel
+        z: 99
+        visible: active
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.topMargin: -Dims.h(25)
+        height: Dims.h(100)
+
+        width: Dims.w(100)
+        externalLanguageSwitchEnabled: false
+    }
+
+    Connections {
+        target: modelData
+        function onConnectRequestFailed(error) {
+            console.log(error)
+            layerStack.push(errorPopup, {networkService: modelData, text: qsTrId("id-wifi-connectionError")})
+        }
+
+        function onConnectedChanged(connected) {
+            if(connected) {
+                sourceFields = {}
+            }
+        }
+    }
+
+    Flickable {
+        anchors.fill: parent
+        contentHeight: contentColumn.implicitHeight
+        Column {
+            id: contentColumn
+            width: parent.width
+            Item {height: Dims.h(15); width: parent.width}
+            Marquee {
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: dialogItem.rowMargin
+                    rightMargin: dialogItem.rowMargin
+                }
+                text: modelData.name
+                font.pixelSize: Dims.l(6)
+                height: Dims.l(8)
+            }
+
+            Column {
+                id: loginFieldsColumn
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: dialogItem.rowMargin
+                    rightMargin: dialogItem.rowMargin
+                }
+            }
+            Column {
+                visible: modelData.connected
+                width: parent.width
+                Label {
+                    anchors {
+                        left: parent.left
+                        right: parent.right
+                        leftMargin: dialogItem.rowMargin
+                        rightMargin: dialogItem.rowMargin
+                    }
+                    text: "IP: " + modelData.ipv4["Address"]
+                    horizontalAlignment: Text.AlignHCenter
+                    font.pixelSize: Dims.l(6)
+                }
+                LabeledActionButton {
+                    width: parent.width
+                    height: dialogItem.rowHeight
+                    //% "Disconnect"
+                    text: qsTrId("id-wifi-disconnect")
+                    icon: "ios-close-circle-outline"
+                    onClicked: {
+                        modelData.requestDisconnect()
+                        layerStack.pop(layerStack.currentLayer)
+                    }
+                }
+            }
+            LabeledSwitch {
+                id: autoConnectCheckBox
+                width: parent.width
+                height: dialogItem.rowHeight
+                //% "Autoconnect"
+                text: qsTrId("id-wifi-autoconnect")
+                checked: modelData.autoConnect
+                onClicked: modelData.autoConnect = checked
+            }
+            LabeledActionButton {
+                visible: modelData.connected || modelData.favorite
+                width: parent.width
+                height: dialogItem.rowHeight
+                //% "Forget network"
+                text: qsTrId("id-wifi-removenetwork")
+                icon: "ios-trash-circle"
+                onClicked: {
+                    modelData.remove()
+                    layerStack.pop(layerStack.currentLayer)
+                }
+            }
+
+            IconButton {
+                visible: loginFieldsColumn.children.length // easiest way to check if we've got some active agent fields
+                iconName: "ios-checkmark-circle-outline"
+                height: width
+                width: Dims.w(20)
+                anchors.horizontalCenter: parent.horizontalCenter
+                onClicked: () => {
+                    if(!modelData.connected) {
+                        var reply = {}
+                        for (const [field, args] of Object.entries(sourceFields)) {
+                            if(loginFields[field].text != "" && args["Requirement"] != "informational")
+                                reply[field] = loginFields[field].text
+                        }
+                        userAgent.sendUserReply(reply)
+                    }
+                }
+            }
+        }
+    }
+    Component {
+        id: loginField
+
+        Column {
+            width: parent.width
+            property string fieldName
+            property var fieldArgs
+            property alias text: fieldInput.text
+            visible: fieldArgs["Requirement"] != "informational"
+            Component.onCompleted: if(fieldArgs["Requirement"] == "mandatory" && sourceFields["PreviousPassphrase"]) fieldInput.text = sourceFields["PreviousPassphrase"]["Value"]
+            Label {
+                id: fieldLabel
+                text: switch (fieldName) {
+                    //% "Name (SSID):"
+                    case "Name": qsTrId("id-wifi-ssid"); break;
+                    //% "Name (Identity):"
+                    case "Identity": qsTrId("id-wifi-identity"); break;
+                    //% "Passphrase:"
+                    case "Passphrase": qsTrId("id-wifi-passphrase"); break;
+                    //% "WPS:"
+                    case "WPS": qsTrId("id-wifi-wps"); break;
+                    //% "Username:"
+                    case "Username": qsTrId("id-wifi-username"); break;
+                    //% "Password:"
+                    case "Password": qsTrId("id-wifi-password"); break;
+                }
+                font.pixelSize: Dims.l(6)
+            }
+            TextField {
+                id: fieldInput
+                text: modelData
+                width: parent.width
+            }
+        }
+    }
+
+    Component {
+        id: errorPopup
+        StatusPage {
+            icon: "ios-remove-circle"
+            anchors.fill: undefined
+            property NetworkService networkService
+            Component.onDestruction: networkService.requestConnect()
+        }
+    }
+}

--- a/src/qml/WiFiPage.qml
+++ b/src/qml/WiFiPage.qml
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2023 - Arseniy Movshev <dodoradio@outlook.com>
+ *               2017-2022 - Chupligin Sergey <neochapay@gmail.com>
+ *               2021 - Darrel Griët <idanlcontact@gmail.com>
+ *               2016 - Sylvia van Os <iamsylvie@openmailbox.org>
+ *               2015 - Florent Revest <revestflo@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* A large proportion of this code has been referenced from Nemomobile-UX Glacier-Settings, published at https://github.com/nemomobile-ux/glacier-settings/blob/master/src/plugins/wifi/WifiSettings.qml
+ */
+
+import QtQuick
+import org.asteroid.controls
+import org.asteroid.utils
+import Connman
+import QtQuick.VirtualKeyboard
+
+Item {
+    id: root
+
+    NetworkTechnology {
+        id: wifiStatus
+        path: "/net/connman/technology/wifi"
+        onPoweredChanged: {
+            if (wifiStatus.powered)
+                wifiModel.requestScan()
+        }
+    }
+
+    ListView {
+        id: wifiList
+        model: TechnologyModel {
+            id: wifiModel
+            name: "wifi"
+        }
+        width: parent.width
+        anchors.horizontalCenter: parent.horizontalCenter
+        height: parent.height
+        header: Item {
+            //this is meant to look like an org.asteroid.controls StatusPage when collapsed
+            width: root.width
+            height: wifiStatus.powered ? width*0.6 : root.height
+            Behavior on height { NumberAnimation { duration: 100 } }
+            anchors.horizontalCenter: parent.horizontalCenter
+            Rectangle {
+                id: statusIconBackground
+                anchors.centerIn: parent
+                anchors.verticalCenterOffset: -parent.width*0.13
+                color: "black"
+                radius: width/2
+                opacity: wifiStatus.powered ? 0.4 : 0.2
+                width: parent.width*0.25
+                height: width
+                Icon {
+                    id: statusIcon
+                    anchors.fill: statusIconBackground
+                    anchors.margins: parent.width*0.12
+                    name: wifiStatus.powered ? "ios-wifi" : "ios-wifi-outline"
+                }
+                MouseArea {
+                    id: statusMA
+                    enabled: true
+                    anchors.fill: parent
+                    onClicked: wifiStatus.powered = !wifiStatus.powered
+                }
+            }
+
+            Label {
+                id: statusLabel
+                font.pixelSize: parent.width*0.05
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                wrapMode: Text.Wrap
+                anchors.left: parent.left; anchors.right: parent.right
+                anchors.leftMargin: parent.width*0.04; anchors.rightMargin: anchors.leftMargin
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.verticalCenterOffset: parent.width*0.15
+                text: "<h3>" + (wifiStatus.powered ?
+                    //% "WiFi on"
+                    qsTrId("id-wifi-on") :
+                    //% "WiFi off"
+                    qsTrId("id-wifi-off")) + "</h3>\n" + (wifiStatus.powered ? (wifiStatus.connected ?
+                    //% "Connected"
+                    qsTrId("id-wifi-connected") :
+                    //% "Not connected"
+                    qsTrId("id-wifi-disconnected")) : "")
+            }
+        }
+
+        footer: Item {height: wifiStatus.powered ? root.height*0.15 : 0; width: parent.width}
+
+        delegate: Item {
+            id: networkListItem
+            visible: wifiStatus.powered
+            height: wifiStatus.powered ? Dims.h(21) : 0
+            width: parent.width
+            HighlightBar {
+                id: highlight
+                onClicked: {
+                    if (!modelData.connected) {
+                        layerStack.push(connectionDialog, {modelData: modelData})
+                        modelData.requestConnect()
+                    } else {
+                        layerStack.push(connectionDialog, {modelData: modelData})
+                    }
+                }
+                onPressAndHold: layerStack.push(connectionDialog, {modelData: modelData})
+            }
+            Marquee {
+                id: wifiNameLabel
+                //% "Hidden network"
+                text: modelData.name ? modelData.name : qsTrId("id-wifi-hiddennetwork")
+                height: parent.height*0.6
+                clip: false
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: DeviceSpecs.hasRoundScreen ? parent.width - Dims.w(36) : parent.width - Dims.w(24)
+            }
+            Label {
+                anchors {
+                    top: wifiNameLabel.bottom
+                    horizontalCenter: parent.horizontalCenter
+                }
+                opacity: 0.8
+                font.pixelSize: parent.width*0.07
+                font.weight: Font.Thin
+                text: {
+                    if (modelData.connected) {
+                        //% "Connected"
+                        qsTrId("id-wifi-connected")
+                    } else if (modelData.favorite){
+                        //% "Saved"
+                        qsTrId("id-wifi-saved")
+                    } else {
+                        //% "Available"
+                        qsTrId("id-wifi-available")
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: connectionDialog
+        WiFiConnectionDialog {}
+    }
+}
+

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -45,6 +45,7 @@ Application {
     Component { id: timezoneLayer;              TimezonePage   { } }
     Component { id: languageLayer;              LanguagePage   { } }
     Component { id: bluetoothLayer;             BluetoothPage  { } }
+    Component { id: wifiLayer;                  WiFiPage       { } }
     Component { id: displayLayer;               DisplayPage    { } }
     Component { id: soundLayer;                 SoundPage      { } }
     Component { id: nightstandLayer;            NightstandPage { } }
@@ -158,6 +159,12 @@ Application {
                     title: qsTrId("id-bluetooth-page")
                     iconName: "ios-bluetooth-outline"
                     onClicked: layerStack.push(bluetoothLayer)
+                }
+                ListItem {
+                    //% "WiFi"
+                    title: qsTrId("id-wifi-page")
+                    iconName: "ios-wifi-outline"
+                    onClicked: layerStack.push(wifiLayer)
                 }
                 ListItem {
                     //% "USB"

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -165,6 +165,7 @@ Application {
                     title: qsTrId("id-wifi-page")
                     iconName: "ios-wifi-outline"
                     onClicked: layerStack.push(wifiLayer)
+                    visible: DeviceSpecs.hasWlan
                 }
                 ListItem {
                     //% "USB"


### PR DESCRIPTION
does what it says on the tin, adds wifi settings. Allows scanning networks, logging in with username or password where needed. Has a dialog to show autoconnect, disconnect and remove buttons, along with the IP address for the given network. 

Limitations:
- doesn't show any 'connection failed' dialog when you fail to log in (i.e. no 'wrong password' or 'bad username' messages)
- doesn't have a 'show typed password' button to allow viewing what you've typed in
- doesn't allow viewing the password for a given saved network
- doesn't allow logging into interactive login wifi (such as the wifi in public transport)
- current asteroid virtual keyboard requires some setup and isn't super easy to type on (but that's not directly relevant to this PR)
- some small UI tweaks still needed (though not exactly ugly in its current form)

The big blocker is security. It would not be good to merge this right now as our watches don't ship any passwords or authentication at all. A number of solutions, as seen in discussions I've had with @eLtMosen and @beroset , in order roughly reflecting simplicity:

1. Show a popup the first time the wifi page is shown with text to the effect of 'your watch has no password by default. don't connect to public wifi. you do this at your own risk' (pros: very easy. Cons: easy to ignore, users are lazy and may not heed this warning)
2. make a default password on all asteroid watches something like `asteroid` (pros: sets a default password. cons: user is not likely to change password, not much better than zero password)
3. Generate a random password for ceres on first install. Add a page which shows the ceres password in asteroid-settings (perhaps this would only show the default password, but not a password the user has set themselves). Disable ssh to root and only allow su or sudo from ceres as the way to get to root. (pros: mitigates the 'lazy user' issue by providing a default password that is, at least, unique. cons: makes boot issues harder to debug, as user will not know this password until first boot. makes ssh instructions look less easy for users unfamiliar with shell.) 
4. Add an rsa key generation step to the installation process (pros: key auth is sexy and cool and all the serious admins do it. very secure. cons: different machines and distros will have different ssh setups, so instructions will likely be 'here's how to do it on ubuntu, or go figure it out yourself'. not trivial for new linux users, and somewhat complicated to deal with on windows)

I think that a good first step for security is adding sudo to our base images. This isn't absolutely necessary, but it will make it easier to disable root-ssh. Then disabling root ssh would be the next step in the right direction. 