### PR TITLE
Fix Qt6 initial property injection for all settings pages

### DIFF
--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -23,6 +23,8 @@ import org.asteroid.settings
 import org.nemomobile.systemsettings
 
 Flickable {
+    property int depth
+    property var pop
     AboutSettings {
         id: about
     }

--- a/src/qml/BluetoothPage.qml
+++ b/src/qml/BluetoothPage.qml
@@ -21,6 +21,8 @@ import org.asteroid.controls
 import org.asteroid.utils
 
 Item {
+    property int depth
+    property var pop
     BluetoothStatus { id: btStatus }
 
     StatusPage {

--- a/src/qml/DatePage.qml
+++ b/src/qml/DatePage.qml
@@ -22,6 +22,7 @@ import org.asteroid.utils
 import org.nemomobile.systemsettings
 
 Item {
+    property int depth
     id: root
     property var pop
 

--- a/src/qml/DisplayPage.qml
+++ b/src/qml/DisplayPage.qml
@@ -27,6 +27,8 @@ import Nemo.Configuration
 import Nemo.Mce
 
 Item {
+    property int depth
+    property var pop
     TapToWake { id: tapToWake }
     TiltToWake { id: tiltToWake }
     DisplaySettings { id: displaySettings }

--- a/src/qml/LanguagePage.qml
+++ b/src/qml/LanguagePage.qml
@@ -21,6 +21,7 @@ import org.asteroid.controls
 import org.nemomobile.systemsettings
 
 Item {
+    property int depth
     id: root
     property var pop
 

--- a/src/qml/LauncherPage.qml
+++ b/src/qml/LauncherPage.qml
@@ -24,6 +24,8 @@ import org.asteroid.controls
 import QtQml.Models
 
 Item {
+    property int depth
+    property var pop
     property alias displayAmbient: compositor.displayAmbient
     property bool fakePressed:     false
     property bool toTopAllowed:    false

--- a/src/qml/NightstandPage.qml
+++ b/src/qml/NightstandPage.qml
@@ -28,6 +28,8 @@ import Nemo.Configuration
 import Nemo.Mce
 
 Item {
+    property int depth
+    property var pop
     ConfigurationValue {
         id: nightstandBrightness
         key: "/desktop/asteroid/nightstand/brightness"

--- a/src/qml/NightstandWatchfacePage.qml
+++ b/src/qml/NightstandWatchfacePage.qml
@@ -25,6 +25,8 @@ import Nemo.Configuration
 import Nemo.Time
 
 Item {
+    property int depth
+    property var pop
 
     property alias displayAmbient: compositor.displayAmbient
     property string assetPath: "file:///usr/share/asteroid-launcher/"

--- a/src/qml/PowerPage.qml
+++ b/src/qml/PowerPage.qml
@@ -22,6 +22,8 @@ import org.asteroid.controls
 import Nemo.DBus
 
 Item {
+    property int depth
+    property var pop
 
     property int pendingIndex: -1
 

--- a/src/qml/QuickPanelPage.qml
+++ b/src/qml/QuickPanelPage.qml
@@ -22,6 +22,8 @@ import Nemo.Configuration
 import Nemo.Mce
 
 Item {
+    property int depth
+    property var pop
     id: quickPanelPage
 
     // Battery status components for the ValueMeter

--- a/src/qml/SoundPage.qml
+++ b/src/qml/SoundPage.qml
@@ -24,6 +24,8 @@ import Nemo.Configuration
 
 
 Item {
+    property int depth
+    property var pop
     VolumeControl { id: volumeControl }
 
     ConfigurationValue {

--- a/src/qml/TimePage.qml
+++ b/src/qml/TimePage.qml
@@ -24,6 +24,7 @@ import Nemo.Configuration
 import org.nemomobile.systemsettings
 
 Item {
+    property int depth
     id: root
     property var pop
 

--- a/src/qml/TimezonePage.qml
+++ b/src/qml/TimezonePage.qml
@@ -24,6 +24,7 @@ import org.asteroid.controls
 import Nemo.DBus
 
 Item {
+    property int depth
     id: root
     property var pop
     property string selectedTz: ""

--- a/src/qml/USBPage.qml
+++ b/src/qml/USBPage.qml
@@ -21,6 +21,7 @@ import Nemo.DBus
 import org.asteroid.controls
 
 Item {
+    property int depth
     id: root
     property var pop
 

--- a/src/qml/UnitsPage.qml
+++ b/src/qml/UnitsPage.qml
@@ -21,6 +21,8 @@ import Nemo.Configuration
 import org.asteroid.controls
 
 Item {
+    property int depth
+    property var pop
 
     ConfigurationValue {
         id: use12H

--- a/src/qml/WallpaperPage.qml
+++ b/src/qml/WallpaperPage.qml
@@ -26,6 +26,8 @@ import org.asteroid.utils
 
 
 Item {
+    property int depth
+    property var pop
 
     property string assetPath: "file:///usr/share/asteroid-launcher/wallpapers/"
 

--- a/src/qml/WatchfacePage.qml
+++ b/src/qml/WatchfacePage.qml
@@ -25,6 +25,8 @@ import Nemo.Configuration
 import Nemo.Time
 
 Item {
+    property int depth
+    property var pop
     property alias displayAmbient: compositor.displayAmbient
     property string assetPath: "file:///usr/share/asteroid-launcher/"
     property alias watchface: watchfaceSource.value


### PR DESCRIPTION
Qt6 only allows passing initial properties via push() if they are explicitly declared on the target component. All settings pages were missing property int depth and property var pop declarations, causing Setting initial properties failed errors on every page open.

Confirmed the issue on sparrow, narwhal and beluga pre fixing.
After applying to all 17 pages the log stays clean.