### PR TITLE
Migrate to org.asteroid.settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ ecm_find_qmlmodule(Nemo.Mce 1.0)
 ecm_find_qmlmodule(Nemo.DBus 2.0)
 ecm_find_qmlmodule(Nemo.Configuration 1.0)
 ecm_find_qmlmodule(Qt.labs.folderlistmodel 2.1)
-ecm_find_qmlmodule(org.nemomobile.systemsettings 1.0)
+ecm_find_qmlmodule(org.asteroid.settings 1.0)
 
 add_subdirectory(src)
 

--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -20,7 +20,7 @@ import QtQuick
 import org.asteroid.utils
 import org.asteroid.controls
 import org.asteroid.settings
-import org.nemomobile.systemsettings
+import org.asteroid.settings
 
 Flickable {
     property int depth

--- a/src/qml/DatePage.qml
+++ b/src/qml/DatePage.qml
@@ -19,7 +19,7 @@
 import QtQuick
 import org.asteroid.controls
 import org.asteroid.utils
-import org.nemomobile.systemsettings
+import org.asteroid.settings
 
 Item {
     property int depth

--- a/src/qml/DisplayPage.qml
+++ b/src/qml/DisplayPage.qml
@@ -22,7 +22,7 @@ import QtQuick.Layouts
 import org.asteroid.controls
 import org.asteroid.utils
 import org.asteroid.settings
-import org.nemomobile.systemsettings
+import org.asteroid.settings
 import Nemo.Configuration
 import Nemo.Mce
 

--- a/src/qml/LanguagePage.qml
+++ b/src/qml/LanguagePage.qml
@@ -18,7 +18,7 @@
 
 import QtQuick
 import org.asteroid.controls
-import org.nemomobile.systemsettings
+import org.asteroid.settings
 
 Item {
     property int depth

--- a/src/qml/NightstandPage.qml
+++ b/src/qml/NightstandPage.qml
@@ -23,7 +23,6 @@ import QtQuick.Layouts
 import org.asteroid.controls
 import org.asteroid.utils
 import org.asteroid.settings
-import org.nemomobile.systemsettings as NemoSystemSettings
 import Nemo.Configuration
 import Nemo.Mce
 
@@ -60,7 +59,7 @@ Item {
         defaultValue: true
     }
 
-    NemoSystemSettings.DisplaySettings {
+    DisplaySettings {
         id: displaySettings
     }
 

--- a/src/qml/TimePage.qml
+++ b/src/qml/TimePage.qml
@@ -21,7 +21,7 @@ import org.asteroid.controls
 import org.asteroid.utils
 import Nemo.Time
 import Nemo.Configuration
-import org.nemomobile.systemsettings
+import org.asteroid.settings
 
 Item {
     property int depth


### PR DESCRIPTION
Switch the systemsettings imports (DisplaySettings, DateTimeSettings, LanguageModel, AboutSettings) to the native qml-asteroid module.