### PR TITLE
feat: port to Qt6 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(
 )
 
 find_package(ECM REQUIRED NO_MODULE)
-find_package(AsteroidApp REQUIRED)
+find_package(AsteroidApp6 REQUIRED)
 
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ASTEROID_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 
@@ -15,12 +15,13 @@ include(FindPkgConfig)
 include(FeatureSummary)
 include(GNUInstallDirs)
 include(ECMFindQmlModule)
-include(AsteroidCMakeSettings)
-include(AsteroidTranslations)
+include(Asteroid6CMakeSettings)
+include(Asteroid6Translations)
 
-find_package(Qt5 COMPONENTS Core Qml Quick DBus Multimedia REQUIRED)
+find_package(Qt6 REQUIRED COMPONENTS Core Qml Quick DBus Multimedia)
 find_package(Mce REQUIRED)
 
+ecm_find_qmlmodule(Nemo.Mce 1.0)
 ecm_find_qmlmodule(Nemo.DBus 2.0)
 ecm_find_qmlmodule(Nemo.Configuration 1.0)
 ecm_find_qmlmodule(Qt.labs.folderlistmodel 2.1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.10.0)
 
-project(asteroid-settings
+project(
+	asteroid-settings
 	VERSION 2.0
-	DESCRIPTION "Default settings app for AsteroidOS")
+	DESCRIPTION "Default settings app for AsteroidOS"
+)
 
 find_package(ECM REQUIRED NO_MODULE)
 find_package(AsteroidApp REQUIRED)
@@ -26,12 +28,16 @@ ecm_find_qmlmodule(org.nemomobile.systemsettings 1.0)
 
 add_subdirectory(src)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-settings.in
+configure_file(
+	${CMAKE_CURRENT_SOURCE_DIR}/asteroid-settings.in
 	${CMAKE_BINARY_DIR}/asteroid-settings
-	@ONLY)
+	@ONLY
+)
 
-install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-settings
-	DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+	PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-settings
+	DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 
 build_translations(i18n)
 generate_desktop(${CMAKE_SOURCE_DIR} asteroid-settings)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10.0)
 
 project(asteroid-settings
-	VERSION 2.0.0
+	VERSION 2.0
 	DESCRIPTION "Default settings app for AsteroidOS")
 
 find_package(ECM REQUIRED NO_MODULE)

--- a/asteroid-settings.in
+++ b/asteroid-settings.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec invoker --single-instance --type=qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-settings.so
+exec invoker --single-instance --type=qt6 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-settings.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,25 +3,34 @@ find_program(QDBUSXML2CPP NAMES qdbusxml2cpp-qt5 qdbusxml2cpp)
 if(NOT QDBUSXML2CPP)
 	message(FATAL_ERROR "qdbusxml2cpp not found")
 endif()
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mceiface.h ${CMAKE_CURRENT_BINARY_DIR}/mceiface.cpp
-	COMMAND ${QDBUSXML2CPP} -p mceiface.h:mceiface.cpp ${CMAKE_CURRENT_SOURCE_DIR}/mce.xml)
+add_custom_command(
+	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mceiface.h ${CMAKE_CURRENT_BINARY_DIR}/mceiface.cpp
+	COMMAND ${QDBUSXML2CPP} -p mceiface.h:mceiface.cpp ${CMAKE_CURRENT_SOURCE_DIR}/mce.xml
+)
 
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.h ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.cpp
-	COMMAND ${QDBUSXML2CPP} -p VolumeControl2.h:VolumeControl2.cpp ${CMAKE_CURRENT_SOURCE_DIR}/VolumeControl2.xml)
+add_custom_command(
+	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.h ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.cpp
+	COMMAND ${QDBUSXML2CPP} -p VolumeControl2.h:VolumeControl2.cpp ${CMAKE_CURRENT_SOURCE_DIR}/VolumeControl2.xml
+)
 
-set(SRC
+set(
+	SRC
 	main.cpp
 	sysinfo.cpp
 	taptowake.cpp
 	tilttowake.cpp
-	volumecontrol.cpp)
-set(HEADERS
+	volumecontrol.cpp
+)
+set(
+	HEADERS
 	sysinfo.h
 	taptowake.h
 	tilttowake.h
-	volumecontrol.h)
+	volumecontrol.h
+)
 
-add_library(asteroid-settings ${SRC} ${HEADERS} resources.qrc 
+add_library(
+	asteroid-settings ${SRC} ${HEADERS} resources.qrc 
     ${CMAKE_CURRENT_BINARY_DIR}/mceiface.h 
     ${CMAKE_CURRENT_BINARY_DIR}/mceiface.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.h 
@@ -29,12 +38,17 @@ add_library(asteroid-settings ${SRC} ${HEADERS} resources.qrc
 )
 set_target_properties(asteroid-settings PROPERTIES PREFIX "")
 
-target_link_libraries(asteroid-settings PRIVATE
-	Qt5::Qml
-	Qt5::Quick
-	Qt5::DBus
-	Qt5::Multimedia
-	Asteroid::AsteroidApp)
+target_link_libraries(
+	asteroid-settings
+	PRIVATE
+		Qt5::Qml
+		Qt5::Quick
+		Qt5::DBus
+		Qt5::Multimedia
+		Asteroid::AsteroidApp
+)
 
-install(TARGETS asteroid-settings
-	DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(
+	TARGETS asteroid-settings
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,16 +1,12 @@
-# Generate mceiface.h
-find_program(QDBUSXML2CPP NAMES qdbusxml2cpp-qt5 qdbusxml2cpp)
-if(NOT QDBUSXML2CPP)
-	message(FATAL_ERROR "qdbusxml2cpp not found")
-endif()
-add_custom_command(
-	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mceiface.h ${CMAKE_CURRENT_BINARY_DIR}/mceiface.cpp
-	COMMAND ${QDBUSXML2CPP} -p mceiface.h:mceiface.cpp ${CMAKE_CURRENT_SOURCE_DIR}/mce.xml
+# Generate DBus interfaces
+qt_add_dbus_interfaces(
+	dbus_srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/mce.xml
 )
 
-add_custom_command(
-	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.h ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.cpp
-	COMMAND ${QDBUSXML2CPP} -p VolumeControl2.h:VolumeControl2.cpp ${CMAKE_CURRENT_SOURCE_DIR}/VolumeControl2.xml
+qt_add_dbus_interfaces(
+	dbus_srcs
+	${CMAKE_CURRENT_SOURCE_DIR}/VolumeControl2.xml
 )
 
 set(
@@ -20,6 +16,7 @@ set(
 	taptowake.cpp
 	tilttowake.cpp
 	volumecontrol.cpp
+	${dbus_srcs}
 )
 set(
 	HEADERS
@@ -29,23 +26,23 @@ set(
 	volumecontrol.h
 )
 
-add_library(
-	asteroid-settings ${SRC} ${HEADERS} resources.qrc 
-    ${CMAKE_CURRENT_BINARY_DIR}/mceiface.h 
-    ${CMAKE_CURRENT_BINARY_DIR}/mceiface.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.h 
-    ${CMAKE_CURRENT_BINARY_DIR}/VolumeControl2.cpp
+add_library(asteroid-settings ${SRC} ${HEADERS} resources.qrc)
+message(${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(
+	asteroid-settings
+	PRIVATE
+	${GENERATED_DBUS_HEADERS_DIR}
 )
 set_target_properties(asteroid-settings PROPERTIES PREFIX "")
 
 target_link_libraries(
 	asteroid-settings
 	PRIVATE
-		Qt5::Qml
-		Qt5::Quick
-		Qt5::DBus
-		Qt5::Multimedia
-		Asteroid::AsteroidApp
+		Qt::Qml
+		Qt::Quick
+		Qt::DBus
+		Qt::Multimedia
+		Asteroid::AsteroidApp6
 )
 
 install(

--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -16,11 +16,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.utils 1.0
-import org.asteroid.controls 1.0
-import org.asteroid.settings 1.0
-import org.nemomobile.systemsettings 1.0
+import QtQuick
+import org.asteroid.utils
+import org.asteroid.controls
+import org.asteroid.settings
+import org.nemomobile.systemsettings
 
 Flickable {
     AboutSettings {

--- a/src/qml/BluetoothPage.qml
+++ b/src/qml/BluetoothPage.qml
@@ -16,9 +16,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
+import QtQuick
+import org.asteroid.controls
+import org.asteroid.utils
 
 Item {
     BluetoothStatus { id: btStatus }

--- a/src/qml/DatePage.qml
+++ b/src/qml/DatePage.qml
@@ -16,10 +16,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
-import org.nemomobile.systemsettings 1.0
+import QtQuick
+import org.asteroid.controls
+import org.asteroid.utils
+import org.nemomobile.systemsettings
 
 Item {
     id: root

--- a/src/qml/DisplayPage.qml
+++ b/src/qml/DisplayPage.qml
@@ -17,14 +17,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import QtQuick.Layouts 1.3
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
-import org.asteroid.settings 1.0
-import org.nemomobile.systemsettings 1.0
-import Nemo.Configuration 1.0
-import Nemo.Mce 1.0
+import QtQuick
+import QtQuick.Layouts
+import org.asteroid.controls
+import org.asteroid.utils
+import org.asteroid.settings
+import org.nemomobile.systemsettings
+import Nemo.Configuration
+import Nemo.Mce
 
 Item {
     TapToWake { id: tapToWake }

--- a/src/qml/LanguagePage.qml
+++ b/src/qml/LanguagePage.qml
@@ -16,9 +16,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.controls 1.0
-import org.nemomobile.systemsettings 1.0
+import QtQuick
+import org.asteroid.controls
+import org.nemomobile.systemsettings
 
 Item {
     id: root

--- a/src/qml/LauncherPage.qml
+++ b/src/qml/LauncherPage.qml
@@ -16,12 +16,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import Qt.labs.folderlistmodel 2.1
-import Nemo.Time 1.0
-import Nemo.Configuration 1.0
-import org.asteroid.controls 1.0
-import QtQml.Models 2.15
+import QtQuick
+import Qt.labs.folderlistmodel
+import Nemo.Time
+import Nemo.Configuration
+import org.asteroid.controls
+import QtQml.Models
 
 Item {
     property alias displayAmbient: compositor.displayAmbient

--- a/src/qml/NightstandPage.qml
+++ b/src/qml/NightstandPage.qml
@@ -18,14 +18,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.15
-import QtQuick.Layouts 1.3
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
-import org.asteroid.settings 1.0
-import org.nemomobile.systemsettings 1.0 as NemoSystemSettings
-import Nemo.Configuration 1.0
-import Nemo.Mce 1.0
+import QtQuick
+import QtQuick.Layouts
+import org.asteroid.controls
+import org.asteroid.utils
+import org.asteroid.settings
+import org.nemomobile.systemsettings as NemoSystemSettings
+import Nemo.Configuration
+import Nemo.Mce
 
 Item {
     ConfigurationValue {

--- a/src/qml/NightstandWatchfacePage.qml
+++ b/src/qml/NightstandWatchfacePage.qml
@@ -17,13 +17,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.1
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
-import Nemo.Configuration 1.0
-import Nemo.Time 1.0
+import QtQuick
+import Qt.labs.folderlistmodel
+import org.asteroid.controls
+import org.asteroid.utils
+import Nemo.Configuration
+import Nemo.Time
 
 Item {
 

--- a/src/qml/PowerPage.qml
+++ b/src/qml/PowerPage.qml
@@ -17,9 +17,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.controls 1.0
-import Nemo.DBus 2.0
+import QtQuick
+import org.asteroid.controls
+import Nemo.DBus
 
 Item {
 

--- a/src/qml/QuickPanelPage.qml
+++ b/src/qml/QuickPanelPage.qml
@@ -15,12 +15,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import QtGraphicalEffects 1.15
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
-import Nemo.Configuration 1.0
-import Nemo.Mce 1.0
+import QtQuick
+import org.asteroid.controls
+import org.asteroid.utils
+import Nemo.Configuration
+import Nemo.Mce
 
 Item {
     id: quickPanelPage

--- a/src/qml/SoundPage.qml
+++ b/src/qml/SoundPage.qml
@@ -16,11 +16,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import QtMultimedia 5.8
-import org.asteroid.controls 1.0
-import org.asteroid.settings 1.0
-import Nemo.Configuration 1.0
+import QtQuick
+import QtMultimedia
+import org.asteroid.controls
+import org.asteroid.settings
+import Nemo.Configuration
 
 
 Item {

--- a/src/qml/TimePage.qml
+++ b/src/qml/TimePage.qml
@@ -16,12 +16,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
-import Nemo.Time 1.0
-import Nemo.Configuration 1.0
-import org.nemomobile.systemsettings 1.0
+import QtQuick
+import org.asteroid.controls
+import org.asteroid.utils
+import Nemo.Time
+import Nemo.Configuration
+import org.nemomobile.systemsettings
 
 Item {
     id: root

--- a/src/qml/TimezonePage.qml
+++ b/src/qml/TimezonePage.qml
@@ -19,9 +19,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.controls 1.0
-import Nemo.DBus 2.0
+import QtQuick
+import org.asteroid.controls
+import Nemo.DBus
 
 Item {
     id: root

--- a/src/qml/USBPage.qml
+++ b/src/qml/USBPage.qml
@@ -16,9 +16,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import Nemo.DBus 2.0
-import org.asteroid.controls 1.0
+import QtQuick
+import Nemo.DBus
+import org.asteroid.controls
 
 Item {
     id: root

--- a/src/qml/UnitsPage.qml
+++ b/src/qml/UnitsPage.qml
@@ -15,10 +15,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import QtQuick.Layouts 1.3
-import Nemo.Configuration 1.0
-import org.asteroid.controls 1.0
+import QtQuick
+import QtQuick.Layouts
+import Nemo.Configuration
+import org.asteroid.controls
 
 Item {
 

--- a/src/qml/WallpaperPage.qml
+++ b/src/qml/WallpaperPage.qml
@@ -17,12 +17,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.1
-import Nemo.Configuration 1.0
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
+import QtQuick
+import Qt5Compat.GraphicalEffects
+import Qt.labs.folderlistmodel
+import Nemo.Configuration
+import org.asteroid.controls
+import org.asteroid.utils
 
 
 Item {

--- a/src/qml/WatchfacePage.qml
+++ b/src/qml/WatchfacePage.qml
@@ -17,13 +17,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.1
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
-import Nemo.Configuration 1.0
-import Nemo.Time 1.0
+import QtQuick
+import Qt.labs.folderlistmodel
+import org.asteroid.controls
+import org.asteroid.utils
+import Nemo.Configuration
+import Nemo.Time
 
 Item {
     property alias displayAmbient: compositor.displayAmbient

--- a/src/qml/WatchfaceSelector.qml
+++ b/src/qml/WatchfaceSelector.qml
@@ -17,13 +17,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.1
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
-import Nemo.Configuration 1.0
-import Nemo.Time 1.0
+import QtQuick
+import Qt5Compat.GraphicalEffects
+import Qt.labs.folderlistmodel
+import org.asteroid.controls
+import org.asteroid.utils
+import Nemo.Configuration
+import Nemo.Time
 
 Item {
     id: watchfaceSelector

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -17,11 +17,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
-import org.asteroid.controls 1.0
-import org.asteroid.utils 1.0
-import org.asteroid.settings 1.0
-import Nemo.Configuration 1.0
+import QtQuick
+import org.asteroid.controls
+import org.asteroid.utils
+import org.asteroid.settings
+import Nemo.Configuration
 
 Application {
     id: app

--- a/src/taptowake.cpp
+++ b/src/taptowake.cpp
@@ -55,7 +55,7 @@
 
 #include <mce/dbus-names.h>
 #include <mce/mode-names.h>
-#include "mceiface.h"
+#include "mceinterface.h"
 
 static const char *MceTapToWakeEnabled = "/system/osso/dsm/powerkey/actions_gesture4";
 

--- a/src/tilttowake.cpp
+++ b/src/tilttowake.cpp
@@ -55,7 +55,7 @@
 
 #include <mce/dbus-names.h>
 #include <mce/mode-names.h>
-#include "mceiface.h"
+#include "mceinterface.h"
 
 static const char *MceWristSensorEnabled = "/system/osso/dsm/display/wrist_sensor_enabled";
 static const char *MceWristSensorAvailable = "/system/osso/dsm/display/wrist_sensor_available";

--- a/src/volumecontrol.cpp
+++ b/src/volumecontrol.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "volumecontrol.h"
-#include "VolumeControl2.h"
+#include "volumecontrol2interface.h"
 #include <QDBusMessage>
 #include <QDBusConnection>
 #include <QDBusArgument>
@@ -94,7 +94,7 @@ void VolumeControl::setVolume(int volume)
             if(effect != NULL)
                 effect->stop();
             effect = new QMediaPlayer(this);
-            effect->setMedia(QUrl::fromLocalFile("/usr/share/sounds/notification.wav"));
+            effect->setSource(QUrl::fromLocalFile("/usr/share/sounds/notification.wav"));
             effect->play();
         }
     }


### PR DESCRIPTION
Requires Qt6 ports of nemo-qml-plugin-systemsettings (https://github.com/PureTryOut/nemo-qml-plugin-systemsettings/tree/qt6) and nemo-qml-plugin-filemanager (https://github.com/sailfishos/nemo-qml-plugin-filemanager/pull/12) which currently don't exist yet but I have local patches for.

The latter also needs https://invent.kde.org/frameworks/karchive/-/merge_requests/199 to be merged first.

Currently the about page still refers to a non-existing function and is thus largely empty which will need fixing.
```
qrc:/qml/AboutPage.qml:92: TypeError: Property 'totalDiskSpace' of object AboutSettings(0x7fc45baee1f0) is not a function
```