### PR TITLE
Fix timezone DBus property type coercion for Qt6

### DIFF
--- a/src/qml/TimezonePage.qml
+++ b/src/qml/TimezonePage.qml
@@ -77,7 +77,7 @@ Item {
         id: timezoneModel
         Component.onCompleted: {
             if (!root.selectedTz) {
-                root.selectedTz = timedateDbus.getProperty("Timezone");
+                root.selectedTz = timedateDbus.getProperty("Timezone").toString();
             };
             if (root.timezoneList.length < 1) {
                 timedateDbus.call("ListTimezones", undefined, function(m) {


### PR DESCRIPTION
In Qt6, Nemo.DBus getProperty() returns a QDBusVariant instead of auto-coercing to the declared property type. Assigning the raw QDBusVariant to a property string fails with "Cannot assign QDBusVariant to QString" and aborts the Component.onCompleted handler before the ListTimezones call executes. This leaves timezoneList empty for the entire session, making the city spinner always empty and crashing on next button press in TIMEZONE_CITY state with TypeError on fullPath of undefined.

Fix: call .toString() on the getProperty result to unwrap the variant.