### PR TITLE
Rename DeviceInfo to DeviceSpecs to remove conflict

### DIFF
--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -82,9 +82,9 @@ Flickable {
         }
         Repeater {
             model: [
-                { label: qsTr("Build ID"), text: DeviceInfo.buildID },
-                { label: qsTr("Codename"), text: DeviceInfo.machineName },
-                { label: qsTr("Host name"), text: DeviceInfo.hostname },
+                { label: qsTr("Build ID"), text: DeviceSpecs.buildID },
+                { label: qsTr("Codename"), text: DeviceSpecs.machineName },
+                { label: qsTr("Host name"), text: DeviceSpecs.hostname },
                 { label: qsTr("WLAN MAC"), text: about.wlanMacAddress },
                 { label: qsTr("IMEI"), text: about.imei },
                 { label: qsTr("Serial number"), text: about.serial },

--- a/src/qml/DatePage.qml
+++ b/src/qml/DatePage.qml
@@ -31,9 +31,9 @@ Item {
         id: dateSelector
         anchors {
             left: parent.left
-            leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(5) : 0
+            leftMargin: DeviceSpecs.hasRoundScreen ? Dims.w(5) : 0
             right: parent.right
-            rightMargin: DeviceInfo.hasRoundScreen ? Dims.w(5) : 0
+            rightMargin: DeviceSpecs.hasRoundScreen ? Dims.w(5) : 0
             top: title.bottom
         }
         height: Dims.h(60)

--- a/src/qml/DisplayPage.qml
+++ b/src/qml/DisplayPage.qml
@@ -32,7 +32,7 @@ Item {
     ConfigurationValue {
         id: useBip
         key: "/org/asteroidos/settings/use-burn-in-protection"
-        defaultValue: DeviceInfo.needsBurnInProtection
+        defaultValue: DeviceSpecs.needsBurnInProtection
     }
 
     ConfigurationValue {
@@ -98,7 +98,7 @@ Item {
             LabeledSwitch {
                 height: rowHeight
                 width: parent.width
-                visible: DeviceInfo.needsBurnInProtection
+                visible: DeviceSpecs.needsBurnInProtection
                 //% "Burn in protection"
                 text: qsTrId("id-burn-in-protection")
                 checked: useBip.value

--- a/src/qml/TimePage.qml
+++ b/src/qml/TimePage.qml
@@ -40,9 +40,9 @@ Item {
         id: timeSelector
         anchors {
             left: parent.left
-            leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(5) : 0
+            leftMargin: DeviceSpecs.hasRoundScreen ? Dims.w(5) : 0
             right: parent.right
-            rightMargin: DeviceInfo.hasRoundScreen ? Dims.w(5) : 0
+            rightMargin: DeviceSpecs.hasRoundScreen ? Dims.w(5) : 0
             top: title.bottom
         }
         height: Dims.h(60)

--- a/src/qml/WatchfaceSelector.qml
+++ b/src/qml/WatchfaceSelector.qml
@@ -84,7 +84,7 @@ Item {
                     height: grid.cellHeight
                     anchors.centerIn: parent
                     color: "transparent"
-                    radius: DeviceInfo.hasRoundScreen ?
+                    radius: DeviceSpecs.hasRoundScreen ?
                                 width :
                                 Dims.w(3)
                     clip: true
@@ -159,15 +159,15 @@ Item {
                     visible: watchface === folderModel.folder + "/" + fileName
                     anchors {
                         bottom: parent.bottom
-                        bottomMargin: DeviceInfo.hasRoundScreen ?
+                        bottomMargin: DeviceSpecs.hasRoundScreen ?
                                           -parent.height * .03 :
                                           -parent.height * .08
                         horizontalCenter: parent.horizontalCenter
                         horizontalCenterOffset: index % 2 ?
-                                                    DeviceInfo.hasRoundScreen ?
+                                                    DeviceSpecs.hasRoundScreen ?
                                                         -parent.height * .45 :
                                                         -parent.height * .40 :
-                                                        DeviceInfo.hasRoundScreen ?
+                                                        DeviceSpecs.hasRoundScreen ?
                                                             parent.height * .45 :
                                                             parent.height * .40
                     }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -66,7 +66,7 @@ Application {
                 id: settingsColumn
                 anchors.fill: parent
 
-                Item { width: parent.width; height: DeviceInfo.hasRoundScreen ? Dims.h(6) : Dims.h(2) }
+                Item { width: parent.width; height: DeviceSpecs.hasRoundScreen ? Dims.h(6) : Dims.h(2) }
 
                 ListItem {
                     //% "Display"
@@ -85,7 +85,7 @@ Application {
                     title: qsTrId("id-sound-page")
                     iconName: "ios-sound-outline"
                     onClicked: layerStack.push(soundLayer)
-                    visible: DeviceInfo.hasSpeaker
+                    visible: DeviceSpecs.hasSpeaker
                 }
                 ListItem {
                     //% "Wallpaper"
@@ -160,7 +160,7 @@ Application {
                     onClicked: layerStack.push(aboutLayer)
                 }
 
-                Item { width: parent.width; height: DeviceInfo.hasRoundScreen ? Dims.h(6) : Dims.h(2) }
+                Item { width: parent.width; height: DeviceSpecs.hasRoundScreen ? Dims.h(6) : Dims.h(2) }
             }
         }
     }


### PR DESCRIPTION
This renames the DeviceInfo QML class in org.asteroid.utils to DeviceSpecs to avoid a conflict with an unrelated DeviceInfo class defined in org.nemomobile.systemsettings.

This fixes AsteroidOS/qml-asteroid#56