### PR TITLE
NightstandPage: persist the Always-on-Display toggle

### DIFF
--- a/src/qml/NightstandPage.qml
+++ b/src/qml/NightstandPage.qml
@@ -156,6 +156,9 @@ Item {
                     text: qsTrId("id-always-on-display")
                     checked: nightstandAlwaysOnDisplay.value
                     onCheckedChanged: {
+                        if (nightstandAlwaysOnDisplay.value === checked)
+                            return
+                        nightstandAlwaysOnDisplay.value = checked
                         // only alter displaySettings if Nightstand mode is
                         // active and we're currently on a charger
                         if (nightstandEnabled.value && mceChargerType.type != MceChargerType.None) {


### PR DESCRIPTION
The switch's onCheckedChanged only poked displaySettings.lowPowerModeEnabled (and only while charging) and never wrote nightstandAlwaysOnDisplay.value, so the dconf key was unreachable from the UI and the switch snapped back to its stored value on reload. Persist the value first, mirroring DisplayPage's Always-on-Display handler.