### PR TITLE
Add reboot-to-bootloader to PowerPage

### DIFF
--- a/i18n/asteroid-settings.ar.ts
+++ b/i18n/asteroid-settings.ar.ts
@@ -24,7 +24,7 @@
         <translation>غير متصل</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>مستوى الصوت</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation>الطاقة</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>إغلاق</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>إعادة تشغيل</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.az.ts
+++ b/i18n/asteroid-settings.az.ts
@@ -24,7 +24,7 @@
         <translation>Bağlantı yoxdur</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">%1% Səs</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Söndürün</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Yenidən başladın</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.ca.ts
+++ b/i18n/asteroid-settings.ca.ts
@@ -167,6 +167,11 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader-page">
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.cs.ts
+++ b/i18n/asteroid-settings.cs.ts
@@ -167,6 +167,11 @@
         <source>Power</source>
         <translation>Napájení</translation>
     </message>
+    <message id="id-reboot-bootloader-page">
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.da.ts
+++ b/i18n/asteroid-settings.da.ts
@@ -24,7 +24,7 @@
         <translation>Ikke forbundet</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Lydstyrke %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Sluk</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Genstart</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.de_DE.ts
+++ b/i18n/asteroid-settings.de_DE.ts
@@ -24,7 +24,7 @@
         <translation>Nicht verbunden</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Lautstärke %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation>Beenden</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Ausschalten</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Neustart</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.el.ts
+++ b/i18n/asteroid-settings.el.ts
@@ -167,6 +167,11 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader-page">
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.en_GB.ts
+++ b/i18n/asteroid-settings.en_GB.ts
@@ -24,7 +24,7 @@
         <translation>Not connected</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volume</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation>Power</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Power Off</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Reboot</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.eo.ts
+++ b/i18n/asteroid-settings.eo.ts
@@ -24,7 +24,7 @@
         <translation>Ne konektita</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Laŭto %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Malstartigi</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Restartigi</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.es.ts
+++ b/i18n/asteroid-settings.es.ts
@@ -24,7 +24,7 @@
         <translation>No conectado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volumen</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation>Energía</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.es_AR.ts
+++ b/i18n/asteroid-settings.es_AR.ts
@@ -24,7 +24,7 @@
         <translation>Desconectado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Volumen %1 %</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.fa.ts
+++ b/i18n/asteroid-settings.fa.ts
@@ -24,7 +24,7 @@
         <translation>وصل نشده</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">حجم صدا %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation>نیرو</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>خاموش</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>راه‌اندازی دوباره</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.fi.ts
+++ b/i18n/asteroid-settings.fi.ts
@@ -24,7 +24,7 @@
         <translation>EI yhdistetty</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Äänenvoimakkuus %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Sammuta</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Käynnistä uudelleen</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.fr.ts
+++ b/i18n/asteroid-settings.fr.ts
@@ -24,7 +24,7 @@
         <translation>Non connecté</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Volume %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Éteindre</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Redémarrer</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.gl.ts
+++ b/i18n/asteroid-settings.gl.ts
@@ -24,7 +24,7 @@
         <translation>Non conectado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volume</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation>Encendido</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Apagar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.he.ts
+++ b/i18n/asteroid-settings.he.ts
@@ -24,7 +24,7 @@
         <translation>מנותק</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>עצמת שמע</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation>ניהול חשמל</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>כיבוי</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>הפעלה מחדש</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.hi.ts
+++ b/i18n/asteroid-settings.hi.ts
@@ -24,7 +24,7 @@
         <translation>जुड़ा नहीं है</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">वॉल्यूम %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>बिजली बंद है</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>रीबूट</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.hr.ts
+++ b/i18n/asteroid-settings.hr.ts
@@ -24,7 +24,7 @@
         <translation>Nije spojen</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Glasnoća</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation>Uključi</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Isključi</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Ponovo pokreni</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.hu.ts
+++ b/i18n/asteroid-settings.hu.ts
@@ -167,6 +167,11 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader-page">
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.id.ts
+++ b/i18n/asteroid-settings.id.ts
@@ -24,7 +24,7 @@
         <translation>Terputus</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Volume %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Matikan</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Nyalakan Ulang</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.it.ts
+++ b/i18n/asteroid-settings.it.ts
@@ -167,6 +167,11 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader-page">
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ja.ts
+++ b/i18n/asteroid-settings.ja.ts
@@ -24,7 +24,7 @@
         <translation>未接続</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">音量 %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>電源を切る</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>再起動</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.ka.ts
+++ b/i18n/asteroid-settings.ka.ts
@@ -24,7 +24,7 @@
         <translation>არაა დაკავშირებული</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">ხმის სიმაღლე %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>კვების გამორთვა</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>გადატვირთვა</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.ko.ts
+++ b/i18n/asteroid-settings.ko.ts
@@ -24,7 +24,7 @@
         <translation>연결되지 않음</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">음량 %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>종료</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>재시동</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.lb.ts
+++ b/i18n/asteroid-settings.lb.ts
@@ -24,7 +24,7 @@
         <translation>Net verbonnen</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Lautstäerkt %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Ausschalten</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Neistart</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.lt.ts
+++ b/i18n/asteroid-settings.lt.ts
@@ -24,7 +24,7 @@
         <translation>Neprisijungta</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Garsumas %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Išjungti</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Perkrauti</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.mr.ts
+++ b/i18n/asteroid-settings.mr.ts
@@ -24,7 +24,7 @@
         <translation>न जोडलेले</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">आवाज %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>वीज बंद</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>रीबूट करा</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.ms.ts
+++ b/i18n/asteroid-settings.ms.ts
@@ -24,7 +24,7 @@
         <translation>Tidak Disambungkan</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Tahap bunyi %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Tutup Kuasa</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Mulakan Semula</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.nb_NO.ts
+++ b/i18n/asteroid-settings.nb_NO.ts
@@ -24,7 +24,7 @@
         <translation>Ikke tilkoblet</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Lydstyrke</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished">Effekt</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Skru av</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Omstart</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.nl_BE.ts
+++ b/i18n/asteroid-settings.nl_BE.ts
@@ -24,7 +24,7 @@
         <translation>Niet verbonden</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Geluid %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Uitschakelen</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Herstarten</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.nl_NL.ts
+++ b/i18n/asteroid-settings.nl_NL.ts
@@ -24,7 +24,7 @@
         <translation>Niet verbonden</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Geluid %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Uitschakelen</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Herstarten</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.pl.ts
+++ b/i18n/asteroid-settings.pl.ts
@@ -24,7 +24,7 @@
         <translation>Nie połączony</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Głośność %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished">Zasilanie</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Wyłącz</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Uruchom ponownie</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.pt.ts
+++ b/i18n/asteroid-settings.pt.ts
@@ -24,7 +24,7 @@
         <translation>Não ligado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Volume %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.pt_BR.ts
+++ b/i18n/asteroid-settings.pt_BR.ts
@@ -24,7 +24,7 @@
         <translation>Não conectado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Volume %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.pt_PT.ts
+++ b/i18n/asteroid-settings.pt_PT.ts
@@ -24,7 +24,7 @@
         <translation>Não ligado</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Volume %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Desligar</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Reiniciar</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.ro.ts
+++ b/i18n/asteroid-settings.ro.ts
@@ -24,7 +24,7 @@
         <translation>Neconectat</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Volum %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Oprire</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Repornire</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.ru.ts
+++ b/i18n/asteroid-settings.ru.ts
@@ -24,7 +24,7 @@
         <translation>Не соединён</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Громкость</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation>Питание</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Выключить</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Перезагрузить</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.sk.ts
+++ b/i18n/asteroid-settings.sk.ts
@@ -167,6 +167,11 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader-page">
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.sq.ts
+++ b/i18n/asteroid-settings.sq.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished"></translation>
@@ -164,18 +164,24 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">

--- a/i18n/asteroid-settings.sv.ts
+++ b/i18n/asteroid-settings.sv.ts
@@ -24,7 +24,7 @@
         <translation>Inte ansluten</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Volym</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation>Ström</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Stäng av</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Starta om</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.ta.ts
+++ b/i18n/asteroid-settings.ta.ts
@@ -167,6 +167,11 @@
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-reboot-bootloader-page">
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.te.ts
+++ b/i18n/asteroid-settings.te.ts
@@ -24,7 +24,7 @@
         <translation>కనెక్టెడ్ లేదు</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">శబ్దం %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>మూసివేయి</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>రీబూట్</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.th.ts
+++ b/i18n/asteroid-settings.th.ts
@@ -24,7 +24,7 @@
         <translation>ไม่เชื่อมต่อ</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">ระดับ %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>ปิด</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>รีบูต</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.tr.ts
+++ b/i18n/asteroid-settings.tr.ts
@@ -167,6 +167,11 @@
         <source>Power</source>
         <translation>Güç</translation>
     </message>
+    <message id="id-reboot-bootloader-page">
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.uk.ts
+++ b/i18n/asteroid-settings.uk.ts
@@ -24,7 +24,7 @@
         <translation>Не підключено</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation>Гучність</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation>Живлення</translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Вимкнути</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Перезавантажити</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.vi.ts
+++ b/i18n/asteroid-settings.vi.ts
@@ -24,7 +24,7 @@
         <translation>Chưa kết nối</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">Âm lượng %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>Tắt nguồn</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>Khởi động lại</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>

--- a/i18n/asteroid-settings.zh_Hans.ts
+++ b/i18n/asteroid-settings.zh_Hans.ts
@@ -167,6 +167,11 @@
         <source>Power</source>
         <translation>电源</translation>
     </message>
+    <message id="id-reboot-bootloader-page">
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.zh_Hant.ts
+++ b/i18n/asteroid-settings.zh_Hant.ts
@@ -24,7 +24,7 @@
         <translation>未連線</translation>
     </message>
     <message id="id-sound-percentage">
-        <location filename="../src/qml/SoundPage.qml" line="88"/>
+        <location filename="../src/qml/SoundPage.qml" line="72"/>
         <source>Volume</source>
         <oldsource>Volume %1%</oldsource>
         <translation type="unfinished">音量 %1%</translation>
@@ -164,19 +164,25 @@
     </message>
     <message id="id-power-page">
         <location filename="../src/qml/main.qml" line="152"/>
-        <location filename="../src/qml/PowerPage.qml" line="70"/>
+        <location filename="../src/qml/PowerPage.qml" line="87"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="id-poweroff-page">
-        <location filename="../src/qml/PowerPage.qml" line="30"/>
+        <location filename="../src/qml/PowerPage.qml" line="29"/>
         <source>Power Off</source>
         <translation>關機</translation>
     </message>
     <message id="id-reboot-page">
-        <location filename="../src/qml/PowerPage.qml" line="32"/>
+        <location filename="../src/qml/PowerPage.qml" line="31"/>
         <source>Reboot</source>
         <translation>重新啟動</translation>
+    </message>
+    <message id="id-reboot-bootloader-page">
+        <location filename="../src/qml/PowerPage.qml" line="33"/>
+        <source>Bootloader</source>
+        <oldsource>Reboot to bootloader</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message id="id-about-page">
         <location filename="../src/qml/main.qml" line="158"/>


### PR DESCRIPTION
This adds a reboot-to-bootloader option to the PowerPage and also moves from using dsme to a standard login1DBus interface.  Note that the corresponding polkit rule update (https://github.com/AsteroidOS/meta-asteroid/pull/164 ) must also be applied for this to work.