### PR TITLE
Fix Qt6 binding loop and signal injection deprecation in DisplayPage

### DIFF
--- a/src/qml/DisplayPage.qml
+++ b/src/qml/DisplayPage.qml
@@ -120,6 +120,8 @@ Item {
                 text: qsTrId("id-always-on-display")
                 checked: alwaysOnDisplay.value
                 onCheckedChanged: {
+                    if (alwaysOnDisplay.value === checked)
+                        return
                     alwaysOnDisplay.value = checked
                     // alter displaySettings unless NightStand mode is active
                     // and we are on a charger
@@ -139,7 +141,7 @@ Item {
                 text: qsTrId("id-burn-in-protection")
                 valueArray: bipLabels
                 currentValue: bipLabels[bipValues.indexOf(bipLevel.value)] || bipLabels[0]
-                onValueChanged: bipLevel.value = bipValues[bipLabels.indexOf(value)]
+                onValueChanged: (value) => bipLevel.value = bipValues[bipLabels.indexOf(value)]
             }
 
             RowSeparator {}


### PR DESCRIPTION
- Add early return guard in onCheckedChanged of Always on Display LabeledSwitch to break the ConfigurationValue binding loop Qt6 detects on dconf-backed properties
- Convert OptionCycler onValueChanged to arrow function syntax with explicit value parameter declaration
- C++ backed LabeledSwitch properties guard same-value re-emission internally and are unaffected