### PR TITLE
Observe mode when changing AoD settings

### DIFF
--- a/src/qml/DisplayPage.qml
+++ b/src/qml/DisplayPage.qml
@@ -24,6 +24,7 @@ import org.asteroid.utils 1.0
 import org.asteroid.settings 1.0
 import org.nemomobile.systemsettings 1.0
 import Nemo.Configuration 1.0
+import Nemo.Mce 1.0
 
 Item {
     TapToWake { id: tapToWake }
@@ -52,6 +53,16 @@ Item {
         id: alwaysOnDisplay
         key: "/org/asteroidos/settings/always-on-display"
         defaultValue: true
+    }
+
+    ConfigurationValue {
+        id: nightstandEnabled
+        key: "/desktop/asteroid/nightstand/enabled"
+        defaultValue: true
+    }
+
+    MceChargerType {
+        id: mceChargerType
     }
 
     property string rowHeight: Dims.h(25)
@@ -107,8 +118,12 @@ Item {
                 text: qsTrId("id-always-on-display")
                 checked: alwaysOnDisplay.value
                 onCheckedChanged: {
-                    displaySettings.lowPowerModeEnabled = checked
                     alwaysOnDisplay.value = checked
+                    // alter displaySettings unless NightStand mode is active
+                    // and we are on a charger
+                    if (!nightstandEnabled.value || mceChargerType.type == MceChargerType.None) {
+                        displaySettings.lowPowerModeEnabled = checked
+                    }
                 }
             }
 

--- a/src/qml/NightstandPage.qml
+++ b/src/qml/NightstandPage.qml
@@ -25,6 +25,7 @@ import org.asteroid.utils 1.0
 import org.asteroid.settings 1.0
 import org.nemomobile.systemsettings 1.0 as NemoSystemSettings
 import Nemo.Configuration 1.0
+import Nemo.Mce 1.0
 
 Item {
     ConfigurationValue {
@@ -56,9 +57,13 @@ Item {
         key: "/desktop/asteroid/nightstand/always-on-display"
         defaultValue: true
     }
-    
-    NemoSystemSettings.DisplaySettings { 
+
+    NemoSystemSettings.DisplaySettings {
         id: displaySettings
+    }
+
+    MceChargerType {
+        id: mceChargerType
     }
 
 
@@ -149,8 +154,11 @@ Item {
                     text: qsTrId("id-always-on-display")
                     checked: nightstandAlwaysOnDisplay.value
                     onCheckedChanged: {
-                        nightstandAlwaysOnDisplay.value = checked
-                        displaySettings.lowPowerModeEnabled = checked
+                        // only alter displaySettings if Nightstand mode is
+                        // active and we're currently on a charger
+                        if (nightstandEnabled.value && mceChargerType.type != MceChargerType.None) {
+                            displaySettings.lowPowerModeEnabled = checked
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This fixes [#328](https://github.com/AsteroidOS/asteroid/issues/328) by implementing checks to make sure that when Nightstand Always-on-Display is enabled, it only alters `displaySettings.lowPowerModeEnabled` if Nightstand is enabled and it is active (meaning that it's on a charger).  Similarly, for the Display Always-on-Display, it only alters `displaySettings.lowPowerModeEnabled` if Nightstand mode is not active.  This assures that whether the settings are changed with the watch on the charger or not and no matter what the current settings are, the display will do the right thing.