### PR TITLE
feat: Power Manager settings UI with battery health estimation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.aider*

--- a/0001-Add-airplane-mode-toggle-to-QuickPanel-settings.patch
+++ b/0001-Add-airplane-mode-toggle-to-QuickPanel-settings.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: AsteroidOS Developer <dev@asteroidos.org>
+Date: Sun, 13 Apr 2026 22:00:00 -0700
+Subject: [PATCH] Add airplane mode toggle to QuickPanel settings page
+
+Adds the airplaneModeToggle to the QuickPanel settings page so users
+can rearrange, enable, or disable it alongside other toggles. The toggle
+uses the ios-plane-outline icon and is enabled by default.
+
+Upstream-Status: Pending
+Signed-off-by: AsteroidOS Developer <dev@asteroidos.org>
+---
+--- a/src/qml/QuickPanelPage.qml	2026-04-13 22:06:02.163114516 -0700
++++ b/src/qml/QuickPanelPage.qml	2026-04-13 22:06:25.975885866 -0700
+@@ -48,6 +48,7 @@
+             "soundToggle",
+             "cinemaToggle",
+             "aodToggle",
++            "airplaneModeToggle",
+             "powerOffToggle",
+             "rebootToggle",
+             "musicButton",
+@@ -71,7 +72,8 @@
+             "powerOffToggle": true,
+             "rebootToggle": true,
+             "musicButton": false,
+-            "flashlightButton": false
++            "flashlightButton": false,
++            "airplaneModeToggle": true
+         }
+     }
+ 
+@@ -126,6 +128,8 @@
+         toggleOptions["cinemaToggle"] = ({ name: qsTrId("id-toggle-cinema"), icon: "ios-film-outline"});
+         //% "AoD Toggle"
+         toggleOptions["aodToggle"] = ({ name: qsTrId("id-always-on-display"), icon: "ios-watch-aod-on"});
++        //% "Airplane Mode"
++        toggleOptions["airplaneModeToggle"] = ({ name: qsTrId("id-toggle-airplane-mode"), icon: "ios-plane-outline"});
+         //% "Poweroff"
+         toggleOptions["powerOffToggle"] = ({ name: qsTrId("id-toggle-power-off"), icon: "ios-power-outline"});
+         //% "Reboot"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,12 @@ ecm_find_qmlmodule(org.nemomobile.systemsettings 1.0)
 
 add_subdirectory(src)
 
+option(BUILD_TESTS "Build QML validation tests" OFF)
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-settings.in
 	${CMAKE_BINARY_DIR}/asteroid-settings
 	@ONLY)

--- a/i18n/asteroid-settings.ace.ts
+++ b/i18n/asteroid-settings.ace.ts
@@ -257,6 +257,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ace.ts
+++ b/i18n/asteroid-settings.ace.ts
@@ -345,5 +345,10 @@
         <source>Qt version</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.ace.ts
+++ b/i18n/asteroid-settings.ace.ts
@@ -222,6 +222,261 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Peurunoe Kuasa</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ar.ts
+++ b/i18n/asteroid-settings.ar.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>مدير الطاقة</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>الملف الشخصي النشط</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>الخدمة غير متوفرة</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>تبديل سريع</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>جميع الملفات</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>تعديل الملفات</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>الأتمتة</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>لا توجد ملفات متاحة</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation>قد تكون الخدمة غير متوفرة</translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>اختيار ملف</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>إضافة ملف جديد</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>الملفات</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>تمرين</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>النوم فقط</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>دائماً</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>دوري</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>مستمر</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>عند الطلب</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>ملف جديد</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>جاري التحميل...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>المستشعرات</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>مقياس التسارع</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>الجيروسكوب</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>معدل ضربات القلب</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>مقياس الضغط الجوي</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>البوصلة</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>الإضاءة المحيطة</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>الاتصالات اللاسلكية</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>تعطيل أثناء النوم</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>النظام</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>المزامنة في الخلفية</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>قواعد البطارية والوقت</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>حفظ</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>حذف الملف</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>قواعد البطارية</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>تبديل الملف عند وصول البطارية إلى الحد</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>إضافة قاعدة بطارية</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>قواعد الوقت</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>تبديل الملف خلال فترة زمنية</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>إضافة قاعدة وقت</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>ملفات التمرين</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>تعيين ملف لكل نوع تمرين</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>تهيئة في إعدادات تطبيق التمرين</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ar.ts
+++ b/i18n/asteroid-settings.ar.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>الأتمتة</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ar.ts
+++ b/i18n/asteroid-settings.ar.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>وضع الطيران</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.ast.ts
+++ b/i18n/asteroid-settings.ast.ts
@@ -148,5 +148,10 @@
         <source>Settings</source>
         <translation>Configuración</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.ast.ts
+++ b/i18n/asteroid-settings.ast.ts
@@ -188,6 +188,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ast.ts
+++ b/i18n/asteroid-settings.ast.ts
@@ -153,5 +153,260 @@
         <source>Airplane Mode</source>
         <translation type="unfinished">Airplane Mode</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Xestor d&apos;enerxía</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.az.ts
+++ b/i18n/asteroid-settings.az.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Avtomatlaşdırma</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.az.ts
+++ b/i18n/asteroid-settings.az.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Enerji İdarəçisi</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktiv Profil</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Xidmət mövcud deyil</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Sürətli Keçid</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Bütün Profillər</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Profilləri Redaktə Et</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Avtomatlaşdırma</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Heç bir profil yoxdur</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation>Xidmət mövcud olmaya bilər</translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Profil Seç</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Yeni Profil Əlavə Et</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profillər</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Yeni Profil</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Yüklənir...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensorlar</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radiolar</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Saxla</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Profili Sil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Batareya Qaydaları</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Vaxt Qaydaları</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.az.ts
+++ b/i18n/asteroid-settings.az.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Təyyarə rejimi</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.be.ts
+++ b/i18n/asteroid-settings.be.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation>Ліхтарык</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Рэжым палёту</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.be.ts
+++ b/i18n/asteroid-settings.be.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished">Налады</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Кіраванне энергіяй</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Актыўны профіль</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Сэрвіс недаступны</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Хуткае пераключэнне</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Усе профілі</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Рэдагаваць профілі</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Аўтаматызацыя</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Няма даступных профіляў</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Выбраць профіль</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Профілі</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Загрузка...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Датчыкі</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Радыё</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Сістэма</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Захаваць</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Выдаліць профіль</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.be.ts
+++ b/i18n/asteroid-settings.be.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Аўтаматызацыя</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.bqi.ts
+++ b/i18n/asteroid-settings.bqi.ts
@@ -345,5 +345,10 @@
         <source>Qt version</source>
         <translation>نوسخه Qt</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.bqi.ts
+++ b/i18n/asteroid-settings.bqi.ts
@@ -257,6 +257,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.bqi.ts
+++ b/i18n/asteroid-settings.bqi.ts
@@ -222,6 +222,261 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>پسند بلگه ساعت</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>مدیر نیرو</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ca.ts
+++ b/i18n/asteroid-settings.ca.ts
@@ -321,6 +321,51 @@
         <source>Automation</source>
         <translation>Automatització</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ca.ts
+++ b/i18n/asteroid-settings.ca.ts
@@ -286,6 +286,261 @@
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Gestor d&apos;energia</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Perfil actiu</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Servei no disponible</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Canvi ràpid</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Tots els perfils</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Editar perfils</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatització</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>No hi ha perfils disponibles</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation>El servei pot no estar disponible</translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Seleccionar perfil</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Afegir nou perfil</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Perfils</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Entrenament</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>Només dormir</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Sempre</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Perfil nou</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Carregant...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensors</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Freqüència cardíaca</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Brúixola</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Llum ambiental</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Ràdios</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Desactivar durant el son</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Sincronització en segon pla</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Regles de bateria i temps</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Desar</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Eliminar perfil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Regles de bateria</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Regles de temps</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ca.ts
+++ b/i18n/asteroid-settings.ca.ts
@@ -262,6 +262,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Mode d'avió</translation>
+    </message>
     <message id="id-tap-to-cancel">
         <source>Tap to cancel</source>
     </message>

--- a/i18n/asteroid-settings.ckb.ts
+++ b/i18n/asteroid-settings.ckb.ts
@@ -120,5 +120,260 @@
         <source>Airplane Mode</source>
         <translation type="unfinished">Airplane Mode</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>بەڕێوەبەری وزە</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.ckb.ts
+++ b/i18n/asteroid-settings.ckb.ts
@@ -155,6 +155,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ckb.ts
+++ b/i18n/asteroid-settings.ckb.ts
@@ -115,5 +115,10 @@
         <source>Charging only</source>
         <translation>تەنها لە کاتی شەحن کردن</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.cs.ts
+++ b/i18n/asteroid-settings.cs.ts
@@ -286,6 +286,261 @@
         <source>Settings</source>
         <translation type="unfinished">Nastavení</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Správce napájení</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktivní profil</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Služba nedostupná</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Rychlé přepnutí</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Všechny profily</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Upravit profily</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatizace</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Žádné profily nejsou k dispozici</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation>Služba může být nedostupná</translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Vybrat profil</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Přidat nový profil</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profily</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Trénink</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>Pouze spánek</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Vždy</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>Periodicky</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>Nepřetržitě</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>Na vyžádání</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Nový profil</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Načítání...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Senzory</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>Akcelerometr</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>Gyroskop</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Tepová frekvence</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Barometr</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Kompas</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Okolní světlo</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Rádia</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Zakázat během spánku</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Systém</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Synchronizace na pozadí</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Pravidla baterie a času</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Uložit</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Smazat profil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Pravidla baterie</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>Přepnout profil při dosažení prahu baterie</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>Přidat pravidlo baterie</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Časová pravidla</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>Přepnout profil v časovém okně</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>Přidat časové pravidlo</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>Tréninkové profily</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>Přiřadit profil každému typu tréninku</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>Konfigurovat v nastavení aplikace Trénink</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.cs.ts
+++ b/i18n/asteroid-settings.cs.ts
@@ -258,6 +258,11 @@
         <source>Flashlight</source>
         <translation>Svítilna</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Režim letadlo</translation>
+    </message>
     <message id="id-tap-to-cancel">
         <source>Tap to cancel</source>
     </message>

--- a/i18n/asteroid-settings.cs.ts
+++ b/i18n/asteroid-settings.cs.ts
@@ -321,6 +321,51 @@
         <source>Automation</source>
         <translation>Automatizace</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.da.ts
+++ b/i18n/asteroid-settings.da.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatisering</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.da.ts
+++ b/i18n/asteroid-settings.da.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Flytilstand</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.da.ts
+++ b/i18n/asteroid-settings.da.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Strømstyring</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktiv profil</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Tjeneste utilgængelig</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Hurtigt skift</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Alle profiler</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Rediger profiler</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatisering</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Ingen profiler tilgængelige</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Vælg profil</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Tilføj ny profil</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profiler</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Altid</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Ny profil</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Indlæser...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensorer</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Puls</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Kompas</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Omgivende lys</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radioer</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Deaktiver under søvn</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Baggrundssynkronisering</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Batteri- og tidsregler</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Gem</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Slet profil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Batteriregler</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Tidsregler</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.de_DE.ts
+++ b/i18n/asteroid-settings.de_DE.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Energieverwaltung</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktives Profil</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Dienst nicht verfügbar</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Schnellwechsel</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Alle Profile</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Profile bearbeiten</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatisierung</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Keine Profile verfügbar</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation>Dienst ist möglicherweise nicht verfügbar</translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Profil auswählen</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Neues Profil hinzufügen</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profile</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Training</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>Nur Schlaf</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Immer</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>Periodisch</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>Kontinuierlich</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>Auf Anfrage</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Neues Profil</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Laden...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensoren</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>Beschleunigungssensor</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>Gyroskop</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Herzfrequenz</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Barometer</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Kompass</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Umgebungslicht</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Funkverbindungen</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Im Schlaf deaktivieren</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Hintergrundsynchronisierung</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Batterie- / Zeitregeln</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Speichern</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Profil löschen</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Batterieregeln</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>Profil wechseln wenn Batterie Schwellwert erreicht</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>Batterieregel hinzufügen</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Zeitregeln</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>Profil im Zeitfenster wechseln</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>Zeitregel hinzufügen</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>Trainingsprofile</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>Profil für jeden Trainingstyp zuweisen</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>In den Trainingsapp-Einstellungen konfigurieren</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.de_DE.ts
+++ b/i18n/asteroid-settings.de_DE.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatisierung</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.de_DE.ts
+++ b/i18n/asteroid-settings.de_DE.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation>Taschenlampe</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Flugmodus</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.el.ts
+++ b/i18n/asteroid-settings.el.ts
@@ -286,6 +286,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Διαχείριση ενέργειας</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Ενεργό προφίλ</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Η υπηρεσία δεν είναι διαθέσιμη</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Γρήγορη εναλλαγή</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Όλα τα προφίλ</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Επεξεργασία προφίλ</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Αυτοματισμός</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Επιλογή προφίλ</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Προφίλ</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Φόρτωση...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Αισθητήρες</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Καρδιακός ρυθμός</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Πυξίδα</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Φωτισμός περιβάλλοντος</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Ασύρματα</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Σύστημα</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Συγχρονισμός στο παρασκήνιο</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Αποθήκευση</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Διαγραφή προφίλ</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Κανόνες μπαταρίας</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Κανόνες χρόνου</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.el.ts
+++ b/i18n/asteroid-settings.el.ts
@@ -321,6 +321,51 @@
         <source>Automation</source>
         <translation>Αυτοματισμός</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.el.ts
+++ b/i18n/asteroid-settings.el.ts
@@ -258,6 +258,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Λειτουργία πτήσης</translation>
+    </message>
     <message id="id-tap-to-cancel">
         <source>Tap to cancel</source>
     </message>

--- a/i18n/asteroid-settings.en_GB.ts
+++ b/i18n/asteroid-settings.en_GB.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Power Manager</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Active Profile</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Service unavailable</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Quick Switch</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>All Profiles</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Edit Profiles</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automation</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>No profiles available</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation>Service may be unavailable</translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Select Profile</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Add New Profile</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profiles</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Workout</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>Sleep only</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Always</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>Periodic</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>Continuous</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>On demand</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>New Profile</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Loading...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensors</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>Accelerometer</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>Gyroscope</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Heart Rate</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Barometer</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Compass</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Ambient Light</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radios</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Disable during sleep</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Background Sync</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Battery / Time Rules</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Save</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Delete Profile</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Battery Rules</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>Switch profile when battery reaches threshold</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>Add Battery Rule</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Time Rules</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>Switch profile during time window</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>Add Time Rule</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>Workout Profiles</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>Assign profile for each workout type</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>Configure in Workout app settings</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.en_GB.ts
+++ b/i18n/asteroid-settings.en_GB.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation>Flashlight</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Aeroplane Mode</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.en_GB.ts
+++ b/i18n/asteroid-settings.en_GB.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automation</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation>Battery Health</translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation>%1 charge cycles</translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation>Accuracy: High (%1 samples)</translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation>Accuracy: Medium (%1 samples)</translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation>Accuracy: Improving...</translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation>Battery is in excellent condition</translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation>Battery is in good condition</translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation>Battery is showing wear — consider replacement</translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation>Battery is significantly degraded</translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.eo.ts
+++ b/i18n/asteroid-settings.eo.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Aviadila reĝimo</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.eo.ts
+++ b/i18n/asteroid-settings.eo.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Aŭtomatigo</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.eo.ts
+++ b/i18n/asteroid-settings.eo.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Energiadministrilo</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktiva profilo</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Servo nedisponebla</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Rapida ŝanĝo</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Ĉiuj profiloj</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Redakti profilojn</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Aŭtomatigo</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Elekti profilon</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profiloj</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Ŝarĝante...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensiloj</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radioj</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistemo</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Konservi</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Forigi profilon</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.es.ts
+++ b/i18n/asteroid-settings.es.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatización</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.es.ts
+++ b/i18n/asteroid-settings.es.ts
@@ -376,6 +376,261 @@
         <source>Enable colored battery?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Gestor de energía</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Perfil activo</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Servicio no disponible</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Cambio rápido</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Todos los perfiles</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Editar perfiles</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatización</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>No hay perfiles disponibles</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation>El servicio puede no estar disponible</translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Seleccionar perfil</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Añadir nuevo perfil</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Perfiles</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Entrenamiento</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>Solo sueño</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Siempre</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>Periódico</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>Continuo</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>Bajo demanda</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Nuevo perfil</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Cargando...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensores</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>Acelerómetro</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>Giroscopio</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Frecuencia cardíaca</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Barómetro</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Brújula</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Luz ambiental</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radios</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Desactivar durante el sueño</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Sincronización en segundo plano</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Reglas de batería y tiempo</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Guardar</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Eliminar perfil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Reglas de batería</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>Cambiar perfil cuando la batería alcance el umbral</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>Añadir regla de batería</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Reglas de tiempo</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>Cambiar perfil durante ventana de tiempo</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>Añadir regla de tiempo</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>Perfiles de entrenamiento</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>Asignar perfil para cada tipo de entrenamiento</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>Configurar en ajustes de la app de entrenamiento</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.es.ts
+++ b/i18n/asteroid-settings.es.ts
@@ -316,6 +316,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Modo avión</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.es_AR.ts
+++ b/i18n/asteroid-settings.es_AR.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Gestor de energía</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Perfil activo</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Servicio no disponible</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Cambio rápido</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Todos los perfiles</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Editar perfiles</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatización</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Seleccionar perfil</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Perfiles</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Cargando...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensores</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radios</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Guardar</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Eliminar perfil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.es_AR.ts
+++ b/i18n/asteroid-settings.es_AR.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatización</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.es_AR.ts
+++ b/i18n/asteroid-settings.es_AR.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Modo avión</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.fa.ts
+++ b/i18n/asteroid-settings.fa.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>خودکارسازی</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.fa.ts
+++ b/i18n/asteroid-settings.fa.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished">تنظیمات</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>مدیر انرژی</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>نمایه فعال</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>سرویس در دسترس نیست</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>تعویض سریع</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>همه نمایه‌ها</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>ویرایش نمایه‌ها</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>خودکارسازی</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>انتخاب نمایه</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>نمایه‌ها</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>بارگذاری...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>حسگرها</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>رادیوها</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>سیستم</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>ذخیره</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>حذف نمایه</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.fa.ts
+++ b/i18n/asteroid-settings.fa.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation>چراغ‌قوه</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>حالت پرواز</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.fi.ts
+++ b/i18n/asteroid-settings.fi.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Lentokonetila</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.fi.ts
+++ b/i18n/asteroid-settings.fi.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automaatio</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.fi.ts
+++ b/i18n/asteroid-settings.fi.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Virranhallinta</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktiivinen profiili</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Palvelu ei ole käytettävissä</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Pikavaihto</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Kaikki profiilit</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Muokkaa profiileja</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automaatio</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Ei profiileja saatavilla</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Valitse profiili</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Lisää uusi profiili</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profiilit</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Harjoitus</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Aina</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Uusi profiili</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Ladataan...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Anturit</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>Kiihtyvyysanturi</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>Gyroskooppi</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Syke</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Ilmanpainemittari</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Kompassi</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Ympäristön valo</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radiot</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Poista käytöstä unen aikana</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Järjestelmä</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Taustasynkronointi</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Akku- ja aikasäännöt</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Tallenna</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Poista profiili</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Akkusäännöt</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Aikasäännöt</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.fr.ts
+++ b/i18n/asteroid-settings.fr.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished">Paramètres</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Gestionnaire d&apos;énergie</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Profil actif</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Service indisponible</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Changement rapide</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Tous les profils</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Modifier les profils</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatisation</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Aucun profil disponible</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation>Le service peut être indisponible</translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Sélectionner le profil</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Ajouter un nouveau profil</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profils</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Entraînement</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>Sommeil uniquement</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Toujours</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>Périodique</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>Continu</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>À la demande</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Nouveau profil</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Chargement...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Capteurs</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>Accéléromètre</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>Gyroscope</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Fréquence cardiaque</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Baromètre</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Boussole</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Lumière ambiante</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Communications</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Désactiver pendant le sommeil</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Système</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Synchronisation en arrière-plan</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Règles batterie et horaire</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Supprimer le profil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Règles de batterie</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>Changer le profil lorsque la batterie atteint le seuil</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>Ajouter une règle de batterie</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Règles horaires</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>Changer le profil pendant une plage horaire</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>Ajouter une règle horaire</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>Profils d&apos;entraînement</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>Attribuer un profil pour chaque type d&apos;entraînement</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>Configurer dans les paramètres de l&apos;app Entraînement</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.fr.ts
+++ b/i18n/asteroid-settings.fr.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation>Lampe de poche</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Mode avion</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.fr.ts
+++ b/i18n/asteroid-settings.fr.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatisation</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.gl.ts
+++ b/i18n/asteroid-settings.gl.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Xestor de enerxía</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Perfil activo</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Servizo non dispoñible</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatización</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Perfís</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Cargando...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensores</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radios</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Gardar</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Eliminar perfil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.gl.ts
+++ b/i18n/asteroid-settings.gl.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatización</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.gl.ts
+++ b/i18n/asteroid-settings.gl.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Modo avión</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.he.ts
+++ b/i18n/asteroid-settings.he.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>אוטומציה</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.he.ts
+++ b/i18n/asteroid-settings.he.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished">הגדרות</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>ניהול צריכת חשמל</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>פרופיל פעיל</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>השירות אינו זמין</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>החלפה מהירה</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>כל הפרופילים</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>עריכת פרופילים</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>אוטומציה</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>בחירת פרופיל</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>פרופילים</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>טוען...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>חיישנים</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>תקשורת אלחוטית</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>מערכת</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>שמירה</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>מחיקת פרופיל</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.he.ts
+++ b/i18n/asteroid-settings.he.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation>פנס</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>מצב טיסה</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.hi.ts
+++ b/i18n/asteroid-settings.hi.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>स्वचालन</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.hi.ts
+++ b/i18n/asteroid-settings.hi.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>पावर मैनेजर</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>सक्रिय प्रोफ़ाइल</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>सेवा उपलब्ध नहीं है</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>त्वरित स्विच</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>सभी प्रोफ़ाइल</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>प्रोफ़ाइल संपादित करें</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>स्वचालन</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>प्रोफ़ाइल</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>लोड हो रहा है...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>सेंसर</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>रेडियो</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>सिस्टम</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>सहेजें</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>प्रोफ़ाइल हटाएं</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.hi.ts
+++ b/i18n/asteroid-settings.hi.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>हवाई जहाज़ मोड</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.hr.ts
+++ b/i18n/asteroid-settings.hr.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Zrakoplovni način</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.hr.ts
+++ b/i18n/asteroid-settings.hr.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatizacija</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.hr.ts
+++ b/i18n/asteroid-settings.hr.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Upravljanje napajanjem</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktivni profil</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Usluga nedostupna</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatizacija</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profili</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Učitavanje...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Senzori</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sustav</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Spremi</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Obriši profil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.hu.ts
+++ b/i18n/asteroid-settings.hu.ts
@@ -286,6 +286,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Energiakezelő</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktív profil</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Szolgáltatás nem elérhető</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Gyorsváltás</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Összes profil</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Profilok szerkesztése</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatizálás</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Profil kiválasztása</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profilok</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Betöltés...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Érzékelők</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Pulzus</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Iránytű</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Rádiók</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Rendszer</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Mentés</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Profil törlése</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Akkumulátor szabályok</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Időszabályok</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.hu.ts
+++ b/i18n/asteroid-settings.hu.ts
@@ -321,6 +321,51 @@
         <source>Automation</source>
         <translation>Automatizálás</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.hu.ts
+++ b/i18n/asteroid-settings.hu.ts
@@ -258,6 +258,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Repülőgép üzemmód</translation>
+    </message>
     <message id="id-tap-to-cancel">
         <source>Tap to cancel</source>
     </message>

--- a/i18n/asteroid-settings.ia.ts
+++ b/i18n/asteroid-settings.ia.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Gestor de energia</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ia.ts
+++ b/i18n/asteroid-settings.ia.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ia.ts
+++ b/i18n/asteroid-settings.ia.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.id.ts
+++ b/i18n/asteroid-settings.id.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation>Senter</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Mode pesawat</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.id.ts
+++ b/i18n/asteroid-settings.id.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Otomatisasi</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.id.ts
+++ b/i18n/asteroid-settings.id.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished">Pengaturan</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Pengelola Daya</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Profil Aktif</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Layanan tidak tersedia</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Beralih Cepat</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Semua Profil</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Edit Profil</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Otomatisasi</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Pilih Profil</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profil</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Memuat...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensor</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radio</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Simpan</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Hapus Profil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.isv.ts
+++ b/i18n/asteroid-settings.isv.ts
@@ -257,6 +257,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.isv.ts
+++ b/i18n/asteroid-settings.isv.ts
@@ -345,5 +345,10 @@
         <source>Qt version</source>
         <translation>Versija Qt</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.isv.ts
+++ b/i18n/asteroid-settings.isv.ts
@@ -222,6 +222,261 @@
         <oldsource>select nightstand watchface</oldsource>
         <translation>Izbrati ciferny indikator</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Upravljanje energijej</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.it.ts
+++ b/i18n/asteroid-settings.it.ts
@@ -258,6 +258,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Modalità aereo</translation>
+    </message>
     <message id="id-tap-to-cancel">
         <source>Tap to cancel</source>
     </message>

--- a/i18n/asteroid-settings.it.ts
+++ b/i18n/asteroid-settings.it.ts
@@ -286,6 +286,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Gestione energia</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Profilo attivo</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Servizio non disponibile</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Cambio rapido</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Tutti i profili</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Modifica profili</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automazione</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Nessun profilo disponibile</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation>Il servizio potrebbe non essere disponibile</translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Seleziona profilo</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Aggiungi nuovo profilo</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profili</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Allenamento</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>Solo sonno</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Sempre</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>Periodico</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>Continuo</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>Su richiesta</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Nuovo profilo</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Caricamento...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensori</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>Accelerometro</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>Giroscopio</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Frequenza cardiaca</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Barometro</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Bussola</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Luce ambientale</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radio</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Disattiva durante il sonno</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Sincronizzazione in background</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Regole batteria e orario</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Salva</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Elimina profilo</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Regole batteria</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>Cambia profilo quando la batteria raggiunge la soglia</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>Aggiungi regola batteria</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Regole orarie</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>Cambia profilo durante la finestra temporale</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>Aggiungi regola oraria</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>Profili allenamento</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>Assegna profilo per ogni tipo di allenamento</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>Configura nelle impostazioni dell&apos;app Allenamento</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.it.ts
+++ b/i18n/asteroid-settings.it.ts
@@ -321,6 +321,51 @@
         <source>Automation</source>
         <translation>Automazione</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ja.ts
+++ b/i18n/asteroid-settings.ja.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>機内モード</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.ja.ts
+++ b/i18n/asteroid-settings.ja.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>電源管理</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>アクティブプロファイル</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>サービス利用不可</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>クイック切替</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>すべてのプロファイル</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>プロファイルを編集</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>自動化</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>利用可能なプロファイルがありません</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>プロファイルを選択</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>新しいプロファイルを追加</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>プロファイル</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>ワークアウト</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>スリープのみ</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>常時</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>定期的</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>連続</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>オンデマンド</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>新しいプロファイル</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>読み込み中...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>センサー</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>加速度計</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>ジャイロスコープ</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>心拍数</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>気圧計</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>コンパス</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>環境光</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>無線</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>スリープ中は無効化</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>システム</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>バックグラウンド同期</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>バッテリーと時間のルール</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>プロファイルを削除</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>バッテリールール</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>バッテリーが閾値に達した時にプロファイルを切替</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>バッテリールールを追加</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>時間ルール</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>時間帯にプロファイルを切替</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>時間ルールを追加</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>ワークアウトプロファイル</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>各ワークアウトタイプにプロファイルを割り当て</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>ワークアウトアプリの設定で構成</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ja.ts
+++ b/i18n/asteroid-settings.ja.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>自動化</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ka.ts
+++ b/i18n/asteroid-settings.ka.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>ავტომატიზაცია</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ka.ts
+++ b/i18n/asteroid-settings.ka.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>თვითმფრინავის რეჟიმი</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.ka.ts
+++ b/i18n/asteroid-settings.ka.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>ენერგიის მართვა</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>აქტიური პროფილი</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>სერვისი მიუწვდომელია</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>ავტომატიზაცია</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>პროფილები</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>იტვირთება...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>სენსორები</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>სისტემა</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>შენახვა</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>პროფილის წაშლა</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.kab.ts
+++ b/i18n/asteroid-settings.kab.ts
@@ -120,5 +120,260 @@
         <source>Airplane Mode</source>
         <translation type="unfinished">Airplane Mode</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Amsefrek n tezzmert</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.kab.ts
+++ b/i18n/asteroid-settings.kab.ts
@@ -155,6 +155,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.kab.ts
+++ b/i18n/asteroid-settings.kab.ts
@@ -115,5 +115,10 @@
         <source>Charging only</source>
         <translation>Asali kan</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.ko.ts
+++ b/i18n/asteroid-settings.ko.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>자동화</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ko.ts
+++ b/i18n/asteroid-settings.ko.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>전원 관리</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>활성 프로필</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>서비스 사용 불가</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>빠른 전환</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>모든 프로필</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>프로필 편집</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>자동화</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>프로필 선택</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>프로필</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>로딩 중...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>센서</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>심박수</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>나침반</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>무선</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>시스템</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>저장</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>프로필 삭제</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>배터리 규칙</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>시간 규칙</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ko.ts
+++ b/i18n/asteroid-settings.ko.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>비행기 모드</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.lb.ts
+++ b/i18n/asteroid-settings.lb.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.lb.ts
+++ b/i18n/asteroid-settings.lb.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Energieverwaltung</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.lb.ts
+++ b/i18n/asteroid-settings.lb.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Fluchmodus</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.lt.ts
+++ b/i18n/asteroid-settings.lt.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatizavimas</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.lt.ts
+++ b/i18n/asteroid-settings.lt.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Lėktuvo režimas</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.lt.ts
+++ b/i18n/asteroid-settings.lt.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Energijos valdymas</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktyvus profilis</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Paslauga nepasiekiama</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatizavimas</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profiliai</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Kraunama...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Jutikliai</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Išsaugoti</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Ištrinti profilį</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.mr.ts
+++ b/i18n/asteroid-settings.mr.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.mr.ts
+++ b/i18n/asteroid-settings.mr.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>पॉवर व्यवस्थापक</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>सक्रिय प्रोफाइल</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>सेवा उपलब्ध नाही</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>लोड होत आहे...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>सेन्सर</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>सिस्टम</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>जतन करा</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.mr.ts
+++ b/i18n/asteroid-settings.mr.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.ms.ts
+++ b/i18n/asteroid-settings.ms.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Pengurus Kuasa</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Profil Aktif</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Perkhidmatan tidak tersedia</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automasi</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profil</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Memuatkan...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Penderia</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Simpan</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ms.ts
+++ b/i18n/asteroid-settings.ms.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automasi</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ms.ts
+++ b/i18n/asteroid-settings.ms.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Mod penerbangan</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.nb_NO.ts
+++ b/i18n/asteroid-settings.nb_NO.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Strømstyring</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktiv profil</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Tjeneste utilgjengelig</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Hurtigbytte</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Alle profiler</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Rediger profiler</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatisering</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Velg profil</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profiler</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Laster...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensorer</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Puls</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Kompass</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radioer</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Lagre</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Slett profil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Batteriregler</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Tidsregler</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.nb_NO.ts
+++ b/i18n/asteroid-settings.nb_NO.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatisering</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.nb_NO.ts
+++ b/i18n/asteroid-settings.nb_NO.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Flymodus</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.nl_BE.ts
+++ b/i18n/asteroid-settings.nl_BE.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatisering</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.nl_BE.ts
+++ b/i18n/asteroid-settings.nl_BE.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Vliegtuigmodus</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.nl_BE.ts
+++ b/i18n/asteroid-settings.nl_BE.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Energiebeheer</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Actief profiel</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Dienst niet beschikbaar</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Snel wisselen</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Alle profielen</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Profielen bewerken</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatisering</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Profiel selecteren</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profielen</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Laden...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensoren</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Hartslag</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Kompas</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radio&apos;s</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Systeem</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Opslaan</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Profiel verwijderen</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Batterijregels</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Tijdregels</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.nl_NL.ts
+++ b/i18n/asteroid-settings.nl_NL.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatisering</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.nl_NL.ts
+++ b/i18n/asteroid-settings.nl_NL.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Vliegtuigmodus</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.nl_NL.ts
+++ b/i18n/asteroid-settings.nl_NL.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Energiebeheer</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Actief profiel</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Dienst niet beschikbaar</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Snel wisselen</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Alle profielen</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Profielen bewerken</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatisering</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Geen profielen beschikbaar</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation>Dienst is mogelijk niet beschikbaar</translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Profiel selecteren</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Nieuw profiel toevoegen</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profielen</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Training</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Altijd</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Nieuw profiel</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Laden...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensoren</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>Versnellingsmeter</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Hartslag</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Barometer</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Kompas</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Omgevingslicht</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radio&apos;s</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Uitschakelen tijdens slaap</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Systeem</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Achtergrondsynchronisatie</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Batterij- en tijdregels</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Opslaan</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Profiel verwijderen</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Batterijregels</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>Profiel wisselen wanneer batterij drempel bereikt</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>Batterijregel toevoegen</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Tijdregels</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>Profiel wisselen tijdens tijdvenster</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>Tijdregel toevoegen</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>Trainingsprofielen</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.oc.ts
+++ b/i18n/asteroid-settings.oc.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation>Lampa</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.oc.ts
+++ b/i18n/asteroid-settings.oc.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.oc.ts
+++ b/i18n/asteroid-settings.oc.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished">Paramètres</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Gestionòri d&apos;energia</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.pl.ts
+++ b/i18n/asteroid-settings.pl.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Tryb samolotowy</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.pl.ts
+++ b/i18n/asteroid-settings.pl.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Zarządzanie energią</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktywny profil</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Usługa niedostępna</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Szybkie przełączanie</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Wszystkie profile</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Edytuj profile</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatyzacja</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Brak dostępnych profili</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Wybierz profil</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Dodaj nowy profil</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profile</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Trening</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>Tylko sen</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Zawsze</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>Okresowo</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>Ciągle</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>Na żądanie</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Nowy profil</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Ładowanie...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Czujniki</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>Akcelerometr</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>Żyroskop</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Tętno</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Barometr</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Kompas</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Światło otoczenia</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radio</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Wyłącz podczas snu</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Synchronizacja w tle</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Reguły baterii i czasu</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Zapisz</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Usuń profil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Reguły baterii</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>Zmień profil gdy bateria osiągnie próg</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>Dodaj regułę baterii</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Reguły czasu</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>Zmień profil w oknie czasowym</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>Dodaj regułę czasu</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>Profile treningowe</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>Przypisz profil do każdego typu treningu</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>Konfiguruj w ustawieniach aplikacji Trening</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.pl.ts
+++ b/i18n/asteroid-settings.pl.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatyzacja</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.pt.ts
+++ b/i18n/asteroid-settings.pt.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automação</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.pt.ts
+++ b/i18n/asteroid-settings.pt.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Gestor de energia</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Perfil ativo</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Serviço indisponível</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automação</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Perfis</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>A carregar...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensores</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Guardar</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Eliminar perfil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.pt.ts
+++ b/i18n/asteroid-settings.pt.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Modo avião</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.pt_BR.ts
+++ b/i18n/asteroid-settings.pt_BR.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automação</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.pt_BR.ts
+++ b/i18n/asteroid-settings.pt_BR.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Gerenciador de energia</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Perfil ativo</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Serviço indisponível</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Troca rápida</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Todos os perfis</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Editar perfis</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automação</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Nenhum perfil disponível</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Selecionar perfil</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Adicionar novo perfil</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Perfis</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Treino</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>Apenas sono</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Sempre</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>Periódico</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>Contínuo</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>Sob demanda</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Novo perfil</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Carregando...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensores</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>Acelerômetro</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>Giroscópio</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Frequência cardíaca</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Barômetro</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Bússola</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Luz ambiente</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Rádios</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Desativar durante o sono</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Sincronização em segundo plano</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Regras de bateria e horário</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Excluir perfil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Regras de bateria</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>Trocar perfil quando a bateria atingir o limite</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>Adicionar regra de bateria</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Regras de horário</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>Trocar perfil durante janela de tempo</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>Adicionar regra de horário</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>Perfis de treino</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>Atribuir perfil para cada tipo de treino</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>Configurar nas definições do app Treino</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.pt_BR.ts
+++ b/i18n/asteroid-settings.pt_BR.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Modo avião</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.pt_PT.ts
+++ b/i18n/asteroid-settings.pt_PT.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automação</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.pt_PT.ts
+++ b/i18n/asteroid-settings.pt_PT.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Gestor de energia</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Perfil ativo</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Serviço indisponível</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automação</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Perfis</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>A carregar...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensores</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Guardar</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Eliminar perfil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.pt_PT.ts
+++ b/i18n/asteroid-settings.pt_PT.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Modo avião</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.ro.ts
+++ b/i18n/asteroid-settings.ro.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Mod avion</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.ro.ts
+++ b/i18n/asteroid-settings.ro.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatizare</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ro.ts
+++ b/i18n/asteroid-settings.ro.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Manager de energie</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Profil activ</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Serviciu indisponibil</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatizare</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profiluri</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Se încarcă...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Senzori</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Salvare</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Șterge profil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ru.ts
+++ b/i18n/asteroid-settings.ru.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished">Настройки</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Управление энергией</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Активный профиль</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Служба недоступна</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Быстрое переключение</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Все профили</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Редактировать профили</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Автоматизация</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Нет доступных профилей</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation>Служба может быть недоступна</translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Выбрать профиль</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Добавить новый профиль</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Профили</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Тренировка</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>Только сон</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Всегда</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>Периодически</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>Непрерывно</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>По запросу</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Новый профиль</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Загрузка...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Датчики</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>Акселерометр</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>Гироскоп</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Пульс</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Барометр</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Компас</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Освещённость</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Радио</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Отключить во время сна</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Фоновая синхронизация</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Правила батареи и времени</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Удалить профиль</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Правила батареи</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>Переключить профиль при достижении порога батареи</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>Добавить правило батареи</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Правила времени</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>Переключить профиль в заданный период</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>Добавить правило времени</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>Профили тренировок</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>Назначить профиль для каждого типа тренировки</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>Настроить в параметрах приложения Тренировка</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ru.ts
+++ b/i18n/asteroid-settings.ru.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation>Фонарик</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Режим полёта</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.ru.ts
+++ b/i18n/asteroid-settings.ru.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Автоматизация</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.rue.ts
+++ b/i18n/asteroid-settings.rue.ts
@@ -184,5 +184,260 @@
         <source>Airplane Mode</source>
         <translation type="unfinished">Airplane Mode</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Менеджер живленя</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.rue.ts
+++ b/i18n/asteroid-settings.rue.ts
@@ -179,5 +179,10 @@
         <source>Settings</source>
         <translation>Штімованя</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.rue.ts
+++ b/i18n/asteroid-settings.rue.ts
@@ -219,6 +219,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.sk.ts
+++ b/i18n/asteroid-settings.sk.ts
@@ -321,6 +321,51 @@
         <source>Automation</source>
         <translation>Automatizácia</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.sk.ts
+++ b/i18n/asteroid-settings.sk.ts
@@ -258,6 +258,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Režim v lietadle</translation>
+    </message>
     <message id="id-tap-to-cancel">
         <source>Tap to cancel</source>
     </message>

--- a/i18n/asteroid-settings.sk.ts
+++ b/i18n/asteroid-settings.sk.ts
@@ -286,6 +286,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Správca napájania</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktívny profil</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Služba nedostupná</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatizácia</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profily</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Načítava sa...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Senzory</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Systém</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Uložiť</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Odstrániť profil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.sq.ts
+++ b/i18n/asteroid-settings.sq.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatizimi</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.sq.ts
+++ b/i18n/asteroid-settings.sq.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Menaxheri i energjisë</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Profili aktiv</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Shërbimi i padisponueshëm</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatizimi</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profilet</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Po ngarkohet...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensorët</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistemi</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Ruaj</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.sq.ts
+++ b/i18n/asteroid-settings.sq.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.sv.ts
+++ b/i18n/asteroid-settings.sv.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation>Ficklampa</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Flygläge</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.sv.ts
+++ b/i18n/asteroid-settings.sv.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Automatisering</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.sv.ts
+++ b/i18n/asteroid-settings.sv.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished">Inställningar</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Energihantering</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktiv profil</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Tjänst ej tillgänglig</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Snabbyte</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Alla profiler</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Redigera profiler</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Automatisering</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Välj profil</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profiler</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Laddar...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensorer</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Puls</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Kompass</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Omgivande ljus</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radio</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Bakgrundssynkronisering</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Spara</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Ta bort profil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Batteriregler</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Tidsregler</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ta.ts
+++ b/i18n/asteroid-settings.ta.ts
@@ -321,6 +321,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.ta.ts
+++ b/i18n/asteroid-settings.ta.ts
@@ -286,6 +286,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>சக்தி மேலாளர்</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>செயலில் உள்ள சுயவிவரம்</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>சேவை கிடைக்கவில்லை</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>ஏற்றுகிறது...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>உணர்விகள்</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>அமைப்பு</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>சேமி</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.ta.ts
+++ b/i18n/asteroid-settings.ta.ts
@@ -258,6 +258,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
     <message id="id-tap-to-cancel">
         <source>Tap to cancel</source>
     </message>

--- a/i18n/asteroid-settings.te.ts
+++ b/i18n/asteroid-settings.te.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.te.ts
+++ b/i18n/asteroid-settings.te.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>పవర్ మేనేజర్</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>క్రియాశీల ప్రొఫైల్</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>సేవ అందుబాటులో లేదు</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>లోడ్ అవుతోంది...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>సెన్సార్లు</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>సిస్టమ్</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>సేవ్</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.te.ts
+++ b/i18n/asteroid-settings.te.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.th.ts
+++ b/i18n/asteroid-settings.th.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>การจัดการพลังงาน</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>โปรไฟล์ที่ใช้งาน</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>บริการไม่พร้อมใช้งาน</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>สลับเร็ว</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>โปรไฟล์ทั้งหมด</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>แก้ไขโปรไฟล์</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>ระบบอัตโนมัติ</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>โปรไฟล์</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>กำลังโหลด...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>เซ็นเซอร์</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>ระบบ</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>บันทึก</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>ลบโปรไฟล์</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.th.ts
+++ b/i18n/asteroid-settings.th.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>ระบบอัตโนมัติ</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.th.ts
+++ b/i18n/asteroid-settings.th.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>โหมดเครื่องบิน</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.tr.ts
+++ b/i18n/asteroid-settings.tr.ts
@@ -286,6 +286,261 @@
         <source>Settings</source>
         <translation type="unfinished">Ayarlar</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Güç Yöneticisi</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Aktif Profil</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Hizmet kullanılamıyor</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Hızlı Geçiş</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Tüm Profiller</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Profilleri Düzenle</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Otomasyon</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Kullanılabilir profil yok</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Profil Seç</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Yeni Profil Ekle</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Profiller</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Antrenman</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Her zaman</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Yeni Profil</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Yükleniyor...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Sensörler</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>İvmeölçer</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Kalp Atış Hızı</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Barometre</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Pusula</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Ortam Işığı</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Radyolar</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Uyku sırasında devre dışı bırak</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Arka Plan Senkronizasyonu</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Pil ve Zaman Kuralları</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Kaydet</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Profili Sil</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Pil Kuralları</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>Pil eşiğe ulaştığında profil değiştir</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>Pil Kuralı Ekle</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Zaman Kuralları</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>Zaman aralığında profil değiştir</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>Zaman Kuralı Ekle</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>Antrenman Profilleri</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.tr.ts
+++ b/i18n/asteroid-settings.tr.ts
@@ -321,6 +321,51 @@
         <source>Automation</source>
         <translation>Otomasyon</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.tr.ts
+++ b/i18n/asteroid-settings.tr.ts
@@ -258,6 +258,11 @@
         <source>Flashlight</source>
         <translation>El feneri</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Uçak modu</translation>
+    </message>
     <message id="id-tap-to-cancel">
         <source>Tap to cancel</source>
     </message>

--- a/i18n/asteroid-settings.tzm.ts
+++ b/i18n/asteroid-settings.tzm.ts
@@ -204,6 +204,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.tzm.ts
+++ b/i18n/asteroid-settings.tzm.ts
@@ -169,5 +169,260 @@
         <source>Airplane Mode</source>
         <translation type="unfinished">Airplane Mode</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Amsefrak n tezzmert</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.tzm.ts
+++ b/i18n/asteroid-settings.tzm.ts
@@ -164,5 +164,10 @@
         <source>Settings</source>
         <translation>Tisɣal</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.uk.ts
+++ b/i18n/asteroid-settings.uk.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Автоматизація</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.uk.ts
+++ b/i18n/asteroid-settings.uk.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation>Ліхтарик</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Режим польоту</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.uk.ts
+++ b/i18n/asteroid-settings.uk.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished">Налаштування</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Керування живленням</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Активний профіль</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Служба недоступна</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Швидке перемикання</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Усі профілі</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Редагувати профілі</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Автоматизація</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>Немає доступних профілів</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>Вибрати профіль</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>Додати новий профіль</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Профілі</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>Тренування</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>Лише сон</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>Завжди</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>Періодично</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>Безперервно</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>За запитом</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>Новий профіль</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Завантаження...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Датчики</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>Акселерометр</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>Гіроскоп</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>Пульс</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>Барометр</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>Компас</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>Освітленість</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Радіо</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>Вимкнути під час сну</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>Фонова синхронізація</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>Правила батареї та часу</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Зберегти</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Видалити профіль</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>Правила батареї</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>Перемикати профіль при досягненні порогу батареї</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>Додати правило батареї</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>Правила часу</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>Перемикати профіль у часовому вікні</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>Додати правило часу</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>Профілі тренувань</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>Призначити профіль для кожного типу тренування</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>Налаштувати в параметрах додатку Тренування</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.vec.ts
+++ b/i18n/asteroid-settings.vec.ts
@@ -204,6 +204,51 @@
         <source>Automation</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.vec.ts
+++ b/i18n/asteroid-settings.vec.ts
@@ -169,5 +169,260 @@
         <source>Airplane Mode</source>
         <translation type="unfinished">Airplane Mode</translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Gestor de enerxia</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.vec.ts
+++ b/i18n/asteroid-settings.vec.ts
@@ -164,5 +164,10 @@
         <source>Settings</source>
         <translation>Configurasion</translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation type="unfinished">Airplane Mode</translation>
+    </message>
 </context>
 </TS>

--- a/i18n/asteroid-settings.vi.ts
+++ b/i18n/asteroid-settings.vi.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>Tự động hóa</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.vi.ts
+++ b/i18n/asteroid-settings.vi.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>Chế độ máy bay</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.vi.ts
+++ b/i18n/asteroid-settings.vi.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>Quản lý nguồn</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>Hồ sơ đang dùng</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>Dịch vụ không khả dụng</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>Chuyển nhanh</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>Tất cả hồ sơ</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>Chỉnh sửa hồ sơ</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>Tự động hóa</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>Hồ sơ</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>Đang tải...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>Cảm biến</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>Sóng vô tuyến</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>Hệ thống</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>Lưu</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>Xóa hồ sơ</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.zh_Hans.ts
+++ b/i18n/asteroid-settings.zh_Hans.ts
@@ -286,6 +286,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>电源管理</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>当前配置</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>服务不可用</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>快速切换</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>所有配置</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>编辑配置</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>自动化</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>没有可用的配置</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation>服务可能不可用</translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>选择配置</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>添加新配置</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>配置</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>运动</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>仅睡眠</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>始终</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation>定期</translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation>连续</translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation>按需</translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>新配置</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>加载中...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>传感器</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>加速度计</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>陀螺仪</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>心率</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>气压计</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>指南针</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>环境光</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>无线电</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>睡眠时禁用</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>系统</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>后台同步</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>电池和时间规则</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>删除配置</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>电池规则</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>当电池达到阈值时切换配置</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>添加电池规则</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>时间规则</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>在时间窗口内切换配置</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>添加时间规则</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>运动配置</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation>为每种运动类型分配配置</translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation>在运动应用设置中配置</translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.zh_Hans.ts
+++ b/i18n/asteroid-settings.zh_Hans.ts
@@ -321,6 +321,51 @@
         <source>Automation</source>
         <translation>自动化</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/i18n/asteroid-settings.zh_Hans.ts
+++ b/i18n/asteroid-settings.zh_Hans.ts
@@ -258,6 +258,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>飞行模式</translation>
+    </message>
     <message id="id-tap-to-cancel">
         <source>Tap to cancel</source>
     </message>

--- a/i18n/asteroid-settings.zh_Hant.ts
+++ b/i18n/asteroid-settings.zh_Hant.ts
@@ -311,6 +311,11 @@
         <source>Flashlight</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-toggle-airplane-mode">
+        <location filename="../src/qml/QuickPanelPage.qml" line="130"/>
+        <source>Airplane Mode</source>
+        <translation>飛行模式</translation>
+    </message>
     <message id="id-fixed-row">
         <location filename="../src/qml/QuickPanelPage.qml" line="154"/>
         <source>Fixed Row</source>

--- a/i18n/asteroid-settings.zh_Hant.ts
+++ b/i18n/asteroid-settings.zh_Hant.ts
@@ -376,6 +376,261 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message id="id-power-manager-page">
+        <location filename="../src/qml/main.qml" line="176"/>
+        <source>Power Manager</source>
+        <translation>電源管理</translation>
+    </message>
+    <message id="id-active-profile">
+        <location filename="../src/qml/PowerManagerPage.qml" line="170"/>
+        <source>Active Profile</source>
+        <translation>目前設定檔</translation>
+    </message>
+    <message id="id-service-unavailable">
+        <location filename="../src/qml/PowerManagerPage.qml" line="189"/>
+        <source>Service unavailable</source>
+        <translation>服務無法使用</translation>
+    </message>
+    <message id="id-quick-switch">
+        <location filename="../src/qml/PowerManagerPage.qml" line="241"/>
+        <source>Quick Switch</source>
+        <translation>快速切換</translation>
+    </message>
+    <message id="id-all-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="295"/>
+        <source>All Profiles</source>
+        <translation>所有設定檔</translation>
+    </message>
+    <message id="id-edit-profiles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="306"/>
+        <source>Edit Profiles</source>
+        <translation>編輯設定檔</translation>
+    </message>
+    <message id="id-automation">
+        <location filename="../src/qml/PowerManagerPage.qml" line="318"/>
+        <source>Automation</source>
+        <translation>自動化</translation>
+    </message>
+    <message id="id-no-profiles">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
+        <source>No profiles available</source>
+        <translation>沒有可用的設定檔</translation>
+    </message>
+    <message id="id-service-may-be-unavailable">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="154"/>
+        <source>Service may be unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-select-profile">
+        <location filename="../src/qml/ProfileSelectorPage.qml" line="165"/>
+        <source>Select Profile</source>
+        <translation>選擇設定檔</translation>
+    </message>
+    <message id="id-add-new-profile">
+        <location filename="../src/qml/ProfileListPage.qml" line="152"/>
+        <source>Add New Profile</source>
+        <translation>新增設定檔</translation>
+    </message>
+    <message id="id-profiles">
+        <location filename="../src/qml/ProfileListPage.qml" line="202"/>
+        <source>Profiles</source>
+        <translation>設定檔</translation>
+    </message>
+    <message id="id-workout">
+        <location filename="../src/qml/ProfileEditPage.qml" line="36"/>
+        <source>Workout</source>
+        <translation>運動</translation>
+    </message>
+    <message id="id-sleep-only">
+        <location filename="../src/qml/ProfileEditPage.qml" line="37"/>
+        <source>Sleep only</source>
+        <translation>僅睡眠</translation>
+    </message>
+    <message id="id-always">
+        <location filename="../src/qml/ProfileEditPage.qml" line="38"/>
+        <source>Always</source>
+        <translation>始終</translation>
+    </message>
+    <message id="id-periodic">
+        <location filename="../src/qml/ProfileEditPage.qml" line="39"/>
+        <source>Periodic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-continuous">
+        <location filename="../src/qml/ProfileEditPage.qml" line="40"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-on-demand">
+        <location filename="../src/qml/ProfileEditPage.qml" line="41"/>
+        <source>On demand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-new-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="61"/>
+        <source>New Profile</source>
+        <translation>新設定檔</translation>
+    </message>
+    <message id="id-loading">
+        <location filename="../src/qml/ProfileEditPage.qml" line="197"/>
+        <source>Loading...</source>
+        <translation>載入中...</translation>
+    </message>
+    <message id="id-sensors">
+        <location filename="../src/qml/ProfileEditPage.qml" line="228"/>
+        <source>Sensors</source>
+        <translation>感測器</translation>
+    </message>
+    <message id="id-accelerometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="239"/>
+        <source>Accelerometer</source>
+        <translation>加速度計</translation>
+    </message>
+    <message id="id-gyroscope">
+        <location filename="../src/qml/ProfileEditPage.qml" line="253"/>
+        <source>Gyroscope</source>
+        <translation>陀螺儀</translation>
+    </message>
+    <message id="id-heart-rate">
+        <location filename="../src/qml/ProfileEditPage.qml" line="267"/>
+        <source>Heart Rate</source>
+        <translation>心率</translation>
+    </message>
+    <message id="id-hrv">
+        <location filename="../src/qml/ProfileEditPage.qml" line="281"/>
+        <source>HRV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-spo2">
+        <location filename="../src/qml/ProfileEditPage.qml" line="295"/>
+        <source>SpO2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-barometer">
+        <location filename="../src/qml/ProfileEditPage.qml" line="309"/>
+        <source>Barometer</source>
+        <translation>氣壓計</translation>
+    </message>
+    <message id="id-compass">
+        <location filename="../src/qml/ProfileEditPage.qml" line="323"/>
+        <source>Compass</source>
+        <translation>指南針</translation>
+    </message>
+    <message id="id-ambient-light">
+        <location filename="../src/qml/ProfileEditPage.qml" line="337"/>
+        <source>Ambient Light</source>
+        <translation>環境光</translation>
+    </message>
+    <message id="id-gps">
+        <location filename="../src/qml/ProfileEditPage.qml" line="351"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-radios">
+        <location filename="../src/qml/ProfileEditPage.qml" line="372"/>
+        <source>Radios</source>
+        <translation>無線電</translation>
+    </message>
+    <message id="id-bluetooth">
+        <location filename="../src/qml/ProfileEditPage.qml" line="383"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="397"/>
+        <source>BLE Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-interval">
+        <location filename="../src/qml/ProfileEditPage.qml" line="414"/>
+        <source>BLE Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-ble-disable-sleep">
+        <location filename="../src/qml/ProfileEditPage.qml" line="431"/>
+        <source>Disable during sleep</source>
+        <translation>睡眠時停用</translation>
+    </message>
+    <message id="id-wifi">
+        <location filename="../src/qml/ProfileEditPage.qml" line="446"/>
+        <source>Wi-Fi</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-wifi-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="460"/>
+        <source>Wi-Fi Sync</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-system">
+        <location filename="../src/qml/ProfileEditPage.qml" line="483"/>
+        <source>System</source>
+        <translation>系統</translation>
+    </message>
+    <message id="id-background-sync">
+        <location filename="../src/qml/ProfileEditPage.qml" line="520"/>
+        <source>Background Sync</source>
+        <translation>背景同步</translation>
+    </message>
+    <message id="id-battery-time-rules">
+        <location filename="../src/qml/ProfileEditPage.qml" line="552"/>
+        <source>Battery / Time Rules</source>
+        <translation>電池與時間規則</translation>
+    </message>
+    <message id="id-save">
+        <location filename="../src/qml/ProfileEditPage.qml" line="584"/>
+        <source>Save</source>
+        <translation>儲存</translation>
+    </message>
+    <message id="id-delete-profile">
+        <location filename="../src/qml/ProfileEditPage.qml" line="611"/>
+        <source>Delete Profile</source>
+        <translation>刪除設定檔</translation>
+    </message>
+    <message id="id-battery-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="92"/>
+        <source>Battery Rules</source>
+        <translation>電池規則</translation>
+    </message>
+    <message id="id-battery-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="103"/>
+        <source>Switch profile when battery reaches threshold</source>
+        <translation>當電池達到閾值時切換設定檔</translation>
+    </message>
+    <message id="id-add-battery-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="144"/>
+        <source>Add Battery Rule</source>
+        <translation>新增電池規則</translation>
+    </message>
+    <message id="id-time-rules">
+        <location filename="../src/qml/AutomationEditPage.qml" line="163"/>
+        <source>Time Rules</source>
+        <translation>時間規則</translation>
+    </message>
+    <message id="id-time-rules-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="174"/>
+        <source>Switch profile during time window</source>
+        <translation>在時間窗口內切換設定檔</translation>
+    </message>
+    <message id="id-add-time-rule">
+        <location filename="../src/qml/AutomationEditPage.qml" line="215"/>
+        <source>Add Time Rule</source>
+        <translation>新增時間規則</translation>
+    </message>
+    <message id="id-workout-profiles">
+        <location filename="../src/qml/AutomationEditPage.qml" line="234"/>
+        <source>Workout Profiles</source>
+        <translation>運動設定檔</translation>
+    </message>
+    <message id="id-workout-profiles-desc">
+        <location filename="../src/qml/AutomationEditPage.qml" line="245"/>
+        <source>Assign profile for each workout type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-workout-configure-in-app">
+        <location filename="../src/qml/AutomationEditPage.qml" line="256"/>
+        <source>Configure in Workout app settings</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AboutPage</name>

--- a/i18n/asteroid-settings.zh_Hant.ts
+++ b/i18n/asteroid-settings.zh_Hant.ts
@@ -411,6 +411,51 @@
         <source>Automation</source>
         <translation>自動化</translation>
     </message>
+    <message id="id-battery-health">
+        <location filename="../src/qml/PowerManagerPage.qml" line="477"/>
+        <source>Battery Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-charge-cycles">
+        <location filename="../src/qml/PowerManagerPage.qml" line="547"/>
+        <source>%1 charge cycles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-high">
+        <location filename="../src/qml/PowerManagerPage.qml" line="564"/>
+        <source>Accuracy: High (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-medium">
+        <location filename="../src/qml/PowerManagerPage.qml" line="567"/>
+        <source>Accuracy: Medium (%1 samples)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-accuracy-low">
+        <location filename="../src/qml/PowerManagerPage.qml" line="570"/>
+        <source>Accuracy: Improving...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-excellent">
+        <location filename="../src/qml/PowerManagerPage.qml" line="588"/>
+        <source>Battery is in excellent condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-good">
+        <location filename="../src/qml/PowerManagerPage.qml" line="591"/>
+        <source>Battery is in good condition</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-worn">
+        <location filename="../src/qml/PowerManagerPage.qml" line="594"/>
+        <source>Battery is showing wear — consider replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="id-health-degraded">
+        <location filename="../src/qml/PowerManagerPage.qml" line="596"/>
+        <source>Battery is significantly degraded</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message id="id-no-profiles">
         <location filename="../src/qml/ProfileSelectorPage.qml" line="145"/>
         <source>No profiles available</source>

--- a/src/qml/AutomationEditPage.qml
+++ b/src/qml/AutomationEditPage.qml
@@ -39,7 +39,7 @@ Item {
         }
 
         function loadProfile() {
-            typedCall("GetProfile", [profileId], function(result) {
+            typedCall("GetProfile", [{"type": "s", "value": profileId}], function(result) {
                 var p = JSON.parse(result)
                 profile = p
                 automation = p.automation || {
@@ -59,11 +59,13 @@ Item {
         profile.automation = automation
         var profileJson = JSON.stringify(profile)
         
-        powerd.typedCall("UpdateProfile", [profileJson], function(success) {
-            if (success) {
-                layerStack.pop(root)
-            }
-        }, powerd.handleError)
+        powerd.typedCall("UpdateProfile",
+            [{"type": "s", "value": profileJson}],
+            function(success) {
+                if (success) {
+                    layerStack.pop(root)
+                }
+            }, powerd.handleError)
     }
 
     Flickable {
@@ -116,22 +118,27 @@ Item {
                     spacing: 0
 
                     ListItem {
+                        id: batteryRuleItem
                         height: Dims.h(15)
                         width: parent.width
                         title: modelData.threshold + "% → " + modelData.switch_to_profile
-                        iconName: "ios-battery-charging-outline"
+                        iconName: "ios-battery-charging"
+                    }
 
+                    MouseArea {
+                        anchors.fill: batteryRuleItem
                         onPressAndHold: {
-                            deleteRuleRemorse.execute(this, "", function() {
+                            deleteRuleRemorse.execute(batteryRuleItem, "", function() {
                                 var rules = automation.battery_rules.slice()
                                 rules.splice(index, 1)
                                 automation.battery_rules = rules
                             })
                         }
+                        onClicked: batteryRuleItem.clicked()
+                    }
 
-                        RemorseTimer {
-                            id: deleteRuleRemorse
-                        }
+                    RemorseTimer {
+                        id: deleteRuleRemorse
                     }
 
                     RowSeparator {}
@@ -187,22 +194,27 @@ Item {
                     spacing: 0
 
                     ListItem {
+                        id: timeRuleItem
                         height: Dims.h(15)
                         width: parent.width
                         title: modelData.start + " - " + modelData.end + " → " + modelData.switch_to_profile
                         iconName: "ios-time-outline"
+                    }
 
+                    MouseArea {
+                        anchors.fill: timeRuleItem
                         onPressAndHold: {
-                            deleteTimeRuleRemorse.execute(this, "", function() {
+                            deleteTimeRuleRemorse.execute(timeRuleItem, "", function() {
                                 var rules = automation.time_rules.slice()
                                 rules.splice(index, 1)
                                 automation.time_rules = rules
                             })
                         }
+                        onClicked: timeRuleItem.clicked()
+                    }
 
-                        RemorseTimer {
-                            id: deleteTimeRuleRemorse
-                        }
+                    RemorseTimer {
+                        id: deleteTimeRuleRemorse
                     }
 
                     RowSeparator {}

--- a/src/qml/AutomationEditPage.qml
+++ b/src/qml/AutomationEditPage.qml
@@ -1,0 +1,304 @@
+/*
+ * Copyright (C) 2024 - AsteroidOS Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
+import Nemo.DBus 2.0
+
+Item {
+    id: root
+
+    property string profileId: ""
+    property var profile: ({})
+    property var automation: ({})
+
+    DBusInterface {
+        id: powerd
+        bus: DBus.SystemBus
+        service: "org.asteroidos.powerd"
+        path: "/org/asteroidos/powerd"
+        iface: "org.asteroidos.powerd.ProfileManager"
+
+        function handleError(error) {
+            console.log("Automation Edit D-Bus error:", error)
+        }
+
+        function loadProfile() {
+            typedCall("GetProfile", [profileId], function(result) {
+                var p = JSON.parse(result)
+                profile = p
+                automation = p.automation || {
+                    "battery_rules": [],
+                    "time_rules": [],
+                    "workout_profiles": {}
+                }
+            }, handleError)
+        }
+
+        Component.onCompleted: {
+            loadProfile()
+        }
+    }
+
+    function saveAutomation() {
+        profile.automation = automation
+        var profileJson = JSON.stringify(profile)
+        
+        powerd.typedCall("UpdateProfile", [profileJson], function(success) {
+            if (success) {
+                layerStack.pop(root)
+            }
+        }, powerd.handleError)
+    }
+
+    Flickable {
+        anchors.fill: parent
+        anchors.topMargin: Dims.h(15)
+        anchors.bottomMargin: Dims.h(5)
+        contentHeight: contentColumn.implicitHeight
+        clip: true
+
+        Column {
+            id: contentColumn
+            anchors.left: parent.left
+            anchors.right: parent.right
+            spacing: 0
+
+            Item {
+                width: parent.width
+                height: Dims.h(3)
+            }
+
+            Label {
+                width: parent.width
+                height: Dims.h(10)
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                //% "Battery Rules"
+                text: qsTrId("id-battery-rules")
+                font.pixelSize: Dims.l(6)
+                opacity: 0.8
+            }
+
+            RowSeparator {}
+
+            Label {
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+                //% "Switch profile when battery reaches threshold"
+                text: qsTrId("id-battery-rules-desc")
+                font.pixelSize: Dims.l(3)
+                color: "#80FFFFFF"
+                wrapMode: Text.WordWrap
+                padding: Dims.w(4)
+            }
+
+            Repeater {
+                model: automation.battery_rules || []
+
+                Column {
+                    width: parent.width
+                    spacing: 0
+
+                    ListItem {
+                        height: Dims.h(15)
+                        width: parent.width
+                        title: modelData.threshold + "% → " + modelData.switch_to_profile
+                        iconName: "ios-battery-charging-outline"
+
+                        onPressAndHold: {
+                            deleteRuleRemorse.execute(this, "", function() {
+                                var rules = automation.battery_rules.slice()
+                                rules.splice(index, 1)
+                                automation.battery_rules = rules
+                            })
+                        }
+
+                        RemorseTimer {
+                            id: deleteRuleRemorse
+                        }
+                    }
+
+                    RowSeparator {}
+                }
+            }
+
+            ListItem {
+                height: Dims.h(15)
+                width: parent.width
+                //% "Add Battery Rule"
+                title: qsTrId("id-add-battery-rule")
+                iconName: "ios-add-circle-outline"
+                enabled: false
+                opacity: 0.5
+            }
+
+            RowSeparator {}
+
+            Item {
+                width: parent.width
+                height: Dims.h(5)
+            }
+
+            Label {
+                width: parent.width
+                height: Dims.h(10)
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                //% "Time Rules"
+                text: qsTrId("id-time-rules")
+                font.pixelSize: Dims.l(6)
+                opacity: 0.8
+            }
+
+            RowSeparator {}
+
+            Label {
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+                //% "Switch profile during time window"
+                text: qsTrId("id-time-rules-desc")
+                font.pixelSize: Dims.l(3)
+                color: "#80FFFFFF"
+                wrapMode: Text.WordWrap
+                padding: Dims.w(4)
+            }
+
+            Repeater {
+                model: automation.time_rules || []
+
+                Column {
+                    width: parent.width
+                    spacing: 0
+
+                    ListItem {
+                        height: Dims.h(15)
+                        width: parent.width
+                        title: modelData.start + " - " + modelData.end + " → " + modelData.switch_to_profile
+                        iconName: "ios-time-outline"
+
+                        onPressAndHold: {
+                            deleteTimeRuleRemorse.execute(this, "", function() {
+                                var rules = automation.time_rules.slice()
+                                rules.splice(index, 1)
+                                automation.time_rules = rules
+                            })
+                        }
+
+                        RemorseTimer {
+                            id: deleteTimeRuleRemorse
+                        }
+                    }
+
+                    RowSeparator {}
+                }
+            }
+
+            ListItem {
+                height: Dims.h(15)
+                width: parent.width
+                //% "Add Time Rule"
+                title: qsTrId("id-add-time-rule")
+                iconName: "ios-add-circle-outline"
+                enabled: false
+                opacity: 0.5
+            }
+
+            RowSeparator {}
+
+            Item {
+                width: parent.width
+                height: Dims.h(5)
+            }
+
+            Label {
+                width: parent.width
+                height: Dims.h(10)
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                //% "Workout Profiles"
+                text: qsTrId("id-workout-profiles")
+                font.pixelSize: Dims.l(6)
+                opacity: 0.8
+            }
+
+            RowSeparator {}
+
+            Label {
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+                //% "Assign profile for each workout type"
+                text: qsTrId("id-workout-profiles-desc")
+                font.pixelSize: Dims.l(3)
+                color: "#80FFFFFF"
+                wrapMode: Text.WordWrap
+                padding: Dims.w(4)
+            }
+
+            Label {
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+                //% "Configure in Workout app settings"
+                text: qsTrId("id-workout-configure-in-app")
+                font.pixelSize: Dims.l(3)
+                color: "#80FFFFFF"
+                wrapMode: Text.WordWrap
+                padding: Dims.w(4)
+            }
+
+            RowSeparator {}
+
+            Item {
+                width: parent.width
+                height: Dims.h(8)
+            }
+
+            Item {
+                width: parent.width
+                height: Dims.h(18)
+
+                IconButton {
+                    anchors.centerIn: parent
+                    width: parent.width * 0.8
+                    height: Dims.h(15)
+                    iconName: "ios-checkmark-circle-outline"
+                    iconColor: "#4CAF50"
+
+                    onClicked: saveAutomation()
+                }
+
+                Label {
+                    anchors.centerIn: parent
+                    //% "Save"
+                    text: qsTrId("id-save")
+                    font.pixelSize: Dims.l(6)
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: Dims.h(5)
+            }
+        }
+    }
+
+    PageHeader {
+        //% "Automation"
+        text: qsTrId("id-automation")
+    }
+}

--- a/src/qml/BatteryHistoryGraph.qml
+++ b/src/qml/BatteryHistoryGraph.qml
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2024 - AsteroidOS Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
+
+/*
+ * BatteryHistoryGraph — Canvas-drawn 7-day battery history chart with
+ * smooth bezier curves, gradient fill that fades from opaque near the
+ * line to transparent at the bottom, and a dashed prediction line.
+ */
+Canvas {
+    id: graph
+
+    property var historyData: []
+    property real currentLevel: 0
+    property real drainRatePerHour: 0
+    property bool isCharging: false
+
+    onHistoryDataChanged: requestPaint()
+    onCurrentLevelChanged: requestPaint()
+    onDrainRatePerHourChanged: requestPaint()
+    onWidthChanged: requestPaint()
+    onHeightChanged: requestPaint()
+
+    onPaint: {
+        var ctx = getContext("2d")
+        ctx.clearRect(0, 0, width, height)
+
+        if (width <= 0 || height <= 0) return
+
+        var leftPad   = width * 0.10
+        var rightPad  = width * 0.03
+        var topPad    = height * 0.08
+        var bottomPad = height * 0.20
+        var chartW = width - leftPad - rightPad
+        var chartH = height - topPad - bottomPad
+        var chartBottom = topPad + chartH
+
+        var now = Math.floor(Date.now() / 1000)
+        var historySpan = 7 * 24 * 3600
+        var totalSpan   = 8 * 24 * 3600
+        var startTime   = now - historySpan
+
+        function timeToX(t) {
+            return leftPad + ((t - startTime) / totalSpan) * chartW
+        }
+        function levelToY(l) {
+            return topPad + chartH * (1.0 - l / 100.0)
+        }
+
+        // --- Gridlines ---
+        ctx.strokeStyle = "rgba(255,255,255,0.12)"
+        ctx.lineWidth = 1
+        var gridLevels = [25, 50, 75, 100]
+        for (var g = 0; g < gridLevels.length; g++) {
+            var gy = levelToY(gridLevels[g])
+            ctx.beginPath()
+            ctx.moveTo(leftPad, gy)
+            ctx.lineTo(leftPad + chartW, gy)
+            ctx.stroke()
+        }
+
+        // --- Y-axis labels ---
+        var fontSize = Math.max(8, Math.round(height * 0.10))
+        ctx.fillStyle = "rgba(255,255,255,0.5)"
+        ctx.font = fontSize + "px sans-serif"
+        ctx.textAlign = "right"
+        ctx.textBaseline = "middle"
+        ctx.fillText("100", leftPad - 3, levelToY(100))
+        ctx.fillText("50",  leftPad - 3, levelToY(50))
+
+        // --- Day labels ---
+        ctx.textAlign = "center"
+        ctx.textBaseline = "top"
+        var dayAbbr = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"]
+        for (var d = 0; d < 7; d++) {
+            var dayMid = startTime + d * 24 * 3600 + 12 * 3600
+            var dx = timeToX(dayMid)
+            var dd = new Date(dayMid * 1000)
+            ctx.fillText(dayAbbr[dd.getDay()], dx, chartBottom + 3)
+        }
+
+        // --- "Now" vertical marker ---
+        var nowX = timeToX(now)
+        ctx.strokeStyle = "rgba(255,255,255,0.35)"
+        ctx.lineWidth = 1
+        ctx.beginPath()
+        ctx.moveTo(nowX, topPad)
+        ctx.lineTo(nowX, chartBottom)
+        ctx.stroke()
+
+        ctx.fillStyle = "rgba(255,255,255,0.4)"
+        ctx.textAlign = "center"
+        ctx.textBaseline = "bottom"
+        ctx.fillText("now", nowX, topPad - 1)
+
+        // --- Battery history ---
+        if (historyData.length > 0) {
+            var sorted = historyData.slice().sort(function(a, b) {
+                return a.timestamp - b.timestamp
+            })
+
+            // Filter to visible range
+            var visible = []
+            var lastBefore = null
+            for (var i = 0; i < sorted.length; i++) {
+                if (sorted[i].timestamp < startTime) {
+                    lastBefore = sorted[i]
+                } else {
+                    visible.push(sorted[i])
+                }
+            }
+            if (visible.length === 0 && lastBefore)
+                visible.push(lastBefore)
+            if (visible.length > 0 && lastBefore && visible[0] !== lastBefore)
+                visible.unshift(lastBefore)
+
+            if (visible.length >= 2) {
+                // Build point arrays
+                var pts = []
+                for (var i = 0; i < visible.length; i++) {
+                    pts.push({
+                        x: timeToX(Math.max(visible[i].timestamp, startTime)),
+                        y: levelToY(visible[i].level)
+                    })
+                }
+
+                // --- Smooth bezier curve using Catmull-Rom spline ---
+                // --- Smooth bezier curve using Catmull-Rom spline ---
+                // continuePath: draws bezier segments from current pen position
+                function traceSmoothSegments(ctx, pts) {
+                    if (pts.length < 2) return
+                    if (pts.length === 2) {
+                        ctx.lineTo(pts[1].x, pts[1].y)
+                        return
+                    }
+                    var tension = 0.3
+                    for (var i = 0; i < pts.length - 1; i++) {
+                        var p0 = pts[Math.max(0, i - 1)]
+                        var p1 = pts[i]
+                        var p2 = pts[i + 1]
+                        var p3 = pts[Math.min(pts.length - 1, i + 2)]
+                        var cp1x = p1.x + (p2.x - p0.x) * tension
+                        var cp1y = p1.y + (p2.y - p0.y) * tension
+                        var cp2x = p2.x - (p3.x - p1.x) * tension
+                        var cp2y = p2.y - (p3.y - p1.y) * tension
+                        ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, p2.x, p2.y)
+                    }
+                }
+
+                // --- Gradient fill under smooth curve ---
+                ctx.beginPath()
+                ctx.moveTo(pts[0].x, chartBottom)
+                ctx.lineTo(pts[0].x, pts[0].y)
+                traceSmoothSegments(ctx, pts)
+                ctx.lineTo(pts[pts.length - 1].x, chartBottom)
+                ctx.closePath()
+
+                var grad = ctx.createLinearGradient(0, topPad, 0, chartBottom)
+                grad.addColorStop(0.0, "rgba(255,152,0,0.70)")
+                grad.addColorStop(0.35, "rgba(255,152,0,0.30)")
+                grad.addColorStop(0.65, "rgba(255,152,0,0.08)")
+                grad.addColorStop(1.0, "rgba(255,152,0,0.01)")
+                ctx.fillStyle = grad
+                ctx.fill()
+
+                // --- Green overlay for charging segments ---
+                for (var i = 0; i < visible.length - 1; i++) {
+                    if (visible[i].charging) {
+                        var cx1 = timeToX(visible[i].timestamp)
+                        var cy1 = levelToY(visible[i].level)
+                        var cx2 = timeToX(visible[i + 1].timestamp)
+                        var cy2 = levelToY(visible[i + 1].level)
+                        ctx.beginPath()
+                        ctx.moveTo(cx1, chartBottom)
+                        ctx.lineTo(cx1, cy1)
+                        ctx.lineTo(cx2, cy2)
+                        ctx.lineTo(cx2, chartBottom)
+                        ctx.closePath()
+                        var cGrad = ctx.createLinearGradient(0, Math.min(cy1, cy2), 0, chartBottom)
+                        cGrad.addColorStop(0.0, "rgba(76,175,80,0.55)")
+                        cGrad.addColorStop(0.5, "rgba(76,175,80,0.18)")
+                        cGrad.addColorStop(1.0, "rgba(76,175,80,0.01)")
+                        ctx.fillStyle = cGrad
+                        ctx.fill()
+                    }
+                }
+
+                // --- Smooth stroke on top (the visible line) ---
+                ctx.beginPath()
+                ctx.moveTo(pts[0].x, pts[0].y)
+                traceSmoothSegments(ctx, pts)
+                ctx.strokeStyle = "#FF9800"
+                ctx.lineWidth = 2
+                ctx.stroke()
+
+            } else if (visible.length === 1) {
+                var px = timeToX(Math.max(visible[0].timestamp, startTime))
+                var py = levelToY(visible[0].level)
+                ctx.beginPath()
+                ctx.arc(px, py, 3, 0, 2 * Math.PI)
+                ctx.fillStyle = "#FF9800"
+                ctx.fill()
+            }
+        }
+
+        // --- Prediction dashed line ---
+        if (drainRatePerHour > 0 && !isCharging && currentLevel > 0) {
+            var predStartX = nowX
+            var predStartY = levelToY(currentLevel)
+            var hoursToEmpty = currentLevel / drainRatePerHour
+            var emptyTime = now + hoursToEmpty * 3600
+            var predEndX = timeToX(emptyTime)
+            var predEndY = levelToY(0)
+
+            if (predEndX > leftPad + chartW) {
+                var ratio = (leftPad + chartW - predStartX) / (predEndX - predStartX)
+                predEndX = leftPad + chartW
+                predEndY = predStartY + ratio * (levelToY(0) - predStartY)
+            }
+
+            ctx.strokeStyle = "#F44336"
+            ctx.lineWidth = 1.5
+            var pdx = predEndX - predStartX
+            var pdy = predEndY - predStartY
+            var dist = Math.sqrt(pdx * pdx + pdy * pdy)
+            if (dist > 0) {
+                var dashLen = 5, gapLen = 4
+                var drawn = 0, on = true
+                while (drawn < dist) {
+                    var segLen = on ? dashLen : gapLen
+                    if (drawn + segLen > dist) segLen = dist - drawn
+                    var t1 = drawn / dist
+                    var t2 = (drawn + segLen) / dist
+                    if (on) {
+                        ctx.beginPath()
+                        ctx.moveTo(predStartX + t1 * pdx, predStartY + t1 * pdy)
+                        ctx.lineTo(predStartX + t2 * pdx, predStartY + t2 * pdy)
+                        ctx.stroke()
+                    }
+                    drawn += segLen
+                    on = !on
+                }
+            }
+        }
+    }
+}

--- a/src/qml/CompactListItem.qml
+++ b/src/qml/CompactListItem.qml
@@ -1,0 +1,51 @@
+/*
+ * CompactListItem — Same as ListItem but with reduced icon-to-text spacing.
+ *
+ * Icon leftMargin halved: Dims.w(18) → Dims.w(12)
+ * Label leftMargin halved: Dims.w(6) → Dims.w(3)
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
+
+Item {
+    property alias title: label.text
+    property alias iconName: icon.name
+    property alias highlight: highlight.forceOn
+    property int iconSize: height - Dims.h(6)
+    property int labelFontSize: Dims.l(9)
+    signal clicked()
+
+    width: parent.width
+    height: Dims.h(21)
+
+    HighlightBar {
+        id: highlight
+        onClicked: parent.clicked()
+    }
+
+    Icon {
+        id: icon
+        width: iconSize
+        height: width
+        anchors {
+            verticalCenter: parent.verticalCenter
+            left: parent.left
+            leftMargin: DeviceSpecs.hasRoundScreen ? Dims.w(8) : Dims.w(5)
+        }
+    }
+
+    Label {
+        id: label
+        anchors {
+            leftMargin: Dims.w(1)
+            left: icon.right
+            verticalCenter: parent.verticalCenter
+        }
+        font {
+            pixelSize: labelFontSize
+            styleName: "SemiCondensed Light"
+        }
+    }
+}

--- a/src/qml/FillBarRow.qml
+++ b/src/qml/FillBarRow.qml
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2024 - AsteroidOS Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
+
+/*
+ * FillBarRow — A setting row with a vertical fill-bar indicator on the right.
+ *
+ * For binary values (e.g. ["off","on"]):
+ *   off  → bar is fully grey
+ *   on   → bar is fully green
+ *
+ * For multi-level values (e.g. ["off","low","medium","high","workout"]):
+ *   off     → 0% filled  (all grey)
+ *   low     → 25% filled (green from bottom)
+ *   medium  → 50% filled
+ *   high    → 75% filled
+ *   workout → 100% filled (all green)
+ *
+ * Clicking the row cycles to the next value.
+ */
+ListRow {
+    id: root
+
+    property var valueArray: []
+    property string currentValue: ""
+
+    signal valueChanged(string value)
+
+    // Shrink the action slot so the bar is compact and doesn't overflow
+    iconSize: Dims.l(10)
+    actionSlotPadding: Dims.l(1)
+
+    onClicked: {
+        if (valueArray.length === 0) return
+        var idx = valueArray.indexOf(currentValue)
+        var nextIdx = (idx + 1) % valueArray.length
+        valueChanged(valueArray[nextIdx])
+    }
+
+    // Use a zero-delay timer to install the binding after the Loader is definitely ready.
+    // Connections.onStatusChanged can miss the Ready transition on Qt 5.12 when the
+    // actionComponent is synchronous inline.
+    Timer {
+        id: bindingInstaller
+        interval: 0; repeat: false
+        onTriggered: {
+            if (actionArea.status === Loader.Ready && actionArea.item) {
+                actionArea.item.fillRatio = Qt.binding(function() {
+                    if (root.valueArray.length <= 1) return 0
+                    var idx = root.valueArray.indexOf(root.currentValue)
+                    if (idx <= 0) return 0
+                    return idx / (root.valueArray.length - 1)
+                })
+            }
+        }
+    }
+    Component.onCompleted: bindingInstaller.start()
+
+    actionComponent: Item {
+        property real fillRatio: 0
+
+        Item {
+            id: barContainer
+            anchors.centerIn: parent
+            width: Math.max(Dims.w(1), 3)
+            height: parent.height * 0.85
+
+            Rectangle {
+                id: trackBg
+                anchors.fill: parent
+                radius: parent.width / 4
+                color: fillRatio > 0 ? "#CCCCCC" : "#888888"
+
+                Behavior on color {
+                    ColorAnimation { duration: 200 }
+                }
+            }
+
+            Rectangle {
+                id: fillRect
+                anchors.bottom: parent.bottom
+                width: parent.width
+                height: parent.height * fillRatio
+                radius: parent.width / 4
+                color: "#4CAF50"
+
+                Behavior on height {
+                    NumberAnimation {
+                        duration: 200
+                        easing.type: Easing.OutQuad
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/qml/LauncherPage.qml
+++ b/src/qml/LauncherPage.qml
@@ -21,7 +21,7 @@ import Qt.labs.folderlistmodel 2.1
 import Nemo.Time 1.0
 import Nemo.Configuration 1.0
 import org.asteroid.controls 1.0
-import QtQml.Models 2.15
+import QtQml.Models 2.12
 
 Item {
     property alias displayAmbient: compositor.displayAmbient

--- a/src/qml/NightstandPage.qml
+++ b/src/qml/NightstandPage.qml
@@ -18,7 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.15
+import QtQuick 2.12
 import QtQuick.Layouts 1.3
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0

--- a/src/qml/NightstandWatchfacePage.qml
+++ b/src/qml/NightstandWatchfacePage.qml
@@ -18,7 +18,7 @@
  */
 
 import QtQuick 2.9
-import QtGraphicalEffects 1.12
+import QtGraphicalEffects 1.0
 import Qt.labs.folderlistmodel 2.1
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0

--- a/src/qml/PowerManagerPage.qml
+++ b/src/qml/PowerManagerPage.qml
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2024 - AsteroidOS Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
+import Nemo.DBus 2.0
+
+Item {
+    id: root
+
+    property string activeProfileId: ""
+    property string activeProfileName: ""
+    property string activeProfileIcon: "ios-battery-outline"
+    property int batteryLevel: 0
+    property bool batteryCharging: false
+    property string drainRate: ""
+    property bool serviceAvailable: false
+
+    ListModel {
+        id: profilesModel
+    }
+
+    ListModel {
+        id: topProfilesModel
+    }
+
+    DBusInterface {
+        id: powerd
+        bus: DBus.SystemBus
+        service: "org.asteroidos.powerd"
+        path: "/org/asteroidos/powerd"
+        iface: "org.asteroidos.powerd.ProfileManager"
+
+        signalsEnabled: true
+
+        function handleError(error) {
+            console.log("Power Manager D-Bus error:", error)
+            serviceAvailable = false
+        }
+
+        function loadProfiles() {
+            typedCall("GetProfiles", [], function(result) {
+                serviceAvailable = true
+                var profiles = JSON.parse(result)
+                profilesModel.clear()
+                topProfilesModel.clear()
+                
+                for (var i = 0; i < profiles.length; i++) {
+                    profilesModel.append(profiles[i])
+                    if (i < 3) {
+                        topProfilesModel.append(profiles[i])
+                    }
+                }
+            }, handleError)
+        }
+
+        function loadActiveProfile() {
+            typedCall("GetActiveProfile", [], function(result) {
+                serviceAvailable = true
+                activeProfileId = result
+                
+                typedCall("GetProfile", [activeProfileId], function(profileJson) {
+                    var profile = JSON.parse(profileJson)
+                    activeProfileName = profile.name
+                    activeProfileIcon = profile.icon || "ios-battery-outline"
+                }, handleError)
+            }, handleError)
+        }
+
+        function loadBatteryState() {
+            typedCall("GetCurrentState", [], function(result) {
+                var state = JSON.parse(result)
+                if (state.battery) {
+                    batteryLevel = state.battery.level || 0
+                    batteryCharging = state.battery.charging || false
+                }
+            }, handleError)
+            
+            typedCall("GetBatteryPrediction", [], function(result) {
+                var prediction = JSON.parse(result)
+                if (prediction.drain_rate_percent_per_hour) {
+                    drainRate = prediction.drain_rate_percent_per_hour.toFixed(1) + "%/h"
+                } else {
+                    drainRate = ""
+                }
+            }, handleError)
+        }
+
+        Component.onCompleted: {
+            loadProfiles()
+            loadActiveProfile()
+            loadBatteryState()
+        }
+
+        onServiceAvailableChanged: {
+            if (available) {
+                loadProfiles()
+                loadActiveProfile()
+                loadBatteryState()
+            } else {
+                serviceAvailable = false
+            }
+        }
+    }
+
+    Connections {
+        target: powerd
+        onActiveProfileChanged: {
+            activeProfileId = id
+            activeProfileName = name
+            powerd.loadActiveProfile()
+        }
+        onProfilesChanged: {
+            powerd.loadProfiles()
+        }
+        onBatteryLevelChanged: {
+            batteryLevel = level
+            batteryCharging = charging
+            powerd.loadBatteryState()
+        }
+    }
+
+    Component {
+        id: profileSelectorLayer
+        ProfileSelectorPage {}
+    }
+
+    Flickable {
+        anchors.fill: parent
+        anchors.topMargin: Dims.h(15)
+        anchors.bottomMargin: Dims.h(15)
+        contentHeight: contentColumn.implicitHeight
+        clip: true
+
+        Column {
+            id: contentColumn
+            anchors.left: parent.left
+            anchors.right: parent.right
+            spacing: Dims.h(2)
+
+            Item {
+                width: parent.width
+                height: Dims.h(8)
+            }
+
+            Rectangle {
+                width: parent.width
+                height: activeProfileCard.height
+                color: "transparent"
+
+                MouseArea {
+                    id: activeProfileCard
+                    anchors.fill: parent
+                    width: parent.width
+                    height: Dims.h(30)
+
+                    onClicked: layerStack.push(profileSelectorLayer)
+
+                    Column {
+                        anchors.centerIn: parent
+                        width: parent.width * 0.9
+                        spacing: Dims.h(2)
+
+                        Label {
+                            width: parent.width
+                            horizontalAlignment: Text.AlignHCenter
+                            //% "Active Profile"
+                            text: qsTrId("id-active-profile")
+                            font.pixelSize: Dims.l(5)
+                            opacity: 0.6
+                        }
+
+                        Label {
+                            width: parent.width
+                            horizontalAlignment: Text.AlignHCenter
+                            text: activeProfileIcon
+                            font.pixelSize: Dims.l(20)
+                            font.family: "weathericons"
+                            opacity: serviceAvailable ? 1.0 : 0.3
+                        }
+
+                        Label {
+                            width: parent.width
+                            horizontalAlignment: Text.AlignHCenter
+                            text: serviceAvailable ? activeProfileName : 
+                                  //% "Service unavailable"
+                                  qsTrId("id-service-unavailable")
+                            font.pixelSize: Dims.l(6)
+                            wrapMode: Text.WordWrap
+                            opacity: serviceAvailable ? 1.0 : 0.6
+                        }
+
+                        Item {
+                            width: parent.width
+                            height: Dims.h(3)
+                        }
+
+                        Row {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            spacing: Dims.w(3)
+
+                            Label {
+                                text: batteryCharging ? "⚡" : "🔋"
+                                font.pixelSize: Dims.l(5)
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            Label {
+                                text: batteryLevel + "%"
+                                font.pixelSize: Dims.l(5)
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            Label {
+                                text: drainRate
+                                font.pixelSize: Dims.l(4)
+                                opacity: 0.6
+                                anchors.verticalCenter: parent.verticalCenter
+                                visible: drainRate !== "" && !batteryCharging
+                            }
+                        }
+                    }
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: Dims.h(3)
+            }
+
+            RowSeparator {
+                visible: topProfilesModel.count > 0
+            }
+
+            Label {
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+                //% "Quick Switch"
+                text: qsTrId("id-quick-switch")
+                font.pixelSize: Dims.l(5)
+                opacity: 0.6
+                visible: topProfilesModel.count > 0
+            }
+
+            Repeater {
+                model: topProfilesModel
+
+                ListItem {
+                    height: Dims.h(12)
+                    width: parent.width
+                    title: model.name
+                    iconName: model.icon || "ios-battery-outline"
+                    
+                    Rectangle {
+                        anchors.right: parent.right
+                        anchors.rightMargin: Dims.w(5)
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: Dims.w(6)
+                        height: Dims.h(6)
+                        radius: Math.min(width, height) / 2
+                        color: "transparent"
+                        border.color: "#FFFFFF"
+                        border.width: Dims.w(0.5)
+                        visible: model.id === activeProfileId
+
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: parent.width * 0.6
+                            height: parent.height * 0.6
+                            radius: Math.min(width, height) / 2
+                            color: "#FFFFFF"
+                        }
+                    }
+
+                    onClicked: {
+                        if (model.id !== activeProfileId) {
+                            powerd.typedCall("SetActiveProfile", [model.id], function(success) {
+                                if (success) {
+                                    activeProfileId = model.id
+                                }
+                            }, powerd.handleError)
+                        }
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            ListItem {
+                height: Dims.h(12)
+                width: parent.width
+                //% "All Profiles"
+                title: qsTrId("id-all-profiles")
+                iconName: "ios-list-outline"
+                onClicked: layerStack.push(profileSelectorLayer)
+            }
+
+            RowSeparator {}
+
+            ListItem {
+                height: Dims.h(12)
+                width: parent.width
+                //% "Edit Profiles"
+                title: qsTrId("id-edit-profiles")
+                iconName: "ios-settings-outline"
+                enabled: false
+                opacity: 0.5
+            }
+
+            RowSeparator {}
+
+            ListItem {
+                height: Dims.h(12)
+                width: parent.width
+                //% "Automation"
+                title: qsTrId("id-automation")
+                iconName: "ios-timer-outline"
+                enabled: false
+                opacity: 0.5
+            }
+
+            Item {
+                width: parent.width
+                height: Dims.h(5)
+            }
+        }
+    }
+
+    PageHeader {
+        //% "Power Manager"
+        text: qsTrId("id-power-manager-page")
+    }
+}

--- a/src/qml/PowerManagerPage.qml
+++ b/src/qml/PowerManagerPage.qml
@@ -34,6 +34,14 @@ Item {
     property bool serviceAvailable: false
     property bool isEmulator: false
 
+    // Battery health properties
+    property int healthPercent: -1
+    property int learnedCapacityMah: -1
+    property int designCapacityMah: -1
+    property int cycleCount: 0
+    property string healthConfidence: "unavailable"
+    property int healthSampleCount: 0
+
     ListModel {
         id: profilesModel
     }
@@ -82,6 +90,22 @@ Item {
                 if (state.battery) {
                     batteryLevel = state.battery.level || 0
                     batteryCharging = state.battery.charging || false
+                    // Health data included in current state
+                    if (state.battery.health_percent !== undefined) {
+                        healthPercent = state.battery.health_percent
+                    }
+                    if (state.battery.learned_capacity_mah !== undefined) {
+                        learnedCapacityMah = state.battery.learned_capacity_mah
+                    }
+                    if (state.battery.design_capacity_mah !== undefined) {
+                        designCapacityMah = state.battery.design_capacity_mah
+                    }
+                    if (state.battery.cycle_count !== undefined) {
+                        cycleCount = state.battery.cycle_count
+                    }
+                    if (state.battery.health_confidence !== undefined) {
+                        healthConfidence = state.battery.health_confidence
+                    }
                 }
             }, handleError)
             
@@ -95,6 +119,43 @@ Item {
                     drainRate = ""
                 }
             }, handleError)
+        }
+
+        function loadBatteryHealth() {
+            typedCall("GetBatteryHealth", [], function(result) {
+                var health = JSON.parse(result)
+                if (health.health_percent !== undefined)
+                    healthPercent = health.health_percent
+                if (health.learned_capacity_mah !== undefined)
+                    learnedCapacityMah = health.learned_capacity_mah
+                if (health.design_capacity_mah !== undefined)
+                    designCapacityMah = health.design_capacity_mah
+                if (health.cycle_count !== undefined)
+                    cycleCount = health.cycle_count
+                if (health.confidence !== undefined)
+                    healthConfidence = health.confidence
+                if (health.sample_count !== undefined)
+                    healthSampleCount = health.sample_count
+
+                // On emulator with no real fuel gauge, generate demo data
+                if (isEmulator && healthPercent <= 0) {
+                    healthPercent = 87
+                    learnedCapacityMah = 361
+                    designCapacityMah = 415
+                    cycleCount = 142
+                    healthConfidence = "high"
+                    healthSampleCount = 45
+                }
+            }, function() {
+                if (isEmulator) {
+                    healthPercent = 87
+                    learnedCapacityMah = 361
+                    designCapacityMah = 415
+                    cycleCount = 142
+                    healthConfidence = "high"
+                    healthSampleCount = 45
+                }
+            })
         }
 
         function loadBatteryHistory() {
@@ -130,12 +191,20 @@ Item {
             loadBatteryHistory()
         }
 
+        function batteryHealthChanged(newHealth, newLearned, newDesign) {
+            healthPercent = newHealth
+            learnedCapacityMah = newLearned
+            designCapacityMah = newDesign
+            loadBatteryHealth()
+        }
+
         Component.onCompleted: {
             detectEmulator()
             loadProfiles()
             loadActiveProfile()
             loadBatteryState()
             loadBatteryHistory()
+            loadBatteryHealth()
         }
     }
 
@@ -152,6 +221,10 @@ Item {
                     // Re-try history now that we know we're on emulator
                     if (batteryHistory.length === 0) {
                         powerd.loadBatteryHistory()
+                    }
+                    // Load demo health data on emulator
+                    if (healthPercent <= 0) {
+                        powerd.loadBatteryHealth()
                     }
                 }
             }
@@ -376,6 +449,158 @@ Item {
                     anchors.verticalCenter: parent.verticalCenter
                     visible: batteryCharging
                 }
+            }
+
+            // --- Battery Health Section ---
+            Item {
+                width: parent.width
+                height: Dims.h(3)
+                visible: healthPercent > 0 || isEmulator
+            }
+
+            RowSeparator {
+                visible: healthPercent > 0 || isEmulator
+            }
+
+            Column {
+                id: healthSection
+                width: parent.width
+                spacing: Dims.h(1)
+                visible: healthPercent > 0 || isEmulator
+
+                Item { width: 1; height: Dims.h(1) }
+
+                Label {
+                    width: parent.width
+                    horizontalAlignment: Text.AlignHCenter
+                    //% "Battery Health"
+                    text: qsTrId("id-battery-health")
+                    font.pixelSize: Dims.l(5)
+                    opacity: 0.6
+                }
+
+                // Health bar
+                Item {
+                    width: parent.width
+                    height: Dims.h(5)
+
+                    Rectangle {
+                        id: healthBarTrack
+                        anchors.centerIn: parent
+                        width: parent.width * 0.70
+                        height: Dims.h(1.5)
+                        radius: height / 2
+                        color: "#333333"
+
+                        Rectangle {
+                            id: healthBarFill
+                            anchors.left: parent.left
+                            anchors.top: parent.top
+                            anchors.bottom: parent.bottom
+                            width: parent.width * Math.max(0, Math.min(1, healthPercent / 100.0))
+                            radius: parent.radius
+                            color: healthPercent >= 80 ? "#4CAF50" :
+                                   healthPercent >= 60 ? "#FF9800" :
+                                   healthPercent >= 40 ? "#FF5722" : "#F44336"
+
+                            Behavior on width {
+                                NumberAnimation { duration: 400; easing.type: Easing.OutQuad }
+                            }
+                            Behavior on color {
+                                ColorAnimation { duration: 300 }
+                            }
+                        }
+                    }
+                }
+
+                // Health percentage + capacity
+                Row {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    spacing: Dims.w(2)
+
+                    Label {
+                        text: healthPercent > 0 ? healthPercent + "%" : "--"
+                        font.pixelSize: Dims.l(7)
+                        font.styleName: "SemiCondensed Light"
+                        color: healthPercent >= 80 ? "#4CAF50" :
+                               healthPercent >= 60 ? "#FF9800" :
+                               healthPercent >= 40 ? "#FF5722" : "#F44336"
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    Column {
+                        anchors.verticalCenter: parent.verticalCenter
+                        Label {
+                            text: {
+                                if (learnedCapacityMah > 0 && designCapacityMah > 0)
+                                    return learnedCapacityMah + " / " + designCapacityMah + " mAh"
+                                return ""
+                            }
+                            font.pixelSize: Dims.l(3.5)
+                            opacity: 0.7
+                            visible: text !== ""
+                        }
+                        Label {
+                            text: {
+                                if (cycleCount > 0)
+                                    //% "%1 charge cycles"
+                                    return qsTrId("id-charge-cycles").arg(cycleCount)
+                                return ""
+                            }
+                            font.pixelSize: Dims.l(3)
+                            opacity: 0.5
+                            visible: text !== ""
+                        }
+                    }
+                }
+
+                // Confidence indicator
+                Label {
+                    width: parent.width
+                    horizontalAlignment: Text.AlignHCenter
+                    text: {
+                        if (healthConfidence === "high")
+                            //% "Accuracy: High (%1 samples)"
+                            return qsTrId("id-health-accuracy-high").arg(healthSampleCount)
+                        if (healthConfidence === "medium")
+                            //% "Accuracy: Medium (%1 samples)"
+                            return qsTrId("id-health-accuracy-medium").arg(healthSampleCount)
+                        if (healthConfidence === "low")
+                            //% "Accuracy: Improving..."
+                            return qsTrId("id-health-accuracy-low")
+                        return ""
+                    }
+                    font.pixelSize: Dims.l(3)
+                    opacity: 0.4
+                    visible: text !== "" && healthPercent > 0
+                }
+
+                // Health status text
+                Label {
+                    width: parent.width * 0.85
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.WordWrap
+                    text: {
+                        if (healthPercent <= 0) return ""
+                        if (healthPercent >= 90)
+                            //% "Battery is in excellent condition"
+                            return qsTrId("id-health-excellent")
+                        if (healthPercent >= 80)
+                            //% "Battery is in good condition"
+                            return qsTrId("id-health-good")
+                        if (healthPercent >= 60)
+                            //% "Battery is showing wear — consider replacement"
+                            return qsTrId("id-health-worn")
+                        //% "Battery is significantly degraded"
+                        return qsTrId("id-health-degraded")
+                    }
+                    font.pixelSize: Dims.l(3)
+                    opacity: 0.5
+                    visible: text !== ""
+                }
+
+                Item { width: 1; height: Dims.h(1) }
             }
 
             Item {

--- a/src/qml/PowerManagerPage.qml
+++ b/src/qml/PowerManagerPage.qml
@@ -25,18 +25,17 @@ Item {
 
     property string activeProfileId: ""
     property string activeProfileName: ""
-    property string activeProfileIcon: "ios-battery-outline"
+    property string activeProfileIcon: "ios-battery-full"
     property int batteryLevel: 0
     property bool batteryCharging: false
     property string drainRate: ""
+    property real drainRatePerHour: 0
+    property var batteryHistory: []
     property bool serviceAvailable: false
+    property bool isEmulator: false
 
     ListModel {
         id: profilesModel
-    }
-
-    ListModel {
-        id: topProfilesModel
     }
 
     DBusInterface {
@@ -58,13 +57,8 @@ Item {
                 serviceAvailable = true
                 var profiles = JSON.parse(result)
                 profilesModel.clear()
-                topProfilesModel.clear()
-                
                 for (var i = 0; i < profiles.length; i++) {
                     profilesModel.append(profiles[i])
-                    if (i < 3) {
-                        topProfilesModel.append(profiles[i])
-                    }
                 }
             }, handleError)
         }
@@ -73,11 +67,11 @@ Item {
             typedCall("GetActiveProfile", [], function(result) {
                 serviceAvailable = true
                 activeProfileId = result
-                
-                typedCall("GetProfile", [activeProfileId], function(profileJson) {
+
+                typedCall("GetProfile", [{"type": "s", "value": activeProfileId}], function(profileJson) {
                     var profile = JSON.parse(profileJson)
                     activeProfileName = profile.name
-                    activeProfileIcon = profile.icon || "ios-battery-outline"
+                    activeProfileIcon = profile.icon || "ios-battery-full"
                 }, handleError)
             }, handleError)
         }
@@ -94,50 +88,159 @@ Item {
             typedCall("GetBatteryPrediction", [], function(result) {
                 var prediction = JSON.parse(result)
                 if (prediction.drain_rate_percent_per_hour) {
-                    drainRate = prediction.drain_rate_percent_per_hour.toFixed(1) + "%/h"
+                    drainRatePerHour = prediction.drain_rate_percent_per_hour
+                    drainRate = drainRatePerHour.toFixed(1) + "%/h"
                 } else {
+                    drainRatePerHour = 0
                     drainRate = ""
                 }
             }, handleError)
         }
 
+        function loadBatteryHistory() {
+            typedCall("GetBatteryHistory",
+                [{"type": "i", "value": 168}],
+                function(result) {
+                    var data = JSON.parse(result)
+                    if (data.length > 10) {
+                        batteryHistory = data
+                    } else if (isEmulator) {
+                        batteryHistory = generateSimulatedHistory()
+                    }
+                }, function() {
+                    if (isEmulator) {
+                        batteryHistory = generateSimulatedHistory()
+                    }
+                })
+        }
+
+        function activeProfileChanged(newId) {
+            activeProfileId = newId
+            loadActiveProfile()
+        }
+
+        function profilesChanged() {
+            loadProfiles()
+        }
+
+        function batteryLevelChanged(newLevel, isCharging) {
+            batteryLevel = newLevel
+            batteryCharging = isCharging
+            loadBatteryState()
+            loadBatteryHistory()
+        }
+
         Component.onCompleted: {
+            detectEmulator()
             loadProfiles()
             loadActiveProfile()
             loadBatteryState()
-        }
-
-        onServiceAvailableChanged: {
-            if (available) {
-                loadProfiles()
-                loadActiveProfile()
-                loadBatteryState()
-            } else {
-                serviceAvailable = false
-            }
+            loadBatteryHistory()
         }
     }
 
-    Connections {
-        target: powerd
-        onActiveProfileChanged: {
-            activeProfileId = id
-            activeProfileName = name
-            powerd.loadActiveProfile()
+    // Detect emulator by reading /etc/hostname (set to "emulator" in QEMU builds,
+    // real watches have device codenames like "catfish", "beluga", "sturgeon", etc.)
+    function detectEmulator() {
+        var xhr = new XMLHttpRequest()
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState === XMLHttpRequest.DONE) {
+                var hostname = (xhr.responseText || "").trim()
+                isEmulator = (hostname === "emulator")
+                if (isEmulator) {
+                    console.log("PowerManager: Running on emulator — simulation data available")
+                    // Re-try history now that we know we're on emulator
+                    if (batteryHistory.length === 0) {
+                        powerd.loadBatteryHistory()
+                    }
+                }
+            }
         }
-        onProfilesChanged: {
-            powerd.loadProfiles()
+        xhr.open("GET", "file:///etc/hostname")
+        xhr.send()
+    }
+
+    // Generate realistic 7-day simulated battery data for graph preview.
+    // ONLY called when isEmulator is true (QEMU build) — never on real hardware.
+    // Points every 2 hours matching daemon heartbeat interval.
+    // Pattern: ~2 days drain → 2h charge → ~3 days drain → 2h charge → drain to now
+    function generateSimulatedHistory() {
+        if (!isEmulator) return []
+
+        var now = Math.floor(Date.now() / 1000)
+        var data = []
+        var t = now - 7 * 24 * 3600
+        var level = 100
+        var STEP = 7200          // 2 hours
+        var HOUR = 3600
+
+        // Helper: drain rate per 2h step (base %/h * 2 + tiny noise)
+        function drainStep(basePerHour) {
+            return (basePerHour + (Math.random() - 0.5) * 0.3) * 2
         }
-        onBatteryLevelChanged: {
-            batteryLevel = level
-            batteryCharging = charging
-            powerd.loadBatteryState()
+        // Helper: charge rate per 2h step
+        function chargeStep(basePerHour) {
+            return (basePerHour + (Math.random() - 0.5) * 2) * 2
         }
+
+        // Phase 1: Drain ~2 days (48h) at ~2%/h
+        var phase1End = t + 48 * HOUR
+        while (t < phase1End && t < now) {
+            data.push({timestamp: t, level: Math.round(level * 10) / 10, charging: false, profile: "balanced"})
+            level -= drainStep(2.0)
+            level = Math.max(0, level)
+            t += STEP
+        }
+
+        // Phase 2: Charge ~2h at ~40%/h (fast charge)
+        var phase2End = t + 2 * HOUR
+        while (t < phase2End && t < now) {
+            data.push({timestamp: t, level: Math.round(level * 10) / 10, charging: true, profile: "balanced"})
+            level += chargeStep(40)
+            level = Math.min(100, level)
+            t += STEP
+        }
+
+        // Phase 3: Drain ~3 days (72h) at ~1.4%/h (power saver)
+        var phase3End = t + 72 * HOUR
+        while (t < phase3End && t < now) {
+            data.push({timestamp: t, level: Math.round(level * 10) / 10, charging: false, profile: "power_saver"})
+            level -= drainStep(1.4)
+            level = Math.max(0, level)
+            t += STEP
+        }
+
+        // Phase 4: If battery low, charge 2h then drain remaining time
+        if (t < now && level < 25) {
+            var phase4End = t + 2 * HOUR
+            while (t < phase4End && t < now) {
+                data.push({timestamp: t, level: Math.round(level * 10) / 10, charging: true, profile: "balanced"})
+                level += chargeStep(38)
+                level = Math.min(100, level)
+                t += STEP
+            }
+        }
+        while (t < now) {
+            data.push({timestamp: t, level: Math.round(level * 10) / 10, charging: false, profile: "balanced"})
+            level -= drainStep(1.8)
+            level = Math.max(0, level)
+            t += STEP
+        }
+
+        // Final point at now
+        var finalLevel = batteryLevel > 0 ? batteryLevel : 61
+        data.push({timestamp: now, level: finalLevel, charging: false, profile: "balanced"})
+        return data
     }
 
     Component {
         id: profileSelectorLayer
         ProfileSelectorPage {}
+    }
+
+    Component {
+        id: profileListLayer
+        ProfileListPage {}
     }
 
     Flickable {
@@ -158,81 +261,46 @@ Item {
                 height: Dims.h(8)
             }
 
-            Rectangle {
+            MouseArea {
                 width: parent.width
-                height: activeProfileCard.height
-                color: "transparent"
+                height: profileCardColumn.height
 
-                MouseArea {
-                    id: activeProfileCard
-                    anchors.fill: parent
+                onClicked: layerStack.push(profileSelectorLayer)
+
+                Column {
+                    id: profileCardColumn
                     width: parent.width
-                    height: Dims.h(30)
+                    spacing: Dims.h(1)
 
-                    onClicked: layerStack.push(profileSelectorLayer)
+                    Label {
+                        width: parent.width
+                        horizontalAlignment: Text.AlignHCenter
+                        //% "Active Profile"
+                        text: qsTrId("id-active-profile")
+                        font.pixelSize: Dims.l(6)
+                        opacity: 0.6
+                    }
 
-                    Column {
-                        anchors.centerIn: parent
-                        width: parent.width * 0.9
-                        spacing: Dims.h(2)
+                    Row {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        spacing: Dims.w(3)
 
-                        Label {
-                            width: parent.width
-                            horizontalAlignment: Text.AlignHCenter
-                            //% "Active Profile"
-                            text: qsTrId("id-active-profile")
-                            font.pixelSize: Dims.l(5)
-                            opacity: 0.6
-                        }
-
-                        Label {
-                            width: parent.width
-                            horizontalAlignment: Text.AlignHCenter
-                            text: activeProfileIcon
-                            font.pixelSize: Dims.l(20)
-                            font.family: "weathericons"
+                        Icon {
+                            name: activeProfileIcon
+                            width: Dims.l(8)
+                            height: width
+                            anchors.verticalCenter: parent.verticalCenter
                             opacity: serviceAvailable ? 1.0 : 0.3
                         }
 
                         Label {
-                            width: parent.width
-                            horizontalAlignment: Text.AlignHCenter
-                            text: serviceAvailable ? activeProfileName : 
+                            text: serviceAvailable ? activeProfileName :
                                   //% "Service unavailable"
                                   qsTrId("id-service-unavailable")
-                            font.pixelSize: Dims.l(6)
+                            font.pixelSize: Dims.l(5)
                             wrapMode: Text.WordWrap
+                            anchors.verticalCenter: parent.verticalCenter
                             opacity: serviceAvailable ? 1.0 : 0.6
-                        }
-
-                        Item {
-                            width: parent.width
-                            height: Dims.h(3)
-                        }
-
-                        Row {
-                            anchors.horizontalCenter: parent.horizontalCenter
-                            spacing: Dims.w(3)
-
-                            Label {
-                                text: batteryCharging ? "⚡" : "🔋"
-                                font.pixelSize: Dims.l(5)
-                                anchors.verticalCenter: parent.verticalCenter
-                            }
-
-                            Label {
-                                text: batteryLevel + "%"
-                                font.pixelSize: Dims.l(5)
-                                anchors.verticalCenter: parent.verticalCenter
-                            }
-
-                            Label {
-                                text: drainRate
-                                font.pixelSize: Dims.l(4)
-                                opacity: 0.6
-                                anchors.verticalCenter: parent.verticalCenter
-                                visible: drainRate !== "" && !batteryCharging
-                            }
                         }
                     }
                 }
@@ -243,73 +311,6 @@ Item {
                 height: Dims.h(3)
             }
 
-            RowSeparator {
-                visible: topProfilesModel.count > 0
-            }
-
-            Label {
-                width: parent.width
-                horizontalAlignment: Text.AlignHCenter
-                //% "Quick Switch"
-                text: qsTrId("id-quick-switch")
-                font.pixelSize: Dims.l(5)
-                opacity: 0.6
-                visible: topProfilesModel.count > 0
-            }
-
-            Repeater {
-                model: topProfilesModel
-
-                ListItem {
-                    height: Dims.h(12)
-                    width: parent.width
-                    title: model.name
-                    iconName: model.icon || "ios-battery-outline"
-                    
-                    Rectangle {
-                        anchors.right: parent.right
-                        anchors.rightMargin: Dims.w(5)
-                        anchors.verticalCenter: parent.verticalCenter
-                        width: Dims.w(6)
-                        height: Dims.h(6)
-                        radius: Math.min(width, height) / 2
-                        color: "transparent"
-                        border.color: "#FFFFFF"
-                        border.width: Dims.w(0.5)
-                        visible: model.id === activeProfileId
-
-                        Rectangle {
-                            anchors.centerIn: parent
-                            width: parent.width * 0.6
-                            height: parent.height * 0.6
-                            radius: Math.min(width, height) / 2
-                            color: "#FFFFFF"
-                        }
-                    }
-
-                    onClicked: {
-                        if (model.id !== activeProfileId) {
-                            powerd.typedCall("SetActiveProfile", [model.id], function(success) {
-                                if (success) {
-                                    activeProfileId = model.id
-                                }
-                            }, powerd.handleError)
-                        }
-                    }
-                }
-            }
-
-            RowSeparator {}
-
-            ListItem {
-                height: Dims.h(12)
-                width: parent.width
-                //% "All Profiles"
-                title: qsTrId("id-all-profiles")
-                iconName: "ios-list-outline"
-                onClicked: layerStack.push(profileSelectorLayer)
-            }
-
             RowSeparator {}
 
             ListItem {
@@ -318,8 +319,7 @@ Item {
                 //% "Edit Profiles"
                 title: qsTrId("id-edit-profiles")
                 iconName: "ios-settings-outline"
-                enabled: false
-                opacity: 0.5
+                onClicked: layerStack.push(profileListLayer)
             }
 
             RowSeparator {}
@@ -332,6 +332,50 @@ Item {
                 iconName: "ios-timer-outline"
                 enabled: false
                 opacity: 0.5
+            }
+
+            RowSeparator {}
+
+            Item {
+                width: parent.width
+                height: Dims.h(35)
+
+                BatteryHistoryGraph {
+                    anchors.fill: parent
+                    anchors.leftMargin: Dims.w(2)
+                    anchors.rightMargin: Dims.w(2)
+                    historyData: batteryHistory
+                    currentLevel: batteryLevel
+                    drainRatePerHour: root.drainRatePerHour
+                    isCharging: batteryCharging
+                }
+            }
+
+            Row {
+                anchors.horizontalCenter: parent.horizontalCenter
+                spacing: Dims.w(3)
+
+                Label {
+                    text: batteryLevel + "%"
+                    font.pixelSize: Dims.l(8)
+                    font.styleName: "SemiCondensed Light"
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                Label {
+                    text: drainRate
+                    font.pixelSize: Dims.l(4)
+                    opacity: 0.6
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: drainRate !== "" && !batteryCharging
+                }
+
+                Label {
+                    text: batteryCharging ? "⚡" : ""
+                    font.pixelSize: Dims.l(5)
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: batteryCharging
+                }
             }
 
             Item {

--- a/src/qml/ProfileEditPage.qml
+++ b/src/qml/ProfileEditPage.qml
@@ -1,0 +1,626 @@
+/*
+ * Copyright (C) 2024 - AsteroidOS Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
+import Nemo.DBus 2.0
+
+Item {
+    id: root
+
+    property string profileId: ""
+    property bool isNewProfile: false
+    property var profile: ({})
+
+    property var sensorModeLabels: ({
+        "off": qsTrId("id-off"),
+        "low": qsTrId("id-low"),
+        "medium": qsTrId("id-medium"),
+        "high": qsTrId("id-high"),
+        "workout": qsTrId("id-workout"),
+        "sleep_only": qsTrId("id-sleep-only"),
+        "always": qsTrId("id-always"),
+        "periodic": qsTrId("id-periodic"),
+        "continuous": qsTrId("id-continuous"),
+        "on_demand": qsTrId("id-on-demand")
+    })
+
+    DBusInterface {
+        id: powerd
+        bus: DBus.SystemBus
+        service: "org.asteroidos.powerd"
+        path: "/org/asteroidos/powerd"
+        iface: "org.asteroidos.powerd.ProfileManager"
+
+        function handleError(error) {
+            console.log("Profile Edit D-Bus error:", error)
+        }
+
+        function loadProfile() {
+            if (isNewProfile) {
+                profile = {
+                    "id": "",
+                    "name": qsTrId("id-new-profile"),
+                    "icon": "ios-battery-outline",
+                    "color": "#2196F3",
+                    "sensors": {
+                        "accelerometer": "medium",
+                        "gyroscope": "medium",
+                        "heart_rate": "medium",
+                        "hrv": "sleep_only",
+                        "spo2": "off",
+                        "barometer": "low",
+                        "compass": "on_demand",
+                        "ambient_light": "low",
+                        "gps": "off"
+                    },
+                    "radios": {
+                        "ble": {
+                            "state": "on",
+                            "sync_mode": "interval",
+                            "interval_hours": 2,
+                            "disable_during_sleep": false
+                        },
+                        "wifi": {
+                            "state": "off",
+                            "sync_mode": "manual"
+                        },
+                        "lte": {
+                            "state": "off"
+                        },
+                        "nfc": {
+                            "state": "off"
+                        }
+                    },
+                    "system": {
+                        "background_sync": "when_radios_on",
+                        "always_on_display": true,
+                        "tilt_to_wake": true
+                    },
+                    "automation": {
+                        "battery_rules": [],
+                        "time_rules": [],
+                        "workout_profiles": {}
+                    }
+                }
+            } else {
+                typedCall("GetProfile", [profileId], function(result) {
+                    profile = JSON.parse(result)
+                }, handleError)
+            }
+        }
+
+        Component.onCompleted: {
+            loadProfile()
+        }
+    }
+
+    function saveProfile() {
+        var profileJson = JSON.stringify(profile)
+        
+        if (isNewProfile) {
+            powerd.typedCall("AddProfile", [profileJson], function(newId) {
+                if (newId) {
+                    layerStack.pop(root)
+                }
+            }, powerd.handleError)
+        } else {
+            powerd.typedCall("UpdateProfile", [profileJson], function(success) {
+                if (success) {
+                    layerStack.pop(root)
+                }
+            }, powerd.handleError)
+        }
+    }
+
+    function deleteProfile() {
+        powerd.typedCall("DeleteProfile", [profileId], function(success) {
+            if (success) {
+                layerStack.pop(root)
+            }
+        }, powerd.handleError)
+    }
+
+    property string rowHeight: Dims.h(15)
+
+    Flickable {
+        anchors.fill: parent
+        anchors.topMargin: Dims.h(15)
+        anchors.bottomMargin: Dims.h(5)
+        contentHeight: contentColumn.implicitHeight
+        clip: true
+
+        Column {
+            id: contentColumn
+            anchors.left: parent.left
+            anchors.right: parent.right
+            spacing: 0
+
+            Item {
+                width: parent.width
+                height: Dims.h(3)
+            }
+
+            Label {
+                width: parent.width
+                height: Dims.h(10)
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                //% "Sensors"
+                text: qsTrId("id-sensors")
+                font.pixelSize: Dims.l(6)
+                opacity: 0.8
+            }
+
+            RowSeparator {}
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                //% "Accelerometer"
+                text: qsTrId("id-accelerometer")
+                valueArray: ["off", "low", "medium", "high", "workout"]
+                currentValue: profile.sensors ? profile.sensors.accelerometer : "medium"
+                onValueChanged: {
+                    if (profile.sensors) {
+                        profile.sensors.accelerometer = value
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                //% "Gyroscope"
+                text: qsTrId("id-gyroscope")
+                valueArray: ["off", "low", "medium", "high", "workout"]
+                currentValue: profile.sensors ? profile.sensors.gyroscope : "medium"
+                onValueChanged: {
+                    if (profile.sensors) {
+                        profile.sensors.gyroscope = value
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                //% "Heart Rate"
+                text: qsTrId("id-heart-rate")
+                valueArray: ["off", "low", "medium", "high", "workout"]
+                currentValue: profile.sensors ? profile.sensors.heart_rate : "medium"
+                onValueChanged: {
+                    if (profile.sensors) {
+                        profile.sensors.heart_rate = value
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                //% "HRV"
+                text: qsTrId("id-hrv")
+                valueArray: ["off", "sleep_only", "always"]
+                currentValue: profile.sensors ? profile.sensors.hrv : "sleep_only"
+                onValueChanged: {
+                    if (profile.sensors) {
+                        profile.sensors.hrv = value
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                //% "SpO2"
+                text: qsTrId("id-spo2")
+                valueArray: ["off", "periodic", "continuous"]
+                currentValue: profile.sensors ? profile.sensors.spo2 : "off"
+                onValueChanged: {
+                    if (profile.sensors) {
+                        profile.sensors.spo2 = value
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                //% "Barometer"
+                text: qsTrId("id-barometer")
+                valueArray: ["off", "low", "high"]
+                currentValue: profile.sensors ? profile.sensors.barometer : "low"
+                onValueChanged: {
+                    if (profile.sensors) {
+                        profile.sensors.barometer = value
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                //% "Compass"
+                text: qsTrId("id-compass")
+                valueArray: ["off", "on_demand", "continuous"]
+                currentValue: profile.sensors ? profile.sensors.compass : "on_demand"
+                onValueChanged: {
+                    if (profile.sensors) {
+                        profile.sensors.compass = value
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                //% "Ambient Light"
+                text: qsTrId("id-ambient-light")
+                valueArray: ["off", "low", "high"]
+                currentValue: profile.sensors ? profile.sensors.ambient_light : "low"
+                onValueChanged: {
+                    if (profile.sensors) {
+                        profile.sensors.ambient_light = value
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                //% "GPS"
+                text: qsTrId("id-gps")
+                valueArray: ["off", "periodic", "continuous"]
+                currentValue: profile.sensors ? profile.sensors.gps : "off"
+                onValueChanged: {
+                    if (profile.sensors) {
+                        profile.sensors.gps = value
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            Item {
+                width: parent.width
+                height: Dims.h(5)
+            }
+
+            Label {
+                width: parent.width
+                height: Dims.h(10)
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                //% "Radios"
+                text: qsTrId("id-radios")
+                font.pixelSize: Dims.l(6)
+                opacity: 0.8
+            }
+
+            RowSeparator {}
+
+            LabeledSwitch {
+                height: rowHeight
+                width: parent.width
+                //% "Bluetooth"
+                text: qsTrId("id-bluetooth")
+                checked: profile.radios && profile.radios.ble ? profile.radios.ble.state === "on" : true
+                onCheckedChanged: {
+                    if (profile.radios && profile.radios.ble) {
+                        profile.radios.ble.state = checked ? "on" : "off"
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                visible: profile.radios && profile.radios.ble && profile.radios.ble.state === "on"
+                //% "BLE Sync"
+                text: qsTrId("id-ble-sync")
+                valueArray: ["manual", "interval", "time_window"]
+                currentValue: profile.radios && profile.radios.ble ? profile.radios.ble.sync_mode : "interval"
+                onValueChanged: {
+                    if (profile.radios && profile.radios.ble) {
+                        profile.radios.ble.sync_mode = value
+                    }
+                }
+            }
+
+            RowSeparator {
+                visible: profile.radios && profile.radios.ble && profile.radios.ble.state === "on"
+            }
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                visible: profile.radios && profile.radios.ble && profile.radios.ble.state === "on" && profile.radios.ble.sync_mode === "interval"
+                //% "BLE Interval"
+                text: qsTrId("id-ble-interval")
+                valueArray: ["1", "2", "5", "10"]
+                currentValue: profile.radios && profile.radios.ble ? String(profile.radios.ble.interval_hours) : "2"
+                onValueChanged: {
+                    if (profile.radios && profile.radios.ble) {
+                        profile.radios.ble.interval_hours = parseInt(value)
+                    }
+                }
+            }
+
+            RowSeparator {
+                visible: profile.radios && profile.radios.ble && profile.radios.ble.state === "on" && profile.radios.ble.sync_mode === "interval"
+            }
+
+            LabeledSwitch {
+                height: rowHeight
+                width: parent.width
+                visible: profile.radios && profile.radios.ble && profile.radios.ble.state === "on" && profile.radios.ble.sync_mode === "interval"
+                //% "Disable during sleep"
+                text: qsTrId("id-ble-disable-sleep")
+                checked: profile.radios && profile.radios.ble ? profile.radios.ble.disable_during_sleep : false
+                onCheckedChanged: {
+                    if (profile.radios && profile.radios.ble) {
+                        profile.radios.ble.disable_during_sleep = checked
+                    }
+                }
+            }
+
+            RowSeparator {
+                visible: profile.radios && profile.radios.ble && profile.radios.ble.state === "on" && profile.radios.ble.sync_mode === "interval"
+            }
+
+            LabeledSwitch {
+                height: rowHeight
+                width: parent.width
+                //% "Wi-Fi"
+                text: qsTrId("id-wifi")
+                checked: profile.radios && profile.radios.wifi ? profile.radios.wifi.state === "on" : false
+                onCheckedChanged: {
+                    if (profile.radios && profile.radios.wifi) {
+                        profile.radios.wifi.state = checked ? "on" : "off"
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                visible: profile.radios && profile.radios.wifi && profile.radios.wifi.state === "on"
+                //% "Wi-Fi Sync"
+                text: qsTrId("id-wifi-sync")
+                valueArray: ["manual", "interval", "time_window"]
+                currentValue: profile.radios && profile.radios.wifi ? profile.radios.wifi.sync_mode : "manual"
+                onValueChanged: {
+                    if (profile.radios && profile.radios.wifi) {
+                        profile.radios.wifi.sync_mode = value
+                    }
+                }
+            }
+
+            RowSeparator {
+                visible: profile.radios && profile.radios.wifi && profile.radios.wifi.state === "on"
+            }
+
+            Item {
+                width: parent.width
+                height: Dims.h(5)
+            }
+
+            Label {
+                width: parent.width
+                height: Dims.h(10)
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                //% "System"
+                text: qsTrId("id-system")
+                font.pixelSize: Dims.l(6)
+                opacity: 0.8
+            }
+
+            RowSeparator {}
+
+            LabeledSwitch {
+                height: rowHeight
+                width: parent.width
+                //% "Always-on Display"
+                text: qsTrId("id-always-on-display")
+                checked: profile.system ? profile.system.always_on_display : true
+                onCheckedChanged: {
+                    if (profile.system) {
+                        profile.system.always_on_display = checked
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            LabeledSwitch {
+                height: rowHeight
+                width: parent.width
+                //% "Tilt-to-wake"
+                text: qsTrId("id-tilt-to-wake")
+                checked: profile.system ? profile.system.tilt_to_wake : true
+                onCheckedChanged: {
+                    if (profile.system) {
+                        profile.system.tilt_to_wake = checked
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            OptionCycler {
+                height: rowHeight
+                width: parent.width
+                //% "Background Sync"
+                text: qsTrId("id-background-sync")
+                valueArray: ["auto", "when_radios_on", "off"]
+                currentValue: profile.system ? profile.system.background_sync : "when_radios_on"
+                onValueChanged: {
+                    if (profile.system) {
+                        profile.system.background_sync = value
+                    }
+                }
+            }
+
+            RowSeparator {}
+
+            Item {
+                width: parent.width
+                height: Dims.h(5)
+            }
+
+            Label {
+                width: parent.width
+                height: Dims.h(10)
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                //% "Automation"
+                text: qsTrId("id-automation")
+                font.pixelSize: Dims.l(6)
+                opacity: 0.8
+            }
+
+            RowSeparator {}
+
+            ListItem {
+                height: rowHeight
+                width: parent.width
+                //% "Battery Rules"
+                title: qsTrId("id-battery-rules")
+                iconName: "ios-battery-charging-outline"
+                enabled: false
+                opacity: 0.5
+            }
+
+            RowSeparator {}
+
+            ListItem {
+                height: rowHeight
+                width: parent.width
+                //% "Time Rules"
+                title: qsTrId("id-time-rules")
+                iconName: "ios-time-outline"
+                enabled: false
+                opacity: 0.5
+            }
+
+            RowSeparator {}
+
+            ListItem {
+                height: rowHeight
+                width: parent.width
+                //% "Workout Profiles"
+                title: qsTrId("id-workout-profiles")
+                iconName: "ios-walk-outline"
+                enabled: false
+                opacity: 0.5
+            }
+
+            RowSeparator {}
+
+            Item {
+                width: parent.width
+                height: Dims.h(8)
+            }
+
+            Item {
+                width: parent.width
+                height: Dims.h(18)
+
+                IconButton {
+                    anchors.centerIn: parent
+                    width: parent.width * 0.8
+                    height: Dims.h(15)
+                    iconName: "ios-checkmark-circle-outline"
+                    iconColor: "#4CAF50"
+
+                    onClicked: saveProfile()
+                }
+
+                Label {
+                    anchors.centerIn: parent
+                    //% "Save"
+                    text: qsTrId("id-save")
+                    font.pixelSize: Dims.l(6)
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: Dims.h(18)
+                visible: !isNewProfile
+
+                IconButton {
+                    anchors.centerIn: parent
+                    width: parent.width * 0.8
+                    height: Dims.h(15)
+                    iconName: "ios-trash-outline"
+                    iconColor: "#F44336"
+
+                    onClicked: {
+                        deleteRemorse.execute(this, "", function() {
+                            deleteProfile()
+                        })
+                    }
+                }
+
+                Label {
+                    anchors.centerIn: parent
+                    //% "Delete Profile"
+                    text: qsTrId("id-delete-profile")
+                    font.pixelSize: Dims.l(6)
+                    color: "#F44336"
+                }
+
+                RemorseTimer {
+                    id: deleteRemorse
+                }
+            }
+
+            Item {
+                width: parent.width
+                height: Dims.h(5)
+            }
+        }
+    }
+
+    PageHeader {
+        text: profile.name || qsTrId("id-profiles")
+    }
+}

--- a/src/qml/ProfileEditPage.qml
+++ b/src/qml/ProfileEditPage.qml
@@ -25,7 +25,8 @@ Item {
 
     property string profileId: ""
     property bool isNewProfile: false
-    property var profile: ({})
+    property var profileData: ({})
+    property bool isLoading: true
 
     property var sensorModeLabels: ({
         "off": qsTrId("id-off"),
@@ -49,11 +50,13 @@ Item {
 
         function handleError(error) {
             console.log("Profile Edit D-Bus error:", error)
+            isLoading = false
         }
 
         function loadProfile() {
+            isLoading = true
             if (isNewProfile) {
-                profile = {
+                profileData = {
                     "id": "",
                     "name": qsTrId("id-new-profile"),
                     "icon": "ios-battery-outline",
@@ -98,9 +101,11 @@ Item {
                         "workout_profiles": {}
                     }
                 }
+                isLoading = false
             } else {
                 typedCall("GetProfile", [profileId], function(result) {
-                    profile = JSON.parse(result)
+                    profileData = JSON.parse(result)
+                    isLoading = false
                 }, handleError)
             }
         }
@@ -110,8 +115,50 @@ Item {
         }
     }
 
+    function updateSensor(sensorName, value) {
+        if (!profileData.sensors) profileData.sensors = {}
+        profileData.sensors[sensorName] = value
+        profileDataChanged()
+    }
+
+    function updateRadioState(radioName, state) {
+        if (!profileData.radios) profileData.radios = {}
+        if (!profileData.radios[radioName]) profileData.radios[radioName] = {}
+        profileData.radios[radioName].state = state
+        profileDataChanged()
+    }
+
+    function updateRadioSyncMode(radioName, mode) {
+        if (!profileData.radios) profileData.radios = {}
+        if (!profileData.radios[radioName]) profileData.radios[radioName] = {}
+        profileData.radios[radioName].sync_mode = mode
+        profileDataChanged()
+    }
+
+    function updateRadioInterval(radioName, interval) {
+        if (!profileData.radios) profileData.radios = {}
+        if (!profileData.radios[radioName]) profileData.radios[radioName] = {}
+        profileData.radios[radioName].interval_hours = interval
+        profileDataChanged()
+    }
+
+    function updateRadioDisableSleep(radioName, disable) {
+        if (!profileData.radios) profileData.radios = {}
+        if (!profileData.radios[radioName]) profileData.radios[radioName] = {}
+        profileData.radios[radioName].disable_during_sleep = disable
+        profileDataChanged()
+    }
+
+    function updateSystemSetting(setting, value) {
+        if (!profileData.system) profileData.system = {}
+        profileData.system[setting] = value
+        profileDataChanged()
+    }
+
+    signal profileDataChanged()
+
     function saveProfile() {
-        var profileJson = JSON.stringify(profile)
+        var profileJson = JSON.stringify(profileData)
         
         if (isNewProfile) {
             powerd.typedCall("AddProfile", [profileJson], function(newId) {
@@ -136,7 +183,25 @@ Item {
         }, powerd.handleError)
     }
 
-    property string rowHeight: Dims.h(15)
+    Component {
+        id: automationEditLayer
+        AutomationEditPage {
+            profileId: root.profileId
+        }
+    }
+
+    Item {
+        anchors.fill: parent
+        visible: isLoading
+
+        Label {
+            anchors.centerIn: parent
+            //% "Loading..."
+            text: qsTrId("id-loading")
+            font.pixelSize: Dims.l(6)
+            opacity: 0.6
+        }
+    }
 
     Flickable {
         anchors.fill: parent
@@ -144,6 +209,7 @@ Item {
         anchors.bottomMargin: Dims.h(5)
         contentHeight: contentColumn.implicitHeight
         clip: true
+        visible: !isLoading
 
         Column {
             id: contentColumn
@@ -170,144 +236,126 @@ Item {
             RowSeparator {}
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "Accelerometer"
                 text: qsTrId("id-accelerometer")
                 valueArray: ["off", "low", "medium", "high", "workout"]
-                currentValue: profile.sensors ? profile.sensors.accelerometer : "medium"
-                onValueChanged: {
-                    if (profile.sensors) {
-                        profile.sensors.accelerometer = value
-                    }
+                currentValue: profileData.sensors ? profileData.sensors.accelerometer : "medium"
+                onCurrentValueChanged: {
+                    updateSensor("accelerometer", currentValue)
                 }
             }
 
             RowSeparator {}
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "Gyroscope"
                 text: qsTrId("id-gyroscope")
                 valueArray: ["off", "low", "medium", "high", "workout"]
-                currentValue: profile.sensors ? profile.sensors.gyroscope : "medium"
-                onValueChanged: {
-                    if (profile.sensors) {
-                        profile.sensors.gyroscope = value
-                    }
+                currentValue: profileData.sensors ? profileData.sensors.gyroscope : "medium"
+                onCurrentValueChanged: {
+                    updateSensor("gyroscope", currentValue)
                 }
             }
 
             RowSeparator {}
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "Heart Rate"
                 text: qsTrId("id-heart-rate")
                 valueArray: ["off", "low", "medium", "high", "workout"]
-                currentValue: profile.sensors ? profile.sensors.heart_rate : "medium"
-                onValueChanged: {
-                    if (profile.sensors) {
-                        profile.sensors.heart_rate = value
-                    }
+                currentValue: profileData.sensors ? profileData.sensors.heart_rate : "medium"
+                onCurrentValueChanged: {
+                    updateSensor("heart_rate", currentValue)
                 }
             }
 
             RowSeparator {}
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "HRV"
                 text: qsTrId("id-hrv")
                 valueArray: ["off", "sleep_only", "always"]
-                currentValue: profile.sensors ? profile.sensors.hrv : "sleep_only"
-                onValueChanged: {
-                    if (profile.sensors) {
-                        profile.sensors.hrv = value
-                    }
+                currentValue: profileData.sensors ? profileData.sensors.hrv : "sleep_only"
+                onCurrentValueChanged: {
+                    updateSensor("hrv", currentValue)
                 }
             }
 
             RowSeparator {}
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "SpO2"
                 text: qsTrId("id-spo2")
                 valueArray: ["off", "periodic", "continuous"]
-                currentValue: profile.sensors ? profile.sensors.spo2 : "off"
-                onValueChanged: {
-                    if (profile.sensors) {
-                        profile.sensors.spo2 = value
-                    }
+                currentValue: profileData.sensors ? profileData.sensors.spo2 : "off"
+                onCurrentValueChanged: {
+                    updateSensor("spo2", currentValue)
                 }
             }
 
             RowSeparator {}
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "Barometer"
                 text: qsTrId("id-barometer")
                 valueArray: ["off", "low", "high"]
-                currentValue: profile.sensors ? profile.sensors.barometer : "low"
-                onValueChanged: {
-                    if (profile.sensors) {
-                        profile.sensors.barometer = value
-                    }
+                currentValue: profileData.sensors ? profileData.sensors.barometer : "low"
+                onCurrentValueChanged: {
+                    updateSensor("barometer", currentValue)
                 }
             }
 
             RowSeparator {}
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "Compass"
                 text: qsTrId("id-compass")
                 valueArray: ["off", "on_demand", "continuous"]
-                currentValue: profile.sensors ? profile.sensors.compass : "on_demand"
-                onValueChanged: {
-                    if (profile.sensors) {
-                        profile.sensors.compass = value
-                    }
+                currentValue: profileData.sensors ? profileData.sensors.compass : "on_demand"
+                onCurrentValueChanged: {
+                    updateSensor("compass", currentValue)
                 }
             }
 
             RowSeparator {}
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "Ambient Light"
                 text: qsTrId("id-ambient-light")
                 valueArray: ["off", "low", "high"]
-                currentValue: profile.sensors ? profile.sensors.ambient_light : "low"
-                onValueChanged: {
-                    if (profile.sensors) {
-                        profile.sensors.ambient_light = value
-                    }
+                currentValue: profileData.sensors ? profileData.sensors.ambient_light : "low"
+                onCurrentValueChanged: {
+                    updateSensor("ambient_light", currentValue)
                 }
             }
 
             RowSeparator {}
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "GPS"
                 text: qsTrId("id-gps")
                 valueArray: ["off", "periodic", "continuous"]
-                currentValue: profile.sensors ? profile.sensors.gps : "off"
-                onValueChanged: {
-                    if (profile.sensors) {
-                        profile.sensors.gps = value
-                    }
+                currentValue: profileData.sensors ? profileData.sensors.gps : "off"
+                onCurrentValueChanged: {
+                    updateSensor("gps", currentValue)
                 }
             }
 
@@ -332,108 +380,96 @@ Item {
             RowSeparator {}
 
             LabeledSwitch {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "Bluetooth"
                 text: qsTrId("id-bluetooth")
-                checked: profile.radios && profile.radios.ble ? profile.radios.ble.state === "on" : true
+                checked: profileData.radios && profileData.radios.ble ? profileData.radios.ble.state === "on" : true
                 onCheckedChanged: {
-                    if (profile.radios && profile.radios.ble) {
-                        profile.radios.ble.state = checked ? "on" : "off"
-                    }
+                    updateRadioState("ble", checked ? "on" : "off")
                 }
             }
 
             RowSeparator {}
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
-                visible: profile.radios && profile.radios.ble && profile.radios.ble.state === "on"
+                visible: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on"
                 //% "BLE Sync"
                 text: qsTrId("id-ble-sync")
                 valueArray: ["manual", "interval", "time_window"]
-                currentValue: profile.radios && profile.radios.ble ? profile.radios.ble.sync_mode : "interval"
-                onValueChanged: {
-                    if (profile.radios && profile.radios.ble) {
-                        profile.radios.ble.sync_mode = value
-                    }
+                currentValue: profileData.radios && profileData.radios.ble ? profileData.radios.ble.sync_mode : "interval"
+                onCurrentValueChanged: {
+                    updateRadioSyncMode("ble", currentValue)
                 }
             }
 
             RowSeparator {
-                visible: profile.radios && profile.radios.ble && profile.radios.ble.state === "on"
+                visible: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on"
             }
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
-                visible: profile.radios && profile.radios.ble && profile.radios.ble.state === "on" && profile.radios.ble.sync_mode === "interval"
+                visible: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on" && profileData.radios.ble.sync_mode === "interval"
                 //% "BLE Interval"
                 text: qsTrId("id-ble-interval")
                 valueArray: ["1", "2", "5", "10"]
-                currentValue: profile.radios && profile.radios.ble ? String(profile.radios.ble.interval_hours) : "2"
-                onValueChanged: {
-                    if (profile.radios && profile.radios.ble) {
-                        profile.radios.ble.interval_hours = parseInt(value)
-                    }
+                currentValue: profileData.radios && profileData.radios.ble ? String(profileData.radios.ble.interval_hours) : "2"
+                onCurrentValueChanged: {
+                    updateRadioInterval("ble", parseInt(currentValue))
                 }
             }
 
             RowSeparator {
-                visible: profile.radios && profile.radios.ble && profile.radios.ble.state === "on" && profile.radios.ble.sync_mode === "interval"
+                visible: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on" && profileData.radios.ble.sync_mode === "interval"
             }
 
             LabeledSwitch {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
-                visible: profile.radios && profile.radios.ble && profile.radios.ble.state === "on" && profile.radios.ble.sync_mode === "interval"
+                visible: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on" && profileData.radios.ble.sync_mode === "interval"
                 //% "Disable during sleep"
                 text: qsTrId("id-ble-disable-sleep")
-                checked: profile.radios && profile.radios.ble ? profile.radios.ble.disable_during_sleep : false
+                checked: profileData.radios && profileData.radios.ble ? profileData.radios.ble.disable_during_sleep : false
                 onCheckedChanged: {
-                    if (profile.radios && profile.radios.ble) {
-                        profile.radios.ble.disable_during_sleep = checked
-                    }
+                    updateRadioDisableSleep("ble", checked)
                 }
             }
 
             RowSeparator {
-                visible: profile.radios && profile.radios.ble && profile.radios.ble.state === "on" && profile.radios.ble.sync_mode === "interval"
+                visible: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on" && profileData.radios.ble.sync_mode === "interval"
             }
 
             LabeledSwitch {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "Wi-Fi"
                 text: qsTrId("id-wifi")
-                checked: profile.radios && profile.radios.wifi ? profile.radios.wifi.state === "on" : false
+                checked: profileData.radios && profileData.radios.wifi ? profileData.radios.wifi.state === "on" : false
                 onCheckedChanged: {
-                    if (profile.radios && profile.radios.wifi) {
-                        profile.radios.wifi.state = checked ? "on" : "off"
-                    }
+                    updateRadioState("wifi", checked ? "on" : "off")
                 }
             }
 
             RowSeparator {}
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
-                visible: profile.radios && profile.radios.wifi && profile.radios.wifi.state === "on"
+                visible: profileData.radios && profileData.radios.wifi && profileData.radios.wifi.state === "on"
                 //% "Wi-Fi Sync"
                 text: qsTrId("id-wifi-sync")
                 valueArray: ["manual", "interval", "time_window"]
-                currentValue: profile.radios && profile.radios.wifi ? profile.radios.wifi.sync_mode : "manual"
-                onValueChanged: {
-                    if (profile.radios && profile.radios.wifi) {
-                        profile.radios.wifi.sync_mode = value
-                    }
+                currentValue: profileData.radios && profileData.radios.wifi ? profileData.radios.wifi.sync_mode : "manual"
+                onCurrentValueChanged: {
+                    updateRadioSyncMode("wifi", currentValue)
                 }
             }
 
             RowSeparator {
-                visible: profile.radios && profile.radios.wifi && profile.radios.wifi.state === "on"
+                visible: profileData.radios && profileData.radios.wifi && profileData.radios.wifi.state === "on"
             }
 
             Item {
@@ -455,46 +491,40 @@ Item {
             RowSeparator {}
 
             LabeledSwitch {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "Always-on Display"
                 text: qsTrId("id-always-on-display")
-                checked: profile.system ? profile.system.always_on_display : true
+                checked: profileData.system ? profileData.system.always_on_display : true
                 onCheckedChanged: {
-                    if (profile.system) {
-                        profile.system.always_on_display = checked
-                    }
+                    updateSystemSetting("always_on_display", checked)
                 }
             }
 
             RowSeparator {}
 
             LabeledSwitch {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "Tilt-to-wake"
                 text: qsTrId("id-tilt-to-wake")
-                checked: profile.system ? profile.system.tilt_to_wake : true
+                checked: profileData.system ? profileData.system.tilt_to_wake : true
                 onCheckedChanged: {
-                    if (profile.system) {
-                        profile.system.tilt_to_wake = checked
-                    }
+                    updateSystemSetting("tilt_to_wake", checked)
                 }
             }
 
             RowSeparator {}
 
             OptionCycler {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
                 //% "Background Sync"
                 text: qsTrId("id-background-sync")
                 valueArray: ["auto", "when_radios_on", "off"]
-                currentValue: profile.system ? profile.system.background_sync : "when_radios_on"
-                onValueChanged: {
-                    if (profile.system) {
-                        profile.system.background_sync = value
-                    }
+                currentValue: profileData.system ? profileData.system.background_sync : "when_radios_on"
+                onCurrentValueChanged: {
+                    updateSystemSetting("background_sync", currentValue)
                 }
             }
 
@@ -519,37 +549,15 @@ Item {
             RowSeparator {}
 
             ListItem {
-                height: rowHeight
+                height: Dims.h(15)
                 width: parent.width
-                //% "Battery Rules"
-                title: qsTrId("id-battery-rules")
-                iconName: "ios-battery-charging-outline"
-                enabled: false
-                opacity: 0.5
-            }
-
-            RowSeparator {}
-
-            ListItem {
-                height: rowHeight
-                width: parent.width
-                //% "Time Rules"
-                title: qsTrId("id-time-rules")
-                iconName: "ios-time-outline"
-                enabled: false
-                opacity: 0.5
-            }
-
-            RowSeparator {}
-
-            ListItem {
-                height: rowHeight
-                width: parent.width
-                //% "Workout Profiles"
-                title: qsTrId("id-workout-profiles")
-                iconName: "ios-walk-outline"
-                enabled: false
-                opacity: 0.5
+                //% "Battery & Time Rules"
+                title: qsTrId("id-battery-time-rules")
+                iconName: "ios-cog-outline"
+                
+                onClicked: {
+                    layerStack.push(automationEditLayer)
+                }
             }
 
             RowSeparator {}
@@ -621,6 +629,6 @@ Item {
     }
 
     PageHeader {
-        text: profile.name || qsTrId("id-profiles")
+        text: profileData.name || qsTrId("id-profiles")
     }
 }

--- a/src/qml/ProfileEditPage.qml
+++ b/src/qml/ProfileEditPage.qml
@@ -27,6 +27,7 @@ Item {
     property bool isNewProfile: false
     property var profileData: ({})
     property bool isLoading: true
+    property bool isBuiltin: false
 
     property var sensorModeLabels: ({
         "off": qsTrId("id-off"),
@@ -59,7 +60,7 @@ Item {
                 profileData = {
                     "id": "",
                     "name": qsTrId("id-new-profile"),
-                    "icon": "ios-battery-outline",
+                    "icon": "ios-battery-full",
                     "color": "#2196F3",
                     "sensors": {
                         "accelerometer": "medium",
@@ -103,8 +104,9 @@ Item {
                 }
                 isLoading = false
             } else {
-                typedCall("GetProfile", [profileId], function(result) {
+                typedCall("GetProfile", [{"type": "s", "value": profileId}], function(result) {
                     profileData = JSON.parse(result)
+                    isBuiltin = profileData.builtin === true
                     isLoading = false
                 }, handleError)
             }
@@ -115,72 +117,103 @@ Item {
         }
     }
 
+    function persistProfile() {
+        if (isLoading) return
+        var profileJson = JSON.stringify(profileData)
+        if (isNewProfile) {
+            powerd.typedCall("AddProfile",
+                [{"type": "s", "value": profileJson}],
+                function(newId) {
+                    if (newId) {
+                        profileId = newId
+                        isNewProfile = false
+                        profileData.id = newId
+                        profileData = profileData
+                    }
+                }, powerd.handleError)
+        } else {
+            powerd.typedCall("UpdateProfile",
+                [{"type": "s", "value": profileJson}],
+                function(success) {}, powerd.handleError)
+        }
+    }
+
     function updateSensor(sensorName, value) {
         if (!profileData.sensors) profileData.sensors = {}
         profileData.sensors[sensorName] = value
-        profileDataChanged()
+        profileData = profileData
+        persistProfile()
     }
 
     function updateRadioState(radioName, state) {
         if (!profileData.radios) profileData.radios = {}
         if (!profileData.radios[radioName]) profileData.radios[radioName] = {}
         profileData.radios[radioName].state = state
-        profileDataChanged()
+        profileData = profileData
+        persistProfile()
     }
 
     function updateRadioSyncMode(radioName, mode) {
         if (!profileData.radios) profileData.radios = {}
         if (!profileData.radios[radioName]) profileData.radios[radioName] = {}
         profileData.radios[radioName].sync_mode = mode
-        profileDataChanged()
+        profileData = profileData
+        persistProfile()
     }
 
     function updateRadioInterval(radioName, interval) {
         if (!profileData.radios) profileData.radios = {}
         if (!profileData.radios[radioName]) profileData.radios[radioName] = {}
         profileData.radios[radioName].interval_hours = interval
-        profileDataChanged()
+        profileData = profileData
+        persistProfile()
     }
 
     function updateRadioDisableSleep(radioName, disable) {
         if (!profileData.radios) profileData.radios = {}
         if (!profileData.radios[radioName]) profileData.radios[radioName] = {}
         profileData.radios[radioName].disable_during_sleep = disable
-        profileDataChanged()
+        profileData = profileData
+        persistProfile()
     }
 
     function updateSystemSetting(setting, value) {
         if (!profileData.system) profileData.system = {}
         profileData.system[setting] = value
-        profileDataChanged()
+        profileData = profileData
+        persistProfile()
     }
-
-    signal profileDataChanged()
 
     function saveProfile() {
         var profileJson = JSON.stringify(profileData)
         
         if (isNewProfile) {
-            powerd.typedCall("AddProfile", [profileJson], function(newId) {
-                if (newId) {
-                    layerStack.pop(root)
-                }
-            }, powerd.handleError)
+            powerd.typedCall("AddProfile",
+                [{"type": "s", "value": profileJson}],
+                function(newId) {
+                    if (newId) {
+                        layerStack.pop(root)
+                    }
+                }, powerd.handleError)
         } else {
-            powerd.typedCall("UpdateProfile", [profileJson], function(success) {
-                if (success) {
-                    layerStack.pop(root)
-                }
-            }, powerd.handleError)
+            powerd.typedCall("UpdateProfile",
+                [{"type": "s", "value": profileJson}],
+                function(success) {
+                    if (success) {
+                        layerStack.pop(root)
+                    }
+                }, powerd.handleError)
         }
     }
 
     function deleteProfile() {
-        powerd.typedCall("DeleteProfile", [profileId], function(success) {
-            if (success) {
-                layerStack.pop(root)
-            }
-        }, powerd.handleError)
+        powerd.typedCall("DeleteProfile",
+            [{"type": "s", "value": profileId}],
+            function(success) {
+                if (success) {
+                    layerStack.pop(root)
+                }
+            }, powerd.handleError)
     }
 
     Component {
@@ -235,127 +268,121 @@ Item {
 
             RowSeparator {}
 
-            OptionCycler {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 //% "Accelerometer"
                 text: qsTrId("id-accelerometer")
                 valueArray: ["off", "low", "medium", "high", "workout"]
                 currentValue: profileData.sensors ? profileData.sensors.accelerometer : "medium"
-                onCurrentValueChanged: {
-                    updateSensor("accelerometer", currentValue)
+                onValueChanged: {
+                    currentValue = value
+                    updateSensor("accelerometer", value)
                 }
             }
 
             RowSeparator {}
 
-            OptionCycler {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 //% "Gyroscope"
                 text: qsTrId("id-gyroscope")
                 valueArray: ["off", "low", "medium", "high", "workout"]
                 currentValue: profileData.sensors ? profileData.sensors.gyroscope : "medium"
-                onCurrentValueChanged: {
-                    updateSensor("gyroscope", currentValue)
+                onValueChanged: {
+                    currentValue = value
+                    updateSensor("gyroscope", value)
                 }
             }
 
             RowSeparator {}
 
-            OptionCycler {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
-                //% "Heart Rate"
+                //% "Heart\nRate"
                 text: qsTrId("id-heart-rate")
                 valueArray: ["off", "low", "medium", "high", "workout"]
                 currentValue: profileData.sensors ? profileData.sensors.heart_rate : "medium"
-                onCurrentValueChanged: {
-                    updateSensor("heart_rate", currentValue)
+                onValueChanged: {
+                    currentValue = value
+                    updateSensor("heart_rate", value)
                 }
             }
 
             RowSeparator {}
 
-            OptionCycler {
-                height: Dims.h(15)
-                width: parent.width
-                //% "HRV"
-                text: qsTrId("id-hrv")
-                valueArray: ["off", "sleep_only", "always"]
-                currentValue: profileData.sensors ? profileData.sensors.hrv : "sleep_only"
-                onCurrentValueChanged: {
-                    updateSensor("hrv", currentValue)
-                }
-            }
-
-            RowSeparator {}
-
-            OptionCycler {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 //% "SpO2"
                 text: qsTrId("id-spo2")
                 valueArray: ["off", "periodic", "continuous"]
                 currentValue: profileData.sensors ? profileData.sensors.spo2 : "off"
-                onCurrentValueChanged: {
-                    updateSensor("spo2", currentValue)
+                onValueChanged: {
+                    currentValue = value
+                    updateSensor("spo2", value)
                 }
             }
 
             RowSeparator {}
 
-            OptionCycler {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 //% "Barometer"
                 text: qsTrId("id-barometer")
                 valueArray: ["off", "low", "high"]
                 currentValue: profileData.sensors ? profileData.sensors.barometer : "low"
-                onCurrentValueChanged: {
-                    updateSensor("barometer", currentValue)
+                onValueChanged: {
+                    currentValue = value
+                    updateSensor("barometer", value)
                 }
             }
 
             RowSeparator {}
 
-            OptionCycler {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 //% "Compass"
                 text: qsTrId("id-compass")
                 valueArray: ["off", "on_demand", "continuous"]
                 currentValue: profileData.sensors ? profileData.sensors.compass : "on_demand"
-                onCurrentValueChanged: {
-                    updateSensor("compass", currentValue)
+                onValueChanged: {
+                    currentValue = value
+                    updateSensor("compass", value)
                 }
             }
 
             RowSeparator {}
 
-            OptionCycler {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
-                //% "Ambient Light"
+                //% "Ambient\nLight"
                 text: qsTrId("id-ambient-light")
                 valueArray: ["off", "low", "high"]
                 currentValue: profileData.sensors ? profileData.sensors.ambient_light : "low"
-                onCurrentValueChanged: {
-                    updateSensor("ambient_light", currentValue)
+                onValueChanged: {
+                    currentValue = value
+                    updateSensor("ambient_light", value)
                 }
             }
 
             RowSeparator {}
 
-            OptionCycler {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 //% "GPS"
                 text: qsTrId("id-gps")
                 valueArray: ["off", "periodic", "continuous"]
                 currentValue: profileData.sensors ? profileData.sensors.gps : "off"
-                onCurrentValueChanged: {
-                    updateSensor("gps", currentValue)
+                onValueChanged: {
+                    currentValue = value
+                    updateSensor("gps", value)
                 }
             }
 
@@ -379,20 +406,22 @@ Item {
 
             RowSeparator {}
 
-            LabeledSwitch {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 //% "Bluetooth"
                 text: qsTrId("id-bluetooth")
-                checked: profileData.radios && profileData.radios.ble ? profileData.radios.ble.state === "on" : true
-                onCheckedChanged: {
-                    updateRadioState("ble", checked ? "on" : "off")
+                valueArray: ["off", "on"]
+                currentValue: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on" ? "on" : "off"
+                onValueChanged: {
+                    currentValue = value
+                    updateRadioState("ble", value)
                 }
             }
 
             RowSeparator {}
 
-            OptionCycler {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 visible: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on"
@@ -400,8 +429,9 @@ Item {
                 text: qsTrId("id-ble-sync")
                 valueArray: ["manual", "interval", "time_window"]
                 currentValue: profileData.radios && profileData.radios.ble ? profileData.radios.ble.sync_mode : "interval"
-                onCurrentValueChanged: {
-                    updateRadioSyncMode("ble", currentValue)
+                onValueChanged: {
+                    currentValue = value
+                    updateRadioSyncMode("ble", value)
                 }
             }
 
@@ -409,16 +439,17 @@ Item {
                 visible: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on"
             }
 
-            OptionCycler {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 visible: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on" && profileData.radios.ble.sync_mode === "interval"
-                //% "BLE Interval"
+                //% "BLE\nInterval"
                 text: qsTrId("id-ble-interval")
-                valueArray: ["1", "2", "5", "10"]
-                currentValue: profileData.radios && profileData.radios.ble ? String(profileData.radios.ble.interval_hours) : "2"
-                onCurrentValueChanged: {
-                    updateRadioInterval("ble", parseInt(currentValue))
+                valueArray: ["1h", "5h", "10h", "24h"]
+                currentValue: profileData.radios && profileData.radios.ble ? profileData.radios.ble.interval_hours + "h" : "5h"
+                onValueChanged: {
+                    currentValue = value
+                    updateRadioInterval("ble", parseInt(value))
                 }
             }
 
@@ -426,15 +457,17 @@ Item {
                 visible: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on" && profileData.radios.ble.sync_mode === "interval"
             }
 
-            LabeledSwitch {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 visible: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on" && profileData.radios.ble.sync_mode === "interval"
-                //% "Disable during sleep"
+                //% "Disable\nDuring Sleep"
                 text: qsTrId("id-ble-disable-sleep")
-                checked: profileData.radios && profileData.radios.ble ? profileData.radios.ble.disable_during_sleep : false
-                onCheckedChanged: {
-                    updateRadioDisableSleep("ble", checked)
+                valueArray: ["off", "on"]
+                currentValue: profileData.radios && profileData.radios.ble && profileData.radios.ble.disable_during_sleep ? "on" : "off"
+                onValueChanged: {
+                    currentValue = value
+                    updateRadioDisableSleep("ble", value === "on")
                 }
             }
 
@@ -442,29 +475,32 @@ Item {
                 visible: profileData.radios && profileData.radios.ble && profileData.radios.ble.state === "on" && profileData.radios.ble.sync_mode === "interval"
             }
 
-            LabeledSwitch {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 //% "Wi-Fi"
                 text: qsTrId("id-wifi")
-                checked: profileData.radios && profileData.radios.wifi ? profileData.radios.wifi.state === "on" : false
-                onCheckedChanged: {
-                    updateRadioState("wifi", checked ? "on" : "off")
+                valueArray: ["off", "on"]
+                currentValue: profileData.radios && profileData.radios.wifi && profileData.radios.wifi.state === "on" ? "on" : "off"
+                onValueChanged: {
+                    currentValue = value
+                    updateRadioState("wifi", value)
                 }
             }
 
             RowSeparator {}
 
-            OptionCycler {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 visible: profileData.radios && profileData.radios.wifi && profileData.radios.wifi.state === "on"
-                //% "Wi-Fi Sync"
+                //% "Wi-Fi\nSync"
                 text: qsTrId("id-wifi-sync")
                 valueArray: ["manual", "interval", "time_window"]
                 currentValue: profileData.radios && profileData.radios.wifi ? profileData.radios.wifi.sync_mode : "manual"
-                onCurrentValueChanged: {
-                    updateRadioSyncMode("wifi", currentValue)
+                onValueChanged: {
+                    currentValue = value
+                    updateRadioSyncMode("wifi", value)
                 }
             }
 
@@ -490,41 +526,46 @@ Item {
 
             RowSeparator {}
 
-            LabeledSwitch {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
-                //% "Always-on Display"
+                //% "Always-on\nDisplay"
                 text: qsTrId("id-always-on-display")
-                checked: profileData.system ? profileData.system.always_on_display : true
-                onCheckedChanged: {
-                    updateSystemSetting("always_on_display", checked)
+                valueArray: ["off", "on"]
+                currentValue: profileData.system && profileData.system.always_on_display ? "on" : "off"
+                onValueChanged: {
+                    currentValue = value
+                    updateSystemSetting("always_on_display", value === "on")
                 }
             }
 
             RowSeparator {}
 
-            LabeledSwitch {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
                 //% "Tilt-to-wake"
                 text: qsTrId("id-tilt-to-wake")
-                checked: profileData.system ? profileData.system.tilt_to_wake : true
-                onCheckedChanged: {
-                    updateSystemSetting("tilt_to_wake", checked)
+                valueArray: ["off", "on"]
+                currentValue: profileData.system && profileData.system.tilt_to_wake ? "on" : "off"
+                onValueChanged: {
+                    currentValue = value
+                    updateSystemSetting("tilt_to_wake", value === "on")
                 }
             }
 
             RowSeparator {}
 
-            OptionCycler {
+            FillBarRow {
                 height: Dims.h(15)
                 width: parent.width
-                //% "Background Sync"
+                //% "Background\nSync"
                 text: qsTrId("id-background-sync")
                 valueArray: ["auto", "when_radios_on", "off"]
                 currentValue: profileData.system ? profileData.system.background_sync : "when_radios_on"
-                onCurrentValueChanged: {
-                    updateSystemSetting("background_sync", currentValue)
+                onValueChanged: {
+                    currentValue = value
+                    updateSystemSetting("background_sync", value)
                 }
             }
 
@@ -551,7 +592,7 @@ Item {
             ListItem {
                 height: Dims.h(15)
                 width: parent.width
-                //% "Battery & Time Rules"
+                //% "Battery / Time Rules"
                 title: qsTrId("id-battery-time-rules")
                 iconName: "ios-cog-outline"
                 
@@ -570,29 +611,7 @@ Item {
             Item {
                 width: parent.width
                 height: Dims.h(18)
-
-                IconButton {
-                    anchors.centerIn: parent
-                    width: parent.width * 0.8
-                    height: Dims.h(15)
-                    iconName: "ios-checkmark-circle-outline"
-                    iconColor: "#4CAF50"
-
-                    onClicked: saveProfile()
-                }
-
-                Label {
-                    anchors.centerIn: parent
-                    //% "Save"
-                    text: qsTrId("id-save")
-                    font.pixelSize: Dims.l(6)
-                }
-            }
-
-            Item {
-                width: parent.width
-                height: Dims.h(18)
-                visible: !isNewProfile
+                visible: !isNewProfile && !isBuiltin
 
                 IconButton {
                     anchors.centerIn: parent

--- a/src/qml/ProfileListPage.qml
+++ b/src/qml/ProfileListPage.qml
@@ -96,12 +96,7 @@ Item {
             height: listItem.height
 
             property bool isActive: model.id === activeProfileId
-            property bool isDefault: model.id && (
-                model.id.indexOf("ultra_saver") === 0 ||
-                model.id.indexOf("health") === 0 ||
-                model.id.indexOf("smartwatch") === 0 ||
-                model.id.indexOf("performance") === 0
-            )
+            property bool isBuiltin: model.builtin === true
 
             ListItem {
                 id: listItem
@@ -131,7 +126,7 @@ Item {
                 }
 
                 onPressAndHold: {
-                    if (!isDefault) {
+                    if (!isBuiltin) {
                         deleteRemorse.execute(listItem, "", function() {
                             powerd.typedCall("DeleteProfile", [model.id], function(success) {
                                 if (success) {

--- a/src/qml/ProfileListPage.qml
+++ b/src/qml/ProfileListPage.qml
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2024 - AsteroidOS Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
+import Nemo.DBus 2.0
+
+Item {
+    id: root
+
+    property string activeProfileId: ""
+
+    ListModel {
+        id: profilesModel
+    }
+
+    DBusInterface {
+        id: powerd
+        bus: DBus.SystemBus
+        service: "org.asteroidos.powerd"
+        path: "/org/asteroidos/powerd"
+        iface: "org.asteroidos.powerd.ProfileManager"
+
+        signalsEnabled: true
+
+        function handleError(error) {
+            console.log("Profile List D-Bus error:", error)
+        }
+
+        function loadData() {
+            typedCall("GetActiveProfile", [], function(result) {
+                activeProfileId = result
+            }, handleError)
+
+            typedCall("GetProfiles", [], function(result) {
+                var profiles = JSON.parse(result)
+                profilesModel.clear()
+                for (var i = 0; i < profiles.length; i++) {
+                    profilesModel.append(profiles[i])
+                }
+            }, handleError)
+        }
+
+        Component.onCompleted: {
+            loadData()
+        }
+
+        onServiceAvailableChanged: {
+            if (available) {
+                loadData()
+            }
+        }
+    }
+
+    Connections {
+        target: powerd
+        onActiveProfileChanged: {
+            activeProfileId = id
+        }
+        onProfilesChanged: {
+            powerd.loadData()
+        }
+    }
+
+    Component {
+        id: profileEditLayer
+        ProfileEditPage {}
+    }
+
+    ListView {
+        id: profileListView
+        anchors.fill: parent
+        anchors.topMargin: Dims.h(15)
+        anchors.bottomMargin: Dims.h(5)
+        model: profilesModel
+        clip: true
+        spacing: 0
+
+        delegate: Item {
+            width: parent.width
+            height: listItem.height
+
+            property bool isActive: model.id === activeProfileId
+            property bool isDefault: model.id && (
+                model.id.indexOf("ultra_saver") === 0 ||
+                model.id.indexOf("health") === 0 ||
+                model.id.indexOf("smartwatch") === 0 ||
+                model.id.indexOf("performance") === 0
+            )
+
+            ListItem {
+                id: listItem
+                height: Dims.h(15)
+                width: parent.width
+                title: model.name
+                iconName: model.icon || "ios-battery-outline"
+
+                Rectangle {
+                    anchors.fill: parent
+                    color: "#FFFFFF"
+                    opacity: isActive ? 0.1 : 0
+                    z: -1
+                }
+
+                Label {
+                    anchors.right: parent.right
+                    anchors.rightMargin: Dims.w(8)
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "✓"
+                    font.pixelSize: Dims.l(8)
+                    visible: isActive
+                }
+
+                onClicked: {
+                    layerStack.push(profileEditLayer, {profileId: model.id})
+                }
+
+                onPressAndHold: {
+                    if (!isDefault) {
+                        deleteRemorse.execute(listItem, "", function() {
+                            powerd.typedCall("DeleteProfile", [model.id], function(success) {
+                                if (success) {
+                                    powerd.loadData()
+                                }
+                            }, powerd.handleError)
+                        })
+                    }
+                }
+
+                RemorseTimer {
+                    id: deleteRemorse
+                }
+            }
+
+            RowSeparator {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+            }
+        }
+
+        footer: Item {
+            width: parent.width
+            height: addButton.height + Dims.h(5)
+
+            ListItem {
+                id: addButton
+                height: Dims.h(15)
+                width: parent.width
+                //% "Add New Profile"
+                title: qsTrId("id-add-new-profile")
+                iconName: "ios-add-circle-outline"
+
+                onClicked: {
+                    layerStack.push(profileEditLayer, {profileId: "", isNewProfile: true})
+                }
+            }
+
+            RowSeparator {
+                anchors.top: parent.top
+                anchors.left: parent.left
+                anchors.right: parent.right
+            }
+        }
+
+        Item {
+            id: emptyState
+            anchors.centerIn: parent
+            width: parent.width * 0.8
+            visible: profilesModel.count === 0
+
+            Column {
+                anchors.centerIn: parent
+                spacing: Dims.h(3)
+                width: parent.width
+
+                Label {
+                    width: parent.width
+                    horizontalAlignment: Text.AlignHCenter
+                    //% "No profiles available"
+                    text: qsTrId("id-no-profiles")
+                    font.pixelSize: Dims.l(6)
+                    wrapMode: Text.WordWrap
+                }
+
+                Label {
+                    width: parent.width
+                    horizontalAlignment: Text.AlignHCenter
+                    //% "Service may be unavailable"
+                    text: qsTrId("id-service-may-be-unavailable")
+                    font.pixelSize: Dims.l(4)
+                    opacity: 0.6
+                    wrapMode: Text.WordWrap
+                }
+            }
+        }
+    }
+
+    PageHeader {
+        //% "Profiles"
+        text: qsTrId("id-profiles")
+    }
+}

--- a/src/qml/ProfileListPage.qml
+++ b/src/qml/ProfileListPage.qml
@@ -56,24 +56,16 @@ Item {
             }, handleError)
         }
 
-        Component.onCompleted: {
+        function activeProfileChanged(newId) {
+            activeProfileId = newId
+        }
+
+        function profilesChanged() {
             loadData()
         }
 
-        onServiceAvailableChanged: {
-            if (available) {
-                loadData()
-            }
-        }
-    }
-
-    Connections {
-        target: powerd
-        onActiveProfileChanged: {
-            activeProfileId = id
-        }
-        onProfilesChanged: {
-            powerd.loadData()
+        Component.onCompleted: {
+            loadData()
         }
     }
 
@@ -103,43 +95,33 @@ Item {
                 height: Dims.h(15)
                 width: parent.width
                 title: model.name
-                iconName: model.icon || "ios-battery-outline"
-
-                Rectangle {
-                    anchors.fill: parent
-                    color: "#FFFFFF"
-                    opacity: isActive ? 0.1 : 0
-                    z: -1
-                }
-
-                Label {
-                    anchors.right: parent.right
-                    anchors.rightMargin: Dims.w(8)
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: "✓"
-                    font.pixelSize: Dims.l(8)
-                    visible: isActive
-                }
+                iconName: model.icon || "ios-battery-full"
 
                 onClicked: {
                     layerStack.push(profileEditLayer, {profileId: model.id})
                 }
+            }
 
+            MouseArea {
+                anchors.fill: listItem
                 onPressAndHold: {
                     if (!isBuiltin) {
                         deleteRemorse.execute(listItem, "", function() {
-                            powerd.typedCall("DeleteProfile", [model.id], function(success) {
-                                if (success) {
-                                    powerd.loadData()
-                                }
-                            }, powerd.handleError)
+                            powerd.typedCall("DeleteProfile",
+                                [{"type": "s", "value": model.id}],
+                                function(success) {
+                                    if (success) {
+                                        powerd.loadData()
+                                    }
+                                }, powerd.handleError)
                         })
                     }
                 }
+                onClicked: listItem.clicked()
+            }
 
-                RemorseTimer {
-                    id: deleteRemorse
-                }
+            RemorseTimer {
+                id: deleteRemorse
             }
 
             RowSeparator {

--- a/src/qml/ProfileSelectorPage.qml
+++ b/src/qml/ProfileSelectorPage.qml
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2024 - AsteroidOS Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
+import Nemo.DBus 2.0
+
+Item {
+    id: root
+
+    property string activeProfileId: ""
+
+    ListModel {
+        id: profilesModel
+    }
+
+    DBusInterface {
+        id: powerd
+        bus: DBus.SystemBus
+        service: "org.asteroidos.powerd"
+        path: "/org/asteroidos/powerd"
+        iface: "org.asteroidos.powerd.ProfileManager"
+
+        signalsEnabled: true
+
+        function handleError(error) {
+            console.log("Profile Selector D-Bus error:", error)
+        }
+
+        function loadData() {
+            typedCall("GetActiveProfile", [], function(result) {
+                activeProfileId = result
+            }, handleError)
+
+            typedCall("GetProfiles", [], function(result) {
+                var profiles = JSON.parse(result)
+                profilesModel.clear()
+                for (var i = 0; i < profiles.length; i++) {
+                    profilesModel.append(profiles[i])
+                }
+            }, handleError)
+        }
+
+        Component.onCompleted: {
+            loadData()
+        }
+
+        onServiceAvailableChanged: {
+            if (available) {
+                loadData()
+            }
+        }
+    }
+
+    Connections {
+        target: powerd
+        onActiveProfileChanged: {
+            activeProfileId = id
+        }
+        onProfilesChanged: {
+            powerd.loadData()
+        }
+    }
+
+    ListView {
+        id: profileListView
+        anchors.fill: parent
+        anchors.topMargin: Dims.h(15)
+        anchors.bottomMargin: Dims.h(5)
+        model: profilesModel
+        clip: true
+        spacing: 0
+
+        delegate: Item {
+            width: parent.width
+            height: listItem.height
+
+            property bool isActive: model.id === activeProfileId
+
+            ListItem {
+                id: listItem
+                height: Dims.h(15)
+                width: parent.width
+                title: model.name
+                iconName: model.icon || "ios-battery-outline"
+
+                Rectangle {
+                    anchors.fill: parent
+                    color: "#FFFFFF"
+                    opacity: isActive ? 0.1 : 0
+                    z: -1
+                }
+
+                Label {
+                    anchors.right: parent.right
+                    anchors.rightMargin: Dims.w(8)
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "✓"
+                    font.pixelSize: Dims.l(8)
+                    visible: isActive
+                }
+
+                onClicked: {
+                    if (!isActive) {
+                        powerd.typedCall("SetActiveProfile", [model.id], function(success) {
+                            if (success) {
+                                activeProfileId = model.id
+                                layerStack.pop(root)
+                            }
+                        }, powerd.handleError)
+                    } else {
+                        layerStack.pop(root)
+                    }
+                }
+            }
+
+            RowSeparator {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+            }
+        }
+
+        Item {
+            id: emptyState
+            anchors.centerIn: parent
+            width: parent.width * 0.8
+            visible: profilesModel.count === 0
+
+            Column {
+                anchors.centerIn: parent
+                spacing: Dims.h(3)
+                width: parent.width
+
+                Label {
+                    width: parent.width
+                    horizontalAlignment: Text.AlignHCenter
+                    //% "No profiles available"
+                    text: qsTrId("id-no-profiles")
+                    font.pixelSize: Dims.l(6)
+                    wrapMode: Text.WordWrap
+                }
+
+                Label {
+                    width: parent.width
+                    horizontalAlignment: Text.AlignHCenter
+                    //% "Service may be unavailable"
+                    text: qsTrId("id-service-may-be-unavailable")
+                    font.pixelSize: Dims.l(4)
+                    opacity: 0.6
+                    wrapMode: Text.WordWrap
+                }
+            }
+        }
+    }
+
+    PageHeader {
+        //% "Select Profile"
+        text: qsTrId("id-select-profile")
+    }
+}

--- a/src/qml/ProfileSelectorPage.qml
+++ b/src/qml/ProfileSelectorPage.qml
@@ -56,24 +56,16 @@ Item {
             }, handleError)
         }
 
-        Component.onCompleted: {
+        function activeProfileChanged(newId) {
+            activeProfileId = newId
+        }
+
+        function profilesChanged() {
             loadData()
         }
 
-        onServiceAvailableChanged: {
-            if (available) {
-                loadData()
-            }
-        }
-    }
-
-    Connections {
-        target: powerd
-        onActiveProfileChanged: {
-            activeProfileId = id
-        }
-        onProfilesChanged: {
-            powerd.loadData()
+        Component.onCompleted: {
+            loadData()
         }
     }
 
@@ -97,35 +89,17 @@ Item {
                 height: Dims.h(15)
                 width: parent.width
                 title: model.name
-                iconName: model.icon || "ios-battery-outline"
-
-                Rectangle {
-                    anchors.fill: parent
-                    color: "#FFFFFF"
-                    opacity: isActive ? 0.1 : 0
-                    z: -1
-                }
-
-                Label {
-                    anchors.right: parent.right
-                    anchors.rightMargin: Dims.w(8)
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: "✓"
-                    font.pixelSize: Dims.l(8)
-                    visible: isActive
-                }
+                iconName: model.icon || "ios-battery-full"
 
                 onClicked: {
-                    if (!isActive) {
-                        powerd.typedCall("SetActiveProfile", [model.id], function(success) {
+                    powerd.typedCall("SetActiveProfile",
+                        [{"type": "s", "value": model.id}],
+                        function(success) {
                             if (success) {
                                 activeProfileId = model.id
                                 layerStack.pop(root)
                             }
                         }, powerd.handleError)
-                    } else {
-                        layerStack.pop(root)
-                    }
                 }
             }
 

--- a/src/qml/QuickPanelPage.qml
+++ b/src/qml/QuickPanelPage.qml
@@ -46,11 +46,11 @@ Item {
             "hapticsToggle",
             "wifiToggle",
             "soundToggle",
-            "cinemaToggle",
-            "aodToggle",
             "airplaneModeToggle",
+            "aodToggle",
             "powerOffToggle",
             "rebootToggle",
+            "cinemaToggle",
             "musicButton",
             "flashlightButton"
         ]
@@ -67,7 +67,7 @@ Item {
             "hapticsToggle": true,
             "wifiToggle": true,
             "soundToggle": true,
-            "cinemaToggle": true,
+            "cinemaToggle": false,
             "aodToggle": true,
             "powerOffToggle": true,
             "rebootToggle": true,

--- a/src/qml/QuickPanelPage.qml
+++ b/src/qml/QuickPanelPage.qml
@@ -16,7 +16,7 @@
  */
 
 import QtQuick 2.9
-import QtGraphicalEffects 1.15
+import QtGraphicalEffects 1.0
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 import Nemo.Configuration 1.0
@@ -48,6 +48,7 @@ Item {
             "soundToggle",
             "cinemaToggle",
             "aodToggle",
+            "airplaneModeToggle",
             "powerOffToggle",
             "rebootToggle",
             "musicButton",
@@ -71,7 +72,8 @@ Item {
             "powerOffToggle": true,
             "rebootToggle": true,
             "musicButton": false,
-            "flashlightButton": false
+            "flashlightButton": false,
+            "airplaneModeToggle": true
         }
     }
 
@@ -126,6 +128,8 @@ Item {
         toggleOptions["cinemaToggle"] = ({ name: qsTrId("id-toggle-cinema"), icon: "ios-film-outline"});
         //% "AoD Toggle"
         toggleOptions["aodToggle"] = ({ name: qsTrId("id-always-on-display"), icon: "ios-watch-aod-on"});
+        //% "Airplane Mode"
+        toggleOptions["airplaneModeToggle"] = ({ name: qsTrId("id-toggle-airplane-mode"), icon: "ios-plane-outline"});
         //% "Poweroff"
         toggleOptions["powerOffToggle"] = ({ name: qsTrId("id-toggle-power-off"), icon: "ios-power-outline"});
         //% "Reboot"

--- a/src/qml/WallpaperPage.qml
+++ b/src/qml/WallpaperPage.qml
@@ -18,7 +18,7 @@
  */
 
 import QtQuick 2.9
-import QtGraphicalEffects 1.12
+import QtGraphicalEffects 1.0
 import Qt.labs.folderlistmodel 2.1
 import Nemo.Configuration 1.0
 import org.asteroid.controls 1.0

--- a/src/qml/WatchfacePage.qml
+++ b/src/qml/WatchfacePage.qml
@@ -18,7 +18,7 @@
  */
 
 import QtQuick 2.9
-import QtGraphicalEffects 1.12
+import QtGraphicalEffects 1.0
 import Qt.labs.folderlistmodel 2.1
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0

--- a/src/qml/WatchfaceSelector.qml
+++ b/src/qml/WatchfaceSelector.qml
@@ -18,7 +18,7 @@
  */
 
 import QtQuick 2.9
-import QtGraphicalEffects 1.12
+import QtGraphicalEffects 1.0
 import Qt.labs.folderlistmodel 2.1
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -81,104 +81,104 @@ Application {
 
                 Item { width: parent.width; height: DeviceSpecs.hasRoundScreen ? Dims.h(6) : Dims.h(2) }
 
-                ListItem {
+                CompactListItem {
                     //% "Display"
                     title: qsTrId("id-display-page")
                     iconName: "ios-display-outline"
                     onClicked: layerStack.push(displayLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Nightstand"
                     title: qsTrId("id-nightstand-page")
                     iconName: "ios-moon-outline"
                     onClicked: layerStack.push(nightstandLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Quick Panel"
                     title: qsTrId("id-quickpanel-page")
                     iconName: options.value.batteryBottom ? "ios-quickpanel-batterybottom" : "ios-quickpanel-batterytop"
                     onClicked: layerStack.push(quickPanelLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Sound"
                     title: qsTrId("id-sound-page")
                     iconName: "ios-sound-outline"
                     onClicked: layerStack.push(soundLayer)
                     visible: DeviceSpecs.hasSpeaker
                 }
-                ListItem {
+                CompactListItem {
                     //% "Wallpaper"
                     title: qsTrId("id-wallpaper-page")
                     iconName: "ios-wallpaper-outline"
                     onClicked: layerStack.push(wallpaperLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Watchface"
                     title: qsTrId("id-watchface-page")
                     iconName: "ios-watchface-outline"
                     onClicked: layerStack.push(watchfaceLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Launcher"
                     title: qsTrId("id-launcher-page")
                     iconName: "ios-launcher-outline"
                     onClicked: layerStack.push(launcherLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Time"
                     title: qsTrId("id-time-page")
                     iconName: "ios-clock-outline"
                     onClicked: layerStack.push(timeLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Date"
                     title: qsTrId("id-date-page")
                     iconName: "ios-date-outline"
                     onClicked: layerStack.push(dateLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Units"
                     title: qsTrId("id-units-page")
                     iconName: "ios-units-outline"
                     onClicked: layerStack.push(unitsLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Language"
                     title: qsTrId("id-language-page")
                     iconName: "ios-earth-outline"
                     onClicked: layerStack.push(languageLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Time zone"
                     title: qsTrId("id-timezone-page")
                     iconName: "ios-globe-outline"
                     onClicked: layerStack.push(timezoneLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Bluetooth"
                     title: qsTrId("id-bluetooth-page")
                     iconName: "ios-bluetooth-outline"
                     onClicked: layerStack.push(bluetoothLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "USB"
                     title: qsTrId("id-usb-page")
                     iconName: "ios-usb"
                     onClicked: layerStack.push(usbLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Power"
                     title: qsTrId("id-power-page")
                     iconName: "ios-power-outline"
                     onClicked: layerStack.push(powerLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "Power Manager"
                     title: qsTrId("id-power-manager-page")
-                    iconName: "ios-battery-full-outline"
+                    iconName: "ios-battery-full"
                     onClicked: layerStack.push(powerManagerLayer)
                 }
-                ListItem {
+                CompactListItem {
                     //% "About"
                     title: qsTrId("id-about-page")
                     iconName: "ios-help-circle-outline"

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -55,6 +55,7 @@ Application {
     Component { id: launcherLayer;              LauncherPage   { } }
     Component { id: usbLayer;                   USBPage        { } }
     Component { id: powerLayer;                 PowerPage      { } }
+    Component { id: powerManagerLayer;          PowerManagerPage { } }
     Component { id: aboutLayer;                 AboutPage      { } }
 
     TiltToWake { id: tiltToWake }
@@ -170,6 +171,12 @@ Application {
                     title: qsTrId("id-power-page")
                     iconName: "ios-power-outline"
                     onClicked: layerStack.push(powerLayer)
+                }
+                ListItem {
+                    //% "Power Manager"
+                    title: qsTrId("id-power-manager-page")
+                    iconName: "ios-battery-full-outline"
+                    onClicked: layerStack.push(powerManagerLayer)
                 }
                 ListItem {
                     //% "About"

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -19,5 +19,10 @@
         <file>qml/USBPage.qml</file>
         <file>qml/PowerPage.qml</file>
         <file>qml/AboutPage.qml</file>
+        <file>qml/PowerManagerPage.qml</file>
+        <file>qml/ProfileSelectorPage.qml</file>
+        <file>qml/ProfileListPage.qml</file>
+        <file>qml/ProfileEditPage.qml</file>
+        <file>qml/AutomationEditPage.qml</file>
     </qresource>
 </RCC>

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -24,5 +24,8 @@
         <file>qml/ProfileListPage.qml</file>
         <file>qml/ProfileEditPage.qml</file>
         <file>qml/AutomationEditPage.qml</file>
+        <file>qml/FillBarRow.qml</file>
+        <file>qml/CompactListItem.qml</file>
+        <file>qml/BatteryHistoryGraph.qml</file>
     </qresource>
 </RCC>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.10.0)
+
+# Can be built standalone:  cd tests && mkdir build && cd build && cmake .. && make && ctest -V
+# Or as part of asteroid-settings:  cmake .. -DBUILD_TESTS=ON
+if(NOT CMAKE_PROJECT_NAME OR CMAKE_PROJECT_NAME STREQUAL "asteroid-settings-tests")
+    project(asteroid-settings-tests)
+    set(STANDALONE_TEST TRUE)
+endif()
+
+find_package(Qt5 COMPONENTS Test Qml Quick Gui REQUIRED)
+set(CMAKE_AUTOMOC ON)
+
+# When built standalone, CMAKE_SOURCE_DIR points at tests/ itself,
+# so QML_SOURCE_DIR must go one level up.
+if(STANDALONE_TEST)
+    set(SETTINGS_SOURCE_DIR "${CMAKE_SOURCE_DIR}/..")
+else()
+    set(SETTINGS_SOURCE_DIR "${CMAKE_SOURCE_DIR}")
+endif()
+
+# Paths for test discovery of QML files and mock modules
+add_definitions(-DQML_SOURCE_DIR="${SETTINGS_SOURCE_DIR}/src/qml")
+add_definitions(-DMOCK_QML_DIR="${CMAKE_CURRENT_SOURCE_DIR}/mock-qml")
+
+# QML validation test — catches white-screen regressions
+add_executable(tst_qmlvalidation tst_qmlvalidation.cpp)
+target_link_libraries(tst_qmlvalidation
+    Qt5::Test
+    Qt5::Qml
+    Qt5::Quick
+    Qt5::Gui
+)
+
+if(STANDALONE_TEST)
+    enable_testing()
+endif()
+
+add_test(NAME tst_qmlvalidation COMMAND tst_qmlvalidation)
+
+# Run headless — no display needed for load-time validation
+set_tests_properties(tst_qmlvalidation PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)

--- a/tests/mock-qml/Nemo/DBus/DBus.qml
+++ b/tests/mock-qml/Nemo/DBus/DBus.qml
@@ -1,0 +1,7 @@
+pragma Singleton
+import QtQuick 2.9
+
+QtObject {
+    readonly property int SystemBus: 0
+    readonly property int SessionBus: 1
+}

--- a/tests/mock-qml/Nemo/DBus/DBusInterface.qml
+++ b/tests/mock-qml/Nemo/DBus/DBusInterface.qml
@@ -1,0 +1,25 @@
+// Mock DBusInterface for QML validation tests.
+// Mirrors the real Nemo.DBus 2.0 DBusInterface properties.
+// Intentionally does NOT expose "serviceAvailable" — if any QML file
+// uses onServiceAvailableChanged inside this element, the test will
+// fail with "Cannot assign to non-existent property", exactly as it
+// does on the real device.
+import QtQuick 2.9
+
+Item {
+    property int bus: 0
+    property string service: ""
+    property string path: ""
+    property string iface: ""
+    property bool signalsEnabled: false
+    property bool propertiesEnabled: false
+
+    // Real Nemo.DBus exposes these:
+    property int status: 0  // DeclarativeDBusInterface::Unknown
+    property bool watchServiceStatus: false
+
+    function call(method, args) {}
+    function typedCall(method, args, successCallback, errorCallback) {}
+    function getProperty(name) { return undefined }
+    function setProperty(name, value) {}
+}

--- a/tests/mock-qml/Nemo/DBus/qmldir
+++ b/tests/mock-qml/Nemo/DBus/qmldir
@@ -1,0 +1,1 @@
+module Nemo.DBus

--- a/tests/mock-qml/org/asteroid/controls/Dims.qml
+++ b/tests/mock-qml/org/asteroid/controls/Dims.qml
@@ -1,0 +1,10 @@
+pragma Singleton
+import QtQuick 2.9
+
+QtObject {
+    readonly property real iconButtonMargin: 10
+
+    function w(percent) { return percent * 3.2 }
+    function h(percent) { return percent * 3.2 }
+    function l(percent) { return percent * 3.2 }
+}

--- a/tests/mock-qml/org/asteroid/controls/Icon.qml
+++ b/tests/mock-qml/org/asteroid/controls/Icon.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.9
+Item {
+    property string name: ""
+    property color color: "#FFFFFF"
+}

--- a/tests/mock-qml/org/asteroid/controls/IconButton.qml
+++ b/tests/mock-qml/org/asteroid/controls/IconButton.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.9
+
+Item {
+    property string iconName: ""
+    property color iconColor: "#FFFFFF"
+    signal clicked()
+}

--- a/tests/mock-qml/org/asteroid/controls/Label.qml
+++ b/tests/mock-qml/org/asteroid/controls/Label.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.9
+
+Text {
+    property real padding: 0
+    color: "#FFFFFF"
+}

--- a/tests/mock-qml/org/asteroid/controls/LabeledSwitch.qml
+++ b/tests/mock-qml/org/asteroid/controls/LabeledSwitch.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.9
+
+Item {
+    property string text: ""
+    property bool checked: false
+}

--- a/tests/mock-qml/org/asteroid/controls/LayerStack.qml
+++ b/tests/mock-qml/org/asteroid/controls/LayerStack.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.9
+
+Item {
+    property var firstPage
+    function push(component, properties) {}
+    function pop(page) {}
+}

--- a/tests/mock-qml/org/asteroid/controls/ListItem.qml
+++ b/tests/mock-qml/org/asteroid/controls/ListItem.qml
@@ -1,0 +1,10 @@
+import QtQuick 2.9
+
+Item {
+    property string title: ""
+    property string iconName: ""
+    property real highlight: 0
+    property int iconSize: 10
+    property int labelFontSize: 10
+    signal clicked()
+}

--- a/tests/mock-qml/org/asteroid/controls/ListRow.qml
+++ b/tests/mock-qml/org/asteroid/controls/ListRow.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.9
+
+Item {
+    property string text: ""
+    property Component actionComponent: null
+    property alias actionArea: loader
+    property bool highlightBarEnabled: true
+    property int actionSlotPadding: 10
+    property int rowMargin: 15
+    property int iconSize: 20
+    property int labelFontSize: 10
+    default property alias content: inner.data
+    signal clicked()
+
+    Item { id: inner }
+    Loader { id: loader; sourceComponent: actionComponent }
+}

--- a/tests/mock-qml/org/asteroid/controls/OptionCycler.qml
+++ b/tests/mock-qml/org/asteroid/controls/OptionCycler.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.9
+
+Item {
+    property string text: ""
+    property var valueArray: []
+    property var currentValue
+}

--- a/tests/mock-qml/org/asteroid/controls/PageHeader.qml
+++ b/tests/mock-qml/org/asteroid/controls/PageHeader.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.9
+
+Item {
+    property string text: ""
+}

--- a/tests/mock-qml/org/asteroid/controls/RemorseTimer.qml
+++ b/tests/mock-qml/org/asteroid/controls/RemorseTimer.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.9
+
+Item {
+    function execute(item, text, callback) {
+        if (callback) callback()
+    }
+}

--- a/tests/mock-qml/org/asteroid/controls/RowSeparator.qml
+++ b/tests/mock-qml/org/asteroid/controls/RowSeparator.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.9
+
+Item {
+    width: parent ? parent.width : 0
+    height: 1
+}

--- a/tests/mock-qml/org/asteroid/controls/StatusPage.qml
+++ b/tests/mock-qml/org/asteroid/controls/StatusPage.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.9
+
+Item {
+    property string text: ""
+    property string icon: ""
+}

--- a/tests/mock-qml/org/asteroid/controls/qmldir
+++ b/tests/mock-qml/org/asteroid/controls/qmldir
@@ -1,0 +1,14 @@
+module org.asteroid.controls
+singleton Dims 1.0 Dims.qml
+Icon 1.0 Icon.qml
+IconButton 1.0 IconButton.qml
+Label 1.0 Label.qml
+LabeledSwitch 1.0 LabeledSwitch.qml
+LayerStack 1.0 LayerStack.qml
+ListItem 1.0 ListItem.qml
+ListRow 1.0 ListRow.qml
+OptionCycler 1.0 OptionCycler.qml
+PageHeader 1.0 PageHeader.qml
+RemorseTimer 1.0 RemorseTimer.qml
+RowSeparator 1.0 RowSeparator.qml
+StatusPage 1.0 StatusPage.qml

--- a/tests/mock-qml/org/asteroid/utils/DeviceInfo.qml
+++ b/tests/mock-qml/org/asteroid/utils/DeviceInfo.qml
@@ -1,0 +1,3 @@
+import QtQuick 2.9
+
+QtObject {}

--- a/tests/mock-qml/org/asteroid/utils/qmldir
+++ b/tests/mock-qml/org/asteroid/utils/qmldir
@@ -1,0 +1,2 @@
+module org.asteroid.utils
+DeviceInfo 1.0 DeviceInfo.qml

--- a/tests/tst_qmlvalidation.cpp
+++ b/tests/tst_qmlvalidation.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2024 - AsteroidOS Contributors
+ *
+ * QML Validation Test — White Screen Guard
+ *
+ * This test loads each power-manager QML component using mock modules
+ * that mirror the real Nemo.DBus and org.asteroid.controls APIs.
+ * If a component fails to load (bad property handlers, missing types,
+ * wrong import versions, etc.), the test fails with the exact error
+ * string — the same error that would cause a WHITE SCREEN on-device
+ * because AsteroidOS evaluates all Component{} declarations at startup.
+ *
+ * Catches:
+ *   - "Cannot assign to non-existent property" (e.g. onServiceAvailableChanged)
+ *   - "Type X unavailable" cascading failures
+ *   - "module ... version ... is not installed"
+ *   - Syntax errors in QML files
+ *   - References to types that don't exist in the module
+ *
+ * Run standalone:
+ *   cd asteroid-settings/tests && mkdir build && cd build
+ *   cmake .. && make && QT_QPA_PLATFORM=offscreen ./tst_qmlvalidation -v2
+ */
+
+#include <QtTest/QtTest>
+#include <QGuiApplication>
+#include <QQmlEngine>
+#include <QQmlComponent>
+#include <QQmlError>
+#include <QQuickItem>
+#include <QJSValue>
+#include <QDir>
+#include <QFileInfo>
+#include <cstdlib>  // _Exit
+
+// Defined via CMake add_definitions:
+//   QML_SOURCE_DIR  — path to asteroid-settings/src/qml/
+//   MOCK_QML_DIR    — path to asteroid-settings/tests/mock-qml/
+
+// ── C++ Mock for Nemo.DBus 2.0 "DBus" singleton ──────────────────
+// QML property declarations cannot start with uppercase letters, but
+// the real Nemo.DBus exposes SystemBus/SessionBus as C++ Q_ENUM values.
+// We mirror that here so `DBus.SystemBus` works in loaded QML files.
+class MockDBus : public QObject
+{
+    Q_OBJECT
+public:
+    enum BusType { SystemBus = 0, SessionBus = 1 };
+    Q_ENUM(BusType)
+};
+
+// ── C++ Mock for Nemo.DBus 2.0 "DBusInterface" ─────────────────────
+// Must be a C++ QObject (matching the real DeclarativeDBusInterface),
+// not a QML-defined type, because the QML engine only rejects unknown
+// on<Signal> handlers for C++ types. This mock intentionally does NOT
+// expose "serviceAvailable", so any QML file that uses
+// onServiceAvailableChanged will be caught as an error.
+class MockDBusInterface : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int bus READ bus WRITE setBus NOTIFY busChanged)
+    Q_PROPERTY(QString service READ service WRITE setService NOTIFY serviceChanged)
+    Q_PROPERTY(QString path READ path WRITE setPath NOTIFY pathChanged)
+    Q_PROPERTY(QString iface READ iface WRITE setIface NOTIFY interfaceChanged)
+    Q_PROPERTY(bool signalsEnabled READ signalsEnabled WRITE setSignalsEnabled NOTIFY signalsEnabledChanged)
+    Q_PROPERTY(bool propertiesEnabled READ propertiesEnabled WRITE setPropertiesEnabled NOTIFY propertiesEnabledChanged)
+    Q_PROPERTY(int status READ status NOTIFY statusChanged)
+    Q_PROPERTY(bool watchServiceStatus READ watchServiceStatus WRITE setWatchServiceStatus NOTIFY watchServiceStatusChanged)
+
+public:
+    explicit MockDBusInterface(QObject *parent = nullptr) : QObject(parent) {}
+
+    int bus() const { return m_bus; }
+    void setBus(int b) { if (m_bus != b) { m_bus = b; emit busChanged(); } }
+
+    QString service() const { return m_service; }
+    void setService(const QString &s) { if (m_service != s) { m_service = s; emit serviceChanged(); } }
+
+    QString path() const { return m_path; }
+    void setPath(const QString &p) { if (m_path != p) { m_path = p; emit pathChanged(); } }
+
+    QString iface() const { return m_iface; }
+    void setIface(const QString &i) { if (m_iface != i) { m_iface = i; emit interfaceChanged(); } }
+
+    bool signalsEnabled() const { return m_signalsEnabled; }
+    void setSignalsEnabled(bool e) { if (m_signalsEnabled != e) { m_signalsEnabled = e; emit signalsEnabledChanged(); } }
+
+    bool propertiesEnabled() const { return m_propertiesEnabled; }
+    void setPropertiesEnabled(bool e) { if (m_propertiesEnabled != e) { m_propertiesEnabled = e; emit propertiesEnabledChanged(); } }
+
+    int status() const { return 0; }
+
+    bool watchServiceStatus() const { return m_watchServiceStatus; }
+    void setWatchServiceStatus(bool w) { if (m_watchServiceStatus != w) { m_watchServiceStatus = w; emit watchServiceStatusChanged(); } }
+
+    // Stubs for methods used in QML
+    Q_INVOKABLE void call(const QString &, const QVariantList & = {}) {}
+    Q_INVOKABLE void typedCall(const QString &, const QVariantList & = {},
+                                const QJSValue & = {}, const QJSValue & = {}) {}
+    Q_INVOKABLE QVariant getProperty(const QString &) { return QVariant(); }
+    Q_INVOKABLE void setProperty(const QString &, const QVariant &) {}
+
+signals:
+    void busChanged();
+    void serviceChanged();
+    void pathChanged();
+    void interfaceChanged();
+    void signalsEnabledChanged();
+    void propertiesEnabledChanged();
+    void statusChanged();
+    void watchServiceStatusChanged();
+
+private:
+    int m_bus = 0;
+    QString m_service;
+    QString m_path;
+    QString m_iface;
+    bool m_signalsEnabled = false;
+    bool m_propertiesEnabled = false;
+    bool m_watchServiceStatus = false;
+};
+
+// ── Test class ──────────────────────────────────────────────────────
+
+class TestQmlValidation : public QObject
+{
+    Q_OBJECT
+
+private:
+    QQmlEngine *m_engine = nullptr;
+
+private slots:
+    void initTestCase();
+    void cleanupTestCase();
+
+    // Data-driven: one row per power-manager QML file
+    void loadPowerManagerPage_data();
+    void loadPowerManagerPage();
+};
+
+// ── Setup / Teardown ────────────────────────────────────────────────
+
+void TestQmlValidation::initTestCase()
+{
+    m_engine = new QQmlEngine(); // no parent — _Exit() handles cleanup
+
+    // Add mock import path (takes priority for QML-defined mock types).
+    // C++ registered types (MockDBusInterface, MockDBus) take priority
+    // over any system-installed Nemo.DBus module, so we don't need to
+    // isolate the import paths — addImportPath is sufficient.
+    m_engine->addImportPath(QStringLiteral(MOCK_QML_DIR));
+
+    // Register C++ mock for DBus singleton (QML can't declare uppercase enum values)
+    qmlRegisterSingletonType<MockDBus>("Nemo.DBus", 2, 0, "DBus",
+        [](QQmlEngine *, QJSEngine *) -> QObject * { return new MockDBus; });
+
+    // Register C++ mock for DBusInterface (C++ types strictly reject unknown
+    // on<Signal> handlers, unlike QML-defined types which silently accept them)
+    qmlRegisterType<MockDBusInterface>("Nemo.DBus", 2, 0, "DBusInterface");
+
+    // Verify the mock path is reachable
+    QDir mockDir(QStringLiteral(MOCK_QML_DIR));
+    QVERIFY2(mockDir.exists(),
+        qPrintable(QString("Mock QML directory not found: %1").arg(mockDir.absolutePath())));
+
+    // Verify we can find the QML source directory
+    QDir qmlDir(QStringLiteral(QML_SOURCE_DIR));
+    QVERIFY2(qmlDir.exists(),
+        qPrintable(QString("QML source directory not found: %1").arg(qmlDir.absolutePath())));
+}
+
+void TestQmlValidation::cleanupTestCase()
+{
+    // Don't delete m_engine here — it crashes during Qt's QML type system
+    // cleanup when C++ types were registered via qmlRegisterType.
+    // The engine will be cleaned up by _Exit() in main().
+    m_engine = nullptr;
+}
+
+// ── Main test: load each power-manager QML page ─────────────────────
+
+void TestQmlValidation::loadPowerManagerPage_data()
+{
+    QTest::addColumn<QString>("qmlFile");
+    QTest::addColumn<QString>("fileName");
+
+    // These are the QML pages we added for the power manager feature.
+    // If any of them fails to load, the ENTIRE settings app shows a white screen
+    // because main.qml pre-evaluates Component{} blocks.
+    static const QStringList powerManagerFiles = {
+        QStringLiteral("PowerManagerPage.qml"),
+        QStringLiteral("ProfileSelectorPage.qml"),
+        QStringLiteral("ProfileListPage.qml"),
+        QStringLiteral("ProfileEditPage.qml"),
+        QStringLiteral("AutomationEditPage.qml"),
+    };
+
+    QDir qmlDir(QStringLiteral(QML_SOURCE_DIR));
+    for (const QString &file : powerManagerFiles) {
+        QString path = qmlDir.absoluteFilePath(file);
+        QVERIFY2(QFile::exists(path),
+            qPrintable(QString("QML file not found: %1").arg(path)));
+        QTest::newRow(qPrintable(file)) << path << file;
+    }
+}
+
+void TestQmlValidation::loadPowerManagerPage()
+{
+    QFETCH(QString, qmlFile);
+    QFETCH(QString, fileName);
+
+    QQmlComponent component(m_engine, QUrl::fromLocalFile(qmlFile));
+
+    if (component.isError()) {
+        QString errors;
+        for (const QQmlError &e : component.errors())
+            errors += QString("  %1:%2 — %3\n")
+                .arg(e.url().fileName())
+                .arg(e.line())
+                .arg(e.description());
+
+        QFAIL(qPrintable(
+            QString("\n"
+                    "╔══════════════════════════════════════════════════════════╗\n"
+                    "║  WHITE SCREEN DETECTED — QML component failed to load  ║\n"
+                    "╚══════════════════════════════════════════════════════════╝\n"
+                    "\n"
+                    "  File: %1\n"
+                    "\n"
+                    "  This error will make the ENTIRE settings app show a\n"
+                    "  blank white screen on-device because AsteroidOS\n"
+                    "  evaluates all Component{} declarations at startup.\n"
+                    "\n"
+                    "  Errors:\n%2")
+                .arg(fileName, errors)));
+    }
+
+    QCOMPARE(component.status(), QQmlComponent::Ready);
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+int main(int argc, char *argv[])
+{
+    // QGuiApplication is required because QML visual types (Item, etc.)
+    // need it even though we never render anything.
+    QGuiApplication app(argc, argv);
+    TestQmlValidation tc;
+    int result = QTest::qExec(&tc, argc, argv);
+    // Use _Exit() to bypass Qt's QML type system cleanup, which crashes
+    // when C++ types registered via qmlRegisterType are cleaned up in
+    // unit test processes.  All test assertions above have already run.
+    _Exit(result);
+}
+
+#include "tst_qmlvalidation.moc"


### PR DESCRIPTION
## Power Manager for AsteroidOS

Hey! We've been working on this for about a week now — it's a **power management system** for AsteroidOS that gives you profile-based control over sensors, radios, and system settings, plus **battery health estimation**.

This PR adds the settings UI side. The companion daemon lives at **[KonTy/asteroid-powerd](https://github.com/KonTy/asteroid-powerd)** — it would be awesome if the AsteroidOS org could adopt that repo so it has a proper home.

### What's in this PR

- **PowerManagerPage** — main entry point showing active profile, battery stats, battery health, and navigation
- **Battery Health UI** — color-coded health bar, learned/design capacity (mAh), charge cycles, confidence indicator, and status text (excellent/good/worn/degraded)
- **ProfileListPage** — browse/select from all available profiles
- **ProfileEditPage** — edit every setting in a profile using fill-bar controls
- **ProfileSelectorPage** — quick profile switching
- **AutomationEditPage** — configure battery threshold rules and time-of-day scheduling
- **Airplane mode toggle** — added to QuickPanel settings page
- **FillBarRow** — custom QML component: a vertical fill-bar that shows sensor/radio power level at a glance (tap to cycle through modes)
- **BatteryHistoryGraph** — battery level graph with Catmull-Rom spline interpolation and gradient fill
- **CompactListItem** — compact list rows optimized for the round watch display
- Full i18n support — **60 languages** with translation templates (9 new battery health translation IDs)

### Screenshots

<p align="center">
  <img src="https://raw.githubusercontent.com/KonTy/asteroid-powerd/master/docs/screenshots/01-settings-menu.png" width="200" alt="Settings menu"/>
  <img src="https://raw.githubusercontent.com/KonTy/asteroid-powerd/master/docs/screenshots/02-power-manager-page.png" width="200" alt="Power Manager page"/>
  <img src="https://raw.githubusercontent.com/KonTy/asteroid-powerd/master/docs/screenshots/03-profiles-list.png" width="200" alt="Profile list"/>
  <img src="https://raw.githubusercontent.com/KonTy/asteroid-powerd/master/docs/screenshots/04-profile-editor.png" width="200" alt="Profile editor"/>
</p>

### Battery Health Estimation

The daemon (`asteroid-powerd`) reads sysfs battery data and computes a health percentage using EMA-smoothed capacity ratios. The UI displays:

- **Health percentage** with color-coded bar (green ≥80%, yellow ≥60%, red <60%)
- **Learned vs design capacity** in mAh
- **Charge cycle count**
- **Confidence indicator** (high/medium/improving based on sample count)
- **Status text** — "Excellent", "Good", "Showing wear", or "Significantly degraded"

Data is fetched via the `GetBatteryHealth()` D-Bus method on `org.asteroidos.powerd`. When running on the emulator without the daemon, demo data is shown.

### The fill-bar controls

Each sensor/radio row has a vertical green bar on the right — it's a multi-state toggle. Tap to cycle through modes (off → low → medium → high → workout). The fill level gives you an instant visual read of how aggressive each setting is. Fully grey = off, fully green = max power.

For example, the accelerometer modes map to real sampling rates:
- **Off** — disabled
- **Low** — 5 Hz (step counting)
- **Medium** — 25 Hz (gestures)
- **High** — 50 Hz (activity tracking)
- **Workout** — 100 Hz (exercise analysis)

### How it works

The UI talks to `asteroid-powerd` over D-Bus (`org.asteroidos.powerd.ProfileManager`). All D-Bus calls use Nemo.DBus `typedCall` with proper argument formatting. Battery health uses a separate `GetBatteryHealth()` method that returns a map of health metrics. When running in the QEMU emulator (no daemon), a simulation mode provides mock data so you can still develop and test the UI.

### Status

This is a **first version** — it works, the image builds, it's been tested in the QEMU emulator. But it definitely needs more testing on real hardware and there are known rough edges. We're actively working on it and would love feedback on:

- The overall UX / flow
- Whether the fill-bar pattern works for this kind of multi-level setting
- The battery health display and thresholds
- Any Qt 5.12 compatibility issues we might have missed
- Suggestions for the automation rules UI

### Companion daemon

The power management daemon is at **[KonTy/asteroid-powerd](https://github.com/KonTy/asteroid-powerd)** — it handles all the actual sensor/radio/system control and battery health estimation. Latest commit adds the `GetBatteryHealth()` D-Bus method, `BatteryHealthChanged` signal, EMA smoothing, sysfs reads, and JSON persistence. 26 unit tests all passing.

Would it make sense to add it to the AsteroidOS org? It follows the same patterns as other asteroid-* packages (CMake, systemd service, D-Bus activation).

Thanks for taking a look! 🙏
