### PR TITLE
[WatchfacePage] On-device watchface store with direct install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ include(ECMFindQmlModule)
 include(Asteroid6CMakeSettings)
 include(Asteroid6Translations)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Qml Quick DBus)
+find_package(Qt6 REQUIRED COMPONENTS Core Qml Quick DBus Network)
 find_package(Mce REQUIRED)
 pkg_check_modules(NGF REQUIRED IMPORTED_TARGET ngf-qt6)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(
 	volumecontrol.cpp
 	watchfacecatalog.cpp
 	watchfacehelper.cpp
+	watchfacepreviews.cpp
 	${dbus_srcs}
 )
 set(
@@ -28,6 +29,7 @@ set(
 	volumecontrol.h
 	watchfacecatalog.h
 	watchfacehelper.h
+	watchfacepreviews.h
 )
 
 add_library(asteroid-settings ${SRC} ${HEADERS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ asteroid_app_qml_module(asteroid-settings
 	qml/WallpaperPage.qml
 	qml/WatchfacePage.qml
 	qml/WatchfaceSelector.qml
+	qml/WatchfaceSettingsContainer.qml
 	qml/WiFiConnectionDialog.qml
 	qml/WiFiPage.qml
 	qml/LauncherPage.qml

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(
 	taptowake.cpp
 	tilttowake.cpp
 	volumecontrol.cpp
+	watchfacehelper.cpp
 	${dbus_srcs}
 )
 set(
@@ -24,6 +25,7 @@ set(
 	taptowake.h
 	tilttowake.h
 	volumecontrol.h
+	watchfacehelper.h
 )
 
 add_library(asteroid-settings ${SRC} ${HEADERS})
@@ -64,6 +66,7 @@ target_link_libraries(
 		Qt::Qml
 		Qt::Quick
 		Qt::DBus
+		Qt::Network
 		PkgConfig::NGF
 		Asteroid::AsteroidApp6
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set(
 	watchfaceinstaller.cpp
 	watchfacepreviews.cpp
 	watchfaceqmlprobe.cpp
+	watchfacestoremodel.cpp
 	${dbus_srcs}
 )
 set(
@@ -34,6 +35,7 @@ set(
 	watchfaceinstaller.h
 	watchfacepreviews.h
 	watchfaceqmlprobe.h
+	watchfacestoremodel.h
 )
 
 add_library(asteroid-settings ${SRC} ${HEADERS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(
 	watchfacecatalog.cpp
 	watchfacehelper.cpp
 	watchfacepreviews.cpp
+	watchfaceqmlprobe.cpp
 	${dbus_srcs}
 )
 set(
@@ -30,6 +31,7 @@ set(
 	watchfacecatalog.h
 	watchfacehelper.h
 	watchfacepreviews.h
+	watchfaceqmlprobe.h
 )
 
 add_library(asteroid-settings ${SRC} ${HEADERS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(
 	taptowake.cpp
 	tilttowake.cpp
 	volumecontrol.cpp
+	watchfacecatalog.cpp
 	watchfacehelper.cpp
 	${dbus_srcs}
 )
@@ -25,6 +26,7 @@ set(
 	taptowake.h
 	tilttowake.h
 	volumecontrol.h
+	watchfacecatalog.h
 	watchfacehelper.h
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(
 	volumecontrol.cpp
 	watchfacecatalog.cpp
 	watchfacehelper.cpp
+	watchfaceinstaller.cpp
 	watchfacepreviews.cpp
 	watchfaceqmlprobe.cpp
 	${dbus_srcs}
@@ -30,6 +31,7 @@ set(
 	volumecontrol.h
 	watchfacecatalog.h
 	watchfacehelper.h
+	watchfaceinstaller.h
 	watchfacepreviews.h
 	watchfaceqmlprobe.h
 )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,8 @@
 #include "tilttowake.h"
 #include "taptowake.h"
 #include "sysinfo.h"
+#include "watchfacehelper.h"
+#include "watchfacestoremodel.h"
 
 int main(int argc, char *argv[])
 {
@@ -38,6 +40,20 @@ int main(int argc, char *argv[])
     qmlRegisterType<TiltToWake>("org.asteroid.settings", 1, 0, "TiltToWake");
     qmlRegisterType<TapToWake>("org.asteroid.settings", 1, 0, "TapToWake");
     qmlRegisterType<SysInfo>("org.asteroid.settings", 1, 0, "SysInfo");
+    // Singletons: one store backend for the whole app. A creatable type would
+    // construct a full backend (watchers, network manager, directory scans)
+    // per page that declares one — three pages do — and again on every page
+    // reopen. The helper singleton exists so path-only consumers (the
+    // wallpaper page) need not touch the store at all.
+    qmlRegisterSingletonType<WatchfaceStoreModel>(
+        "org.asteroid.settings", 1, 0, "WatchfaceStoreModel",
+        [](QQmlEngine *engine, QJSEngine *) -> QObject * {
+            auto *model = new WatchfaceStoreModel;
+            model->setQmlEngine(engine);
+            return model;
+        });
+    qmlRegisterSingletonInstance("org.asteroid.settings", 1, 0, "WatchfaceHelper",
+                                 WatchfaceHelper::instance());
     view->setSource(QUrl("qrc:/Settings/qml/main.qml"));
     view->rootContext()->setContextProperty("qtVersion", QString(qVersion()));
     view->rootContext()->setContextProperty("kernelVersion", QString(buf.release));

--- a/src/qml/NightstandWatchfacePage.qml
+++ b/src/qml/NightstandWatchfacePage.qml
@@ -56,5 +56,8 @@ Item {
 
     WatchfaceSelector {
         anchors.fill: parent
+        // Face selection only: this path picks the nightstand face, it is not
+        // a second store surface — no catalog browsing, no network probe.
+        storeEnabled: false
     }
 }

--- a/src/qml/WallpaperPage.qml
+++ b/src/qml/WallpaperPage.qml
@@ -1,21 +1,28 @@
-import Nemo.Configuration
-import Qt.labs.folderlistmodel
 /*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
  * SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/eLtMosen>
  * SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
  * SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
+
+import Nemo.Configuration
+import Qt.labs.folderlistmodel
 import QtQuick
 import QtQuick.Effects
 import org.asteroid.controls
+import org.asteroid.settings
 import org.asteroid.utils
 
 Item {
     property int depth
     property var pop
     property string assetPath: "file:///usr/share/asteroid-launcher/wallpapers/"
+    // User wallpaper folder (file:// URL), where a watchface's bundled
+    // wallpaper is installed. From the lightweight helper singleton: a page
+    // that only needs a path must not construct the store backend to get one.
+    readonly property string userAssetPath: WatchfaceHelper.userAssetPath + "wallpapers/"
 
     ConfigurationValue {
         id: wallpaperSource
@@ -31,68 +38,141 @@ Item {
         nameFilters: ["*.qml"]
     }
 
+    // System and user wallpapers merged into one grid, so a watchface's bundled
+    // wallpaper (installed into the user folder) appears alongside the stock
+    // set. Each entry carries everything the delegate needs precomputed — the
+    // displayed thumbnail and the .qml activation sibling when one exists — so
+    // delegates do no per-item filesystem checks or string work while flicking.
+    ListModel {
+        id: unifiedModel
+    }
+
+    FolderListModel {
+        id: sysWallpaperModel
+
+        folder: assetPath + "full"
+        nameFilters: ["*.jpg", "*.png", "*.svg"]
+        onCountChanged: rebuildTimer.restart()
+    }
+
+    FolderListModel {
+        id: userWallpaperModel
+
+        folder: userAssetPath + "full"
+        nameFilters: ["*.jpg", "*.png", "*.svg"]
+        onCountChanged: rebuildTimer.restart()
+    }
+
+    // Coalesce the two folder models' change bursts into a single rebuild, and
+    // skip the rebuild when the resulting list is unchanged: the two models
+    // populate asynchronously and would otherwise tear down and rebuild the
+    // grid twice on every page open.
+    Timer {
+        id: rebuildTimer
+
+        property var lastPaths: []
+
+        interval: 100
+        repeat: false
+        onTriggered: {
+            var entries = [];
+            for (var i = 0; i < sysWallpaperModel.count; i++) {
+                var fn = sysWallpaperModel.get(i, "fileName");
+                var sysThumb = assetPath + Dims.w(50) + "/" + fn;
+                entries.push({
+                    "filePath": assetPath + "full/" + fn,
+                    "thumbPath": FileInfo.exists(sysThumb.slice(7)) ? sysThumb : assetPath + "full/" + fn
+                });
+            }
+            for (var j = 0; j < userWallpaperModel.count; j++) {
+                var ufn = userWallpaperModel.get(j, "fileName");
+                if (!FileInfo.exists((userAssetPath + "full/" + ufn).slice(7)))
+                    continue;
+
+                // User wallpapers have no pre-scaled thumbnail; the delegate's
+                // sourceSize keeps their decode at cell size.
+                entries.push({
+                    "filePath": userAssetPath + "full/" + ufn,
+                    "thumbPath": userAssetPath + "full/" + ufn
+                });
+            }
+            var paths = entries.map(function(e) {
+                return e.filePath;
+            });
+            if (JSON.stringify(paths) === JSON.stringify(lastPaths))
+                return ;
+
+            lastPaths = paths;
+            unifiedModel.clear();
+            for (var k = 0; k < entries.length; k++) {
+                var qmlSibling = entries[k].filePath.replace(/\.[^.]+$/, ".qml");
+                unifiedModel.append({
+                    "filePath": entries[k].filePath,
+                    "thumbPath": entries[k].thumbPath,
+                    "qmlPath": qmlWallpapersModel.indexOf(qmlSibling) !== -1 ? qmlSibling : ""
+                });
+            }
+            for (var m = 0; m < unifiedModel.count; m++) {
+                var entry = unifiedModel.get(m);
+                if (wallpaperSource.value === entry.filePath || wallpaperSource.value === entry.qmlPath) {
+                    // Deferred: this timer can fire before the grid's first
+                    // layout, where positioning would silently no-op.
+                    var idx = m;
+                    Qt.callLater(function() {
+                        grid.positionViewAtIndex(idx, GridView.Center);
+                    });
+                    break;
+                }
+            }
+        }
+    }
+
     GridView {
         id: grid
 
         cellWidth: Dims.w(50)
         cellHeight: Dims.h(40)
         anchors.fill: parent
-
-        model: FolderListModel {
-            id: folderModel
-
-            folder: assetPath + "full"
-            nameFilters: ["*.jpg", "*.png", "*.svg"]
-            onCountChanged: {
-                var i = 0;
-                while (i < folderModel.count) {
-                    var fileName = folderModel.get(i, "fileName");
-                    var fileBaseName = folderModel.get(i, "fileBaseName");
-                    if (wallpaperSource.value === folderModel.folder + "/" + fileName | wallpaperSource.value === folderModel.folder + "/" + fileBaseName + ".qml")
-                        grid.positionViewAtIndex(i, GridView.Center);
-
-                    i = i + 1;
-                }
-            }
-        }
+        model: unifiedModel
 
         delegate: Component {
             id: fileDelegate
 
             Item {
+                // The value a tap writes: the live .qml sibling when the
+                // wallpaper has one, the image itself otherwise.
+                readonly property string activationValue: model.qmlPath !== "" ? model.qmlPath : model.filePath
+
                 width: grid.cellWidth
                 height: grid.cellHeight
 
                 Image {
-                    // Else use the full resolution wallpaper with negative impact on performance, as failsafe.
-
                     id: img
 
                     anchors.fill: parent
                     fillMode: Image.PreserveAspectCrop
-                    // If a pre-scaled thumbnail file exists, use that.
-                    source: FileInfo.exists((assetPath + Dims.w(50) + "/" + fileName).slice(7)) ? assetPath + Dims.w(50) + "/" + fileName : folderModel.folder + "/" + fileName
+                    source: model.thumbPath
+                    // Decode at cell size: a full-resolution user wallpaper
+                    // otherwise decodes to a multi-megabyte image per tile.
+                    sourceSize.width: grid.cellWidth
+                    sourceSize.height: grid.cellHeight
                     asynchronous: true
                 }
 
                 MouseArea {
                     anchors.fill: parent
-                    onClicked: {
-                        if (qmlWallpapersModel.indexOf(folderModel.folder + "/" + fileBaseName + ".qml") !== -1)
-                            wallpaperSource.value = folderModel.folder + "/" + fileBaseName + ".qml";
-                        else
-                            wallpaperSource.value = folderModel.folder + "/" + fileName;
-                    }
+                    onClicked: wallpaperSource.value = activationValue
                 }
 
                 Rectangle {
                     id: highlightSelection
 
-                    property bool notSelected: wallpaperSource.value !== folderModel.folder + "/" + fileName & wallpaperSource.value !== folderModel.folder + "/" + fileBaseName + ".qml"
-
                     anchors.fill: img
                     color: "#30000000"
                     visible: opacity
+                    property bool notSelected: wallpaperSource.value !== model.qmlPath &
+                                               wallpaperSource.value !== model.filePath
+
                     opacity: notSelected ? 1 : 0
 
                     Behavior on opacity {
@@ -108,7 +188,8 @@ Item {
                     name: "ios-checkmark-circle"
                     height: width
                     width: parent.width * 0.3
-                    visible: wallpaperSource.value === folderModel.folder + "/" + fileName | wallpaperSource.value === folderModel.folder + "/" + fileBaseName + ".qml"
+                    visible: wallpaperSource.value === model.qmlPath |
+                             wallpaperSource.value === model.filePath
                     layer.enabled: visible
 
                     anchors {

--- a/src/qml/WallpaperPage.qml
+++ b/src/qml/WallpaperPage.qml
@@ -1,3 +1,5 @@
+import Nemo.Configuration
+import Qt.labs.folderlistmodel
 /*
  * SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/eLtMosen>
  * SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
@@ -7,16 +9,12 @@
  */
 import QtQuick
 import QtQuick.Effects
-import Qt.labs.folderlistmodel
-import Nemo.Configuration
 import org.asteroid.controls
 import org.asteroid.utils
-
 
 Item {
     property int depth
     property var pop
-
     property string assetPath: "file:///usr/share/asteroid-launcher/wallpapers/"
 
     ConfigurationValue {
@@ -46,15 +44,14 @@ Item {
             folder: assetPath + "full"
             nameFilters: ["*.jpg", "*.png", "*.svg"]
             onCountChanged: {
-                var i = 0
-                while (i < folderModel.count){
-                    var fileName = folderModel.get(i, "fileName")
-                    var fileBaseName = folderModel.get(i, "fileBaseName")
-                    if(wallpaperSource.value === folderModel.folder + "/" + fileName |
-                       wallpaperSource.value === folderModel.folder + "/" + fileBaseName + ".qml") {
-                        grid.positionViewAtIndex(i, GridView.Center)
-                    }
-                    i = i + 1
+                var i = 0;
+                while (i < folderModel.count) {
+                    var fileName = folderModel.get(i, "fileName");
+                    var fileBaseName = folderModel.get(i, "fileBaseName");
+                    if (wallpaperSource.value === folderModel.folder + "/" + fileName | wallpaperSource.value === folderModel.folder + "/" + fileBaseName + ".qml")
+                        grid.positionViewAtIndex(i, GridView.Center);
+
+                    i = i + 1;
                 }
             }
         }
@@ -65,68 +62,77 @@ Item {
             Item {
                 width: grid.cellWidth
                 height: grid.cellHeight
+
                 Image {
+                    // Else use the full resolution wallpaper with negative impact on performance, as failsafe.
+
                     id: img
 
                     anchors.fill: parent
                     fillMode: Image.PreserveAspectCrop
                     // If a pre-scaled thumbnail file exists, use that.
-                    source: FileInfo.exists((assetPath + Dims.w(50) + "/" + fileName).slice(7)) ?
-                                assetPath + Dims.w(50) + "/" + fileName :
-                                // Else use the full resolution wallpaper with negative impact on performance, as failsafe.
-                                folderModel.folder + "/" + fileName
+                    source: FileInfo.exists((assetPath + Dims.w(50) + "/" + fileName).slice(7)) ? assetPath + Dims.w(50) + "/" + fileName : folderModel.folder + "/" + fileName
                     asynchronous: true
                 }
 
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
-                        if(qmlWallpapersModel.indexOf(folderModel.folder + "/" + fileBaseName + ".qml") !== -1)
-                            wallpaperSource.value = folderModel.folder + "/" + fileBaseName + ".qml"
+                        if (qmlWallpapersModel.indexOf(folderModel.folder + "/" + fileBaseName + ".qml") !== -1)
+                            wallpaperSource.value = folderModel.folder + "/" + fileBaseName + ".qml";
                         else
-                            wallpaperSource.value = folderModel.folder + "/" + fileName
+                            wallpaperSource.value = folderModel.folder + "/" + fileName;
                     }
                 }
 
                 Rectangle {
                     id: highlightSelection
 
-                    property bool notSelected: wallpaperSource.value !== folderModel.folder + "/" + fileName &
-                                               wallpaperSource.value !== folderModel.folder + "/" + fileBaseName + ".qml"
+                    property bool notSelected: wallpaperSource.value !== folderModel.folder + "/" + fileName & wallpaperSource.value !== folderModel.folder + "/" + fileBaseName + ".qml"
 
                     anchors.fill: img
                     color: "#30000000"
                     visible: opacity
                     opacity: notSelected ? 1 : 0
-                    Behavior on opacity { NumberAnimation { duration: 100 } }
+
+                    Behavior on opacity {
+                        NumberAnimation {
+                            duration: 100
+                        }
+
+                    }
+
                 }
 
                 Icon {
                     name: "ios-checkmark-circle"
+                    height: width
+                    width: parent.width * 0.3
+                    visible: wallpaperSource.value === folderModel.folder + "/" + fileName | wallpaperSource.value === folderModel.folder + "/" + fileBaseName + ".qml"
+                    layer.enabled: visible
+
                     anchors {
                         bottom: parent.bottom
                         bottomMargin: parent.height * 0.05
                         horizontalCenter: parent.horizontalCenter
-                        horizontalCenterOffset: index % 2 ?
-                                                    -parent.height * 0.4 :
-                                                    parent.height * 0.38
+                        horizontalCenterOffset: index % 2 ? -parent.height * 0.4 : parent.height * 0.38
                     }
-                    height: width
-                    width: parent.width * 0.3
-                    visible: wallpaperSource.value === folderModel.folder + "/" + fileName |
-                             wallpaperSource.value === folderModel.folder + "/" + fileBaseName + ".qml"
 
-                    layer.enabled: visible
                     layer.effect: MultiEffect {
                         shadowEnabled: true
                         shadowColor: "#88000000"
                         shadowHorizontalOffset: 2
                         shadowVerticalOffset: 2
-                        shadowBlur: 1.0
+                        shadowBlur: 1
                         blurMax: 8
                     }
+
                 }
+
             }
+
         }
+
     }
+
 }

--- a/src/qml/WallpaperPage.qml
+++ b/src/qml/WallpaperPage.qml
@@ -142,6 +142,7 @@ Item {
                 // The value a tap writes: the live .qml sibling when the
                 // wallpaper has one, the image itself otherwise.
                 readonly property string activationValue: model.qmlPath !== "" ? model.qmlPath : model.filePath
+                readonly property bool selected: wallpaperSource.value === activationValue
 
                 width: grid.cellWidth
                 height: grid.cellHeight
@@ -170,10 +171,7 @@ Item {
                     anchors.fill: img
                     color: "#30000000"
                     visible: opacity
-                    property bool notSelected: wallpaperSource.value !== model.qmlPath &
-                                               wallpaperSource.value !== model.filePath
-
-                    opacity: notSelected ? 1 : 0
+                    opacity: selected ? 0 : 1
 
                     Behavior on opacity {
                         NumberAnimation {
@@ -188,8 +186,7 @@ Item {
                     name: "ios-checkmark-circle"
                     height: width
                     width: parent.width * 0.3
-                    visible: wallpaperSource.value === model.qmlPath |
-                             wallpaperSource.value === model.filePath
+                    visible: selected
                     layer.enabled: visible
 
                     anchors {

--- a/src/qml/WallpaperPage.qml
+++ b/src/qml/WallpaperPage.qml
@@ -1,22 +1,10 @@
 /*
- * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
- *               2022 - Darrel Griët <dgriet@gmail.com>
- *               2015 - Florent Revest <revestflo@gmail.com>
+ * SPDX-FileCopyrightText: 2022 Timo Könnecke <github.com/eLtMosen>
+ * SPDX-FileCopyrightText: 2022 Darrel Griët <dgriet@gmail.com>
+ * SPDX-FileCopyrightText: 2015 Florent Revest <revestflo@gmail.com>
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
-
 import QtQuick
 import QtQuick.Effects
 import Qt.labs.folderlistmodel

--- a/src/qml/WatchfaceSelector.qml
+++ b/src/qml/WatchfaceSelector.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2022 - Timo Könnecke <github.com/eLtMosen>
+ * Copyright (C) 2026 - Timo Könnecke <github.com/moWerk>
+ *               2023 - Arseniy Movshev <dodoradio@outlook.com>
  *               2022 - Darrel Griët <dgriet@gmail.com>
  *               2015 - Florent Revest <revestflo@gmail.com>
  *
@@ -17,201 +18,781 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import QtQml.Models
 import QtQuick
 import QtQuick.Effects
-import Qt.labs.folderlistmodel
 import org.asteroid.controls
+import org.asteroid.settings
 import org.asteroid.utils
-import Nemo.Configuration
 
 Item {
     id: watchfaceSelector
 
-    readonly property var previewSizes: [112, 128, 144, 160, 182]
-    readonly property int idealPreviewSize: Math.round(Dims.w(40))
-    readonly property int previewSize: {
-        let best = previewSizes[0];
-        let minDiff = Math.abs(best - idealPreviewSize);
+    // The nightstand page embeds this selector for face selection only; it
+    // sets storeEnabled false, which drops the catalog footer and the network
+    // probe so no store surface leaks into that path.
+    property bool storeEnabled: true
+    // Context for faces instantiated inside the settings app (the previewless
+    // tile fallback and the on-demand settings host): faces read these
+    // unqualified from the launcher scope.
+    property bool displayAmbient: false
+    property bool nightstand: false
+    // The app-wide store backend. A singleton: however many pages embed the
+    // selector, there is one set of watchers and one model.
+    readonly property var storeModel: WatchfaceStoreModel
+    // The size a tile draws its preview at, handed to the model so it picks the
+    // closest preview folder instead of the first one on disk. Same proportion
+    // the launcher grabs at, so its render lands on the tile unscaled.
+    readonly property int previewSize: Math.round(Dims.l(40))
+    // Selection feedback is split in two: the wallpaper backdrop follows the
+    // tapped face instantly (selectedPath), while the name pill waits for the
+    // face to finish loading (tile.isActive). Defaults to the live active face;
+    // a tap or an install auto-activation reassigns it immediately.
+    property string selectedPath: watchface
+    readonly property string activeBaseName: {
+        var v = watchface;
+        var lastSlash = v.lastIndexOf("/");
+        var name = lastSlash >= 0 ? v.substring(lastSlash + 1) : v;
+        var dotQml = name.indexOf(".qml");
+        return dotQml >= 0 ? name.substring(0, dotQml) : name;
+    }
+    // The name as shown, without the ordering prefix. Stock faces are filed
+    // 000- to 017- so the directory keeps them in curated rather than
+    // alphabetical order; the digits are a filing device, not part of the
+    // name. Display only — every lookup keyed by name (settings detection,
+    // install, activation, preview paths) keeps the real on-disk name.
+    readonly property string activeDisplayName: activeBaseName.replace(/^\d{3}-/, "")
+    // From a cached source scan, not from an instantiated face: the live tile
+    // render is only a fallback for faces lacking a preview image, so an item
+    // to ask is usually not around.
+    readonly property bool activeHasSettings: storeModel.faceHasSettings(activeBaseName)
+    // Armed by a gate-opening "get more" tap; the model reset that actually
+    // brings the catalog rows repositions the view onto the first of them.
+    // With an empty cache those rows only arrive with the network response,
+    // one or two resets later, so the anchor waits on the reset, not the tap.
+    property int pendingBrowseAnchor: -1
 
-        for (let i = 1, n = previewSizes.length; i < n; ++i) {
-            const size = previewSizes[i];
-            const diff = Math.abs(size - idealPreviewSize);
+    // Reflect the online state on open; the catalog is only fetched when the
+    // user taps "get more"/"update", never automatically.
+    Component.onCompleted: {
+        if (storeEnabled)
+            storeModel.probe();
 
-            if (diff < minDiff || (diff === minDiff && size > best)) {
-                minDiff = diff;
-                best = size;
-            }
+    }
+
+    Binding {
+        target: storeModel
+        property: "activeWatchface"
+        value: watchface
+    }
+
+    Binding {
+        target: storeModel
+        property: "previewSize"
+        value: previewSize
+    }
+
+    Connections {
+        // A completed install activates the face only if it is still the user's
+        // current selection. selectedPath is set the moment an install begins, so
+        // tapping another face mid-download moves the intent and a slow install
+        // never steals activation from the newer choice.
+        function onActivated(value) {
+            if (watchfaceSelector.selectedPath === value)
+                watchface = value;
+
         }
-        return best;
+
+        // Set-once wallpaper: the engine emits this only on a fresh install (never
+        // on re-activation), so the bundled wallpaper is forced once for the peek
+        // preview and the user's later wallpaper choice is respected afterwards.
+        function onWallpaperForced(url) {
+            wallpaperSource.value = url;
+        }
+
+        // Any reset, whatever its trigger (catalog refresh, connectivity
+        // flip, a face pushed or removed on disk), keeps the user's place:
+        // remember the position just before, restore just after. Cells are
+        // uniform so the restored offset is exact. The get-more anchor takes
+        // precedence when armed.
+        function onModelAboutToBeReset() {
+            grid.savedContentY = grid.contentY;
+        }
+
+        // The fetch settled without producing catalog rows (offline race,
+        // empty catalog): disarm so a later unrelated reset cannot jump.
+        function onLoadingChanged() {
+            if (!storeModel.loading && grid.count <= watchfaceSelector.pendingBrowseAnchor)
+                watchfaceSelector.pendingBrowseAnchor = -1;
+
+        }
+
+        target: storeModel
+    }
+
+
+    // Context the live-rendered fallback faces expect (a face without any
+    // preview image renders itself in the tile). Page scope, so every
+    // delegate of the grid below resolves them.
+    Item {
+        id: burnInProtectionManager
+
+        property int leftOffset
+        property int rightOffset
+        property int topOffset
+        property int bottomOffset
+        property int widthOffset
+        property int heightOffset
+    }
+
+    WallClock {
+        id: wallClock
+
+        enabled: true
+        updateFrequency: WallClock.Second
+    }
+
+    QtObject {
+        id: localeManager
+
+        property string changesObserver: ""
+    }
+
+    Component {
+        id: tileDelegate
+
+        Item {
+            id: tile
+
+            property bool _pressActive: false
+            property bool _scrollCancelled: false
+            property bool _downloadFiredOnHold: false
+            readonly property bool isActive: model.active
+            readonly property bool isInstalled: model.installed
+            readonly property bool isUser: model.installed && !model.stock
+            readonly property string baseName: model.name
+            readonly property bool isInstalling: model.downloading
+            readonly property bool isFailed: model.failed
+            readonly property string missingModule: model.missingModule
+            readonly property string resolvedFilePath: storeModel.watchfaceUrl(model.name)
+
+            width: GridView.view.cellWidth
+            height: GridView.view.cellHeight
+            onIsInstallingChanged: {
+                if (!isInstalling && isInstalled)
+                    bumpAnim.start();
+
+            }
+            onIsFailedChanged: {
+                if (isFailed)
+                    failAnim.start();
+
+            }
+
+            Rectangle {
+                id: stateBg
+
+                width: Dims.l(40)
+                height: width
+                radius: DeviceSpecs.hasRoundScreen ? width : Dims.l(3)
+                anchors.centerIn: parent
+                color: !isInstalled ? "#000000" : "transparent"
+                opacity: !isInstalled ? 0.2 : (isActive ? 0.2 : 0)
+
+                NumberAnimation {
+                    id: opacityAnim
+
+                    target: stateBg
+                    property: "opacity"
+                    easing.type: Easing.OutQuad
+                }
+
+                ColorAnimation {
+                    id: colorAnim
+
+                    target: stateBg
+                    property: "color"
+                    easing.type: Easing.OutQuad
+                }
+
+                SequentialAnimation {
+                    id: bumpAnim
+
+                    PropertyAction {
+                        target: stateBg
+                        property: "color"
+                        value: "#44ff88"
+                    }
+
+                    NumberAnimation {
+                        target: stateBg
+                        property: "opacity"
+                        to: 1
+                        duration: 200
+                        easing.type: Easing.OutQuad
+                    }
+
+                    NumberAnimation {
+                        target: stateBg
+                        property: "opacity"
+                        to: 0
+                        duration: 200
+                        easing.type: Easing.InQuad
+                    }
+
+                }
+
+                SequentialAnimation {
+                    id: failAnim
+
+                    ColorAnimation {
+                        target: stateBg
+                        property: "color"
+                        to: "#ff4444"
+                        duration: 200
+                    }
+
+                    PauseAnimation {
+                        duration: 1200
+                    }
+
+                    ColorAnimation {
+                        target: stateBg
+                        property: "color"
+                        to: "#000000"
+                        duration: 400
+                    }
+
+                    NumberAnimation {
+                        target: stateBg
+                        property: "opacity"
+                        to: 0.2
+                        duration: 300
+                    }
+
+                }
+
+            }
+
+            Timer {
+                id: contextHoldTimer
+
+                interval: 800
+                repeat: false
+                onTriggered: {
+                    if (!tile.isInstalled) {
+                        if (!tile.isInstalling) {
+                            _downloadFiredOnHold = true;
+                            colorAnim.stop();
+                            opacityAnim.stop();
+                            colorAnim.from = stateBg.color;
+                            colorAnim.to = "#44ff88";
+                            colorAnim.duration = 300;
+                            colorAnim.start();
+                            opacityAnim.from = stateBg.opacity;
+                            opacityAnim.to = 0.5;
+                            opacityAnim.duration = 300;
+                            opacityAnim.easing.type = Easing.OutQuad;
+                            opacityAnim.start();
+                            // Record the intent so the install activates on completion
+                            // only if this is still the selected face.
+                            watchfaceSelector.selectedPath = resolvedFilePath;
+                            storeModel.install(tile.baseName);
+                        }
+                        return ;
+                    }
+                    pressOverlayIn.stop();
+                    pressOverlay.opacity = 0;
+                    // Detection comes from the cached source scan, never from
+                    // the tile's live render (which only exists for faces
+                    // lacking a preview image). The container instantiates the
+                    // face on demand to reach its settingsPage; a user face
+                    // opens it even without settings, as the remove target.
+                    if (tile.isUser || storeModel.faceHasSettings(tile.baseName))
+                        layerStack.push(watchfaceSettingsContainerComponent, {
+                        "watchfaceName": tile.baseName,
+                        "watchfaceFile": resolvedFilePath,
+                        "isStock": !tile.isUser,
+                        "store": storeModel
+                    });
+
+                }
+            }
+
+            Rectangle {
+                id: maskArea
+
+                width: Dims.l(40)
+                height: width
+                anchors.centerIn: parent
+                color: "transparent"
+                radius: DeviceSpecs.hasRoundScreen ? width : Dims.l(3)
+                clip: true
+                layer.enabled: true
+
+                Image {
+                    id: previewPng
+
+                    property bool previewExists: model.preview !== ""
+
+                    z: 1
+                    anchors.centerIn: parent
+                    width: Math.min(parent.width, parent.height)
+                    height: width
+                    opacity: tile.isInstalled ? 1 : 0.7
+                    source: previewExists ? "file://" + model.preview : ""
+                    asynchronous: true
+                    cache: false
+                    fillMode: Image.PreserveAspectFit
+                    // Every face without a device preview shows a static substitute
+                    // — the repo gallery thumbnail — so browsing never live-loads a
+                    // watchface. The device-specific grab replaces it on activation.
+                    Component.onCompleted: {
+                        if (!previewExists)
+                            storeModel.requestPreview(model.name);
+
+                    }
+
+                    Behavior on opacity {
+                        NumberAnimation {
+                            duration: 400
+                            easing.type: Easing.InOutQuad
+                        }
+
+                    }
+
+                }
+
+                Loader {
+                    id: previewQml
+
+                    z: 2
+                    // Last-resort display only. A face with no preview anywhere —
+                    // no launcher grab, no stock image, no gallery thumbnail —
+                    // renders live so its tile is not empty. The launcher captures
+                    // a real preview once the face is activated; this is just the
+                    // fallback for bare QML a user pushed while learning. Faces
+                    // that HAVE any preview never render here, and nothing is
+                    // grabbed in the settings process.
+                    visible: !previewPng.previewExists && tile.isInstalled
+                    active: !previewPng.previewExists && tile.isInstalled
+                    anchors.centerIn: parent
+                    width: Math.min(parent.width, parent.height)
+                    height: width
+                    source: (!previewPng.previewExists && tile.isInstalled) ? resolvedFilePath : ""
+                    asynchronous: true
+                }
+
+                Image {
+                    id: wallpaperBack
+
+                    // The wallpaper as a displayable image: a live wallpaper is
+                    // a .qml whose still sibling is the .jpg next to it, so the
+                    // backdrop never asks the Image to decode QML. Prefer the
+                    // pre-scaled copy for this tile size, fall back to full.
+                    property string previewSizePath: "wallpapers/" + Dims.w(50)
+                    property string wallpaperImg: wallpaperSource.value.replace(/\.[^.]+$/, ".jpg")
+                    property string wallpaperPreviewImg: wallpaperImg.replace("wallpapers/full", previewSizePath)
+
+                    z: 0
+                    anchors.fill: parent
+                    fillMode: Image.PreserveAspectFit
+                    visible: opacity > 0
+                    // Instant selection feedback, decoupled from the load-gated
+                    // isActive: the backdrop follows the tapped face immediately.
+                    opacity: resolvedFilePath === watchfaceSelector.selectedPath ? 1 : 0
+                    source: opacity > 0 ? (FileInfo.exists(wallpaperPreviewImg.slice(7)) ? wallpaperPreviewImg : wallpaperImg) : ""
+
+                    Behavior on opacity {
+                        NumberAnimation {
+                            duration: 100
+                        }
+
+                    }
+
+                }
+
+                Rectangle {
+                    id: pressOverlay
+
+                    z: 3
+                    anchors.fill: parent
+                    color: "#000000"
+                    opacity: 0
+
+                    NumberAnimation {
+                        id: pressOverlayIn
+
+                        target: pressOverlay
+                        property: "opacity"
+                        from: 0
+                        to: 0.5
+                        duration: 800
+                        easing.type: Easing.Linear
+                    }
+
+                    NumberAnimation {
+                        id: pressOverlayOut
+
+                        target: pressOverlay
+                        property: "opacity"
+                        duration: 150
+                        easing.type: Easing.OutQuad
+                    }
+
+                }
+
+                // Greyed overlay for a face whose imports are not met on this
+                // device: darken it and name the missing module so the user knows
+                // why it is unavailable instead of being offered a blank face.
+                Rectangle {
+                    z: 50
+                    anchors.fill: parent
+                    visible: tile.missingModule !== ""
+                    // Dim via the colour's alpha, not the item's opacity, so the
+                    // reason text below stays crisp instead of being dimmed with it.
+                    color: "#8c000000"
+
+                    Text {
+                        anchors.centerIn: parent
+                        horizontalAlignment: Text.AlignHCenter
+                        color: "#ff5252"
+                        text: "needs\n" + tile.missingModule.split(".").pop()
+
+                        // Condensed to keep the module name on one line; sized up
+                        // now that the narrow family leaves the width to spare.
+                        font {
+                            pixelSize: parent.height * 0.195
+                            family: "Noto Sans Condensed"
+                        }
+
+                    }
+
+                }
+
+                MouseArea {
+                    property real startX: 0
+                    property real startY: 0
+
+                    anchors.fill: parent
+                    onPressed: (mouse) => {
+                        startX = mouse.x;
+                        startY = mouse.y;
+                        _scrollCancelled = false;
+                        _pressActive = true;
+                        bumpAnim.stop();
+                        failAnim.stop();
+                        opacityAnim.stop();
+                        colorAnim.stop();
+                        if (!tile.isInstalled && !tile.isInstalling) {
+                            _downloadFiredOnHold = false;
+                            colorAnim.from = stateBg.color;
+                            colorAnim.to = "#44ff88";
+                            colorAnim.duration = 300;
+                            colorAnim.start();
+                            opacityAnim.from = stateBg.opacity;
+                            opacityAnim.to = 0.35;
+                            opacityAnim.duration = 300;
+                            opacityAnim.easing.type = Easing.OutQuad;
+                            opacityAnim.start();
+                            contextHoldTimer.restart();
+                        } else if (tile.isInstalled && tile.missingModule === "") {
+                            pressOverlayIn.stop();
+                            pressOverlayOut.stop();
+                            pressOverlay.opacity = 0;
+                            pressOverlayIn.start();
+                            contextHoldTimer.restart();
+                        }
+                    }
+                    onPositionChanged: (mouse) => {
+                        if (_scrollCancelled)
+                            return ;
+
+                        var dx = Math.abs(mouse.x - startX);
+                        var dy = Math.abs(mouse.y - startY);
+                        if (dx > Dims.l(2) || dy > Dims.l(2)) {
+                            _scrollCancelled = true;
+                            _pressActive = false;
+                            contextHoldTimer.stop();
+                            pressOverlayIn.stop();
+                            pressOverlayOut.from = pressOverlay.opacity;
+                            pressOverlayOut.to = 0;
+                            pressOverlayOut.start();
+                            opacityAnim.stop();
+                            colorAnim.stop();
+                            colorAnim.from = stateBg.color;
+                            colorAnim.to = !tile.isInstalled ? "#000000" : "transparent";
+                            colorAnim.duration = 150;
+                            colorAnim.start();
+                            opacityAnim.from = stateBg.opacity;
+                            opacityAnim.to = !tile.isInstalled ? 0.2 : (tile.isActive ? 0.2 : 0);
+                            opacityAnim.duration = 150;
+                            opacityAnim.easing.type = Easing.OutQuad;
+                            opacityAnim.start();
+                            mouse.accepted = false;
+                        }
+                    }
+                    onReleased: {
+                        if (_scrollCancelled)
+                            return ;
+
+                        contextHoldTimer.stop();
+                        _pressActive = false;
+                        if (_downloadFiredOnHold) {
+                            _downloadFiredOnHold = false;
+                            return ;
+                        }
+                        if (!tile.isInstalled && !tile.isInstalling) {
+                            colorAnim.stop();
+                            opacityAnim.stop();
+                            colorAnim.from = stateBg.color;
+                            colorAnim.to = "#44ff88";
+                            colorAnim.duration = 300;
+                            colorAnim.start();
+                            opacityAnim.from = stateBg.opacity;
+                            opacityAnim.to = 0.5;
+                            opacityAnim.duration = 300;
+                            opacityAnim.easing.type = Easing.OutQuad;
+                            opacityAnim.start();
+                            // Record the intent now so the install activates on
+                            // completion only if this is still the selected face.
+                            watchfaceSelector.selectedPath = resolvedFilePath;
+                            storeModel.install(tile.baseName);
+                        } else if (tile.isInstalled && tile.missingModule === "") {
+                            pressOverlayIn.stop();
+                            pressOverlayOut.from = pressOverlay.opacity;
+                            pressOverlayOut.to = 0;
+                            pressOverlayOut.start();
+                            opacityAnim.stop();
+                            opacityAnim.from = stateBg.opacity;
+                            opacityAnim.to = tile.isActive ? 0.2 : 0;
+                            opacityAnim.duration = 200;
+                            opacityAnim.easing.type = Easing.OutQuad;
+                            opacityAnim.start();
+                            // Instant selection: record the intent (which moves the
+                            // wallpaper backdrop) and activate at once; the name pill
+                            // follows when the face finishes loading.
+                            watchfaceSelector.selectedPath = resolvedFilePath;
+                            watchface = resolvedFilePath;
+                        }
+                    }
+                    onCanceled: {
+                        contextHoldTimer.stop();
+                        _pressActive = false;
+                        _downloadFiredOnHold = false;
+                        pressOverlayIn.stop();
+                        pressOverlayOut.from = pressOverlay.opacity;
+                        pressOverlayOut.to = 0;
+                        pressOverlayOut.start();
+                        opacityAnim.stop();
+                        colorAnim.stop();
+                        colorAnim.from = stateBg.color;
+                        colorAnim.to = !tile.isInstalled ? "#000000" : "transparent";
+                        colorAnim.duration = 200;
+                        colorAnim.start();
+                        opacityAnim.from = stateBg.opacity;
+                        opacityAnim.to = !tile.isInstalled ? 0.2 : (tile.isActive ? 0.2 : 0);
+                        opacityAnim.duration = 200;
+                        opacityAnim.easing.type = Easing.OutQuad;
+                        opacityAnim.start();
+                    }
+                }
+
+                layer.effect: MultiEffect {
+                    maskEnabled: true
+                    maskSource: maskShape
+                }
+
+            }
+
+            // External mask shape for the MultiEffect. Kept out of maskArea so
+            // it is not part of the layered content, only its alpha is sampled.
+            // Geometry matches the mask source exactly.
+            Rectangle {
+                id: maskShape
+
+                anchors.centerIn: maskArea
+                width: Math.min(wallpaperBack.width, wallpaperBack.height)
+                height: width
+                radius: maskArea.radius
+                visible: false
+                layer.enabled: true
+            }
+
+            Rectangle {
+                id: namePill
+
+                width: parent.width
+                height: Dims.l(11)
+                radius: height / 2
+                color: "#cc000000"
+                visible: opacity > 0
+                opacity: tile.isActive ? 1 : 0
+
+                anchors {
+                    verticalCenter: parent.bottom
+                    verticalCenterOffset: -Dims.l(3)
+                    horizontalCenter: parent.horizontalCenter
+                }
+
+                Row {
+                    id: pillContent
+
+                    anchors.centerIn: parent
+                    spacing: Dims.l(1)
+                    height: parent.height
+
+                    Marquee {
+                        id: pillMarquee
+
+                        width: namePill.width - Dims.l(6) - (pillGear.visible ? pillGear.width + Dims.l(1) : 0)
+                        text: watchfaceSelector.activeDisplayName
+                        speed: 0.5
+                    }
+
+                    Icon {
+                        id: pillGear
+
+                        name: "ios-settings-outline"
+                        width: Dims.l(7)
+                        height: width
+                        visible: watchfaceSelector.activeHasSettings
+                        anchors.verticalCenter: parent.verticalCenter
+                        opacity: 0.7
+                    }
+
+                }
+
+            }
+
+        }
+
     }
 
     GridView {
         id: grid
-        cellWidth: Dims.w(50)
-        cellHeight: Dims.h(40)
+
+        property real savedContentY: -1
+
         anchors.fill: parent
-
-        model: FolderListModel {
-            id: folderModel
-            folder: assetPath + "watchfaces"
-            nameFilters: ["*.qml"]
-            onCountChanged: {
-                var i = 0
-                while (i < folderModel.count){
-                    var fileName = folderModel.get(i, "fileName")
-                    if(watchface === folderModel.folder + "/" + fileName)
-                        grid.positionViewAtIndex(i, GridView.Center)
-
-                    i = i+1
-                }
+        cellWidth: Dims.w(50)
+        cellHeight: Dims.h(45)
+        clip: true
+        // One virtualized grid over the whole model: stock rows first, then the
+        // community section, in the order the model provides. The grid owns the
+        // scrolling so delegates are created on demand — sizing grids to their
+        // full content inside an outer Flickable instantiated every tile at
+        // once, which was most of the store's old multi-second page open.
+        model: storeModel
+        delegate: tileDelegate
+        // The armed "get more" anchor lands here, not on the model signal: the
+        // view's count only reflects the new rows once IT has processed the
+        // reset, which is after the model's own subscribers ran.
+        onCountChanged: {
+            var anchor = watchfaceSelector.pendingBrowseAnchor;
+            if (anchor >= 0 && count > anchor) {
+                watchfaceSelector.pendingBrowseAnchor = -1;
+                grid.savedContentY = -1;
+                Qt.callLater(function() {
+                    grid.positionViewAtIndex(anchor, GridView.Beginning);
+                });
+            } else if (grid.savedContentY >= 0) {
+                var y = grid.savedContentY;
+                grid.savedContentY = -1;
+                Qt.callLater(function() {
+                    grid.contentY = Math.max(0, Math.min(y, grid.contentHeight - grid.height));
+                });
             }
         }
 
-        Item {
-            id: burnInProtectionManager
-
-            property int leftOffset
-            property int rightOffset
-            property int topOffset
-            property int bottomOffset
-            property int widthOffset
-            property int heightOffset
-        }
-
-        WallClock {
-            id: wallClock
-            enabled: true
-            updateFrequency: WallClock.Second
-        }
-
-        QtObject {
-            id: localeManager
-            property string changesObserver: ""
-        }
-
-        delegate: Component {
+        // The store actions ride along as the grid footer.
+        footer: Column {
+            width: grid.width
 
             Item {
-                width: grid.cellWidth
-                height: grid.cellHeight
-
-                Rectangle {
-                    id: maskArea
-
-                    width: Dims.w(40)
-                    height: grid.cellHeight
-                    anchors.centerIn: parent
-                    color: "transparent"
-                    radius: DeviceSpecs.hasRoundScreen ?
-                                width :
-                                Dims.w(3)
-                    clip: true
-
-                    Image {
-                        id: previewPng
-
-                        readonly property string previewFolder: `${assetPath}watchfaces-preview/${previewSize}/`
-                        readonly property string previewImg: `${previewFolder}${fileName.slice(0, -4)}.png`
-                        property bool previewExists: FileInfo.exists(previewImg)
-
-                        z: 1
-                        anchors.centerIn: parent
-                        width: Math.min(parent.width, parent.height)
-                        height: width
-                        source: !previewExists ? "" : previewImg
-                        asynchronous: true
-                        fillMode: Image.PreserveAspectFit
-                        mipmap: true
-                    }
-
-                    Loader {
-                        id: previewQml
-
-                        z: 2
-                        visible: !previewPng.previewExists
-                        active: visible
-                        anchors.centerIn: parent
-                        width: Math.min(parent.width, parent.height)
-                        height: width
-                        source: folderModel.folder + "/" + fileName
-                        asynchronous: true
-                    }
-
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: watchface = folderModel.folder + "/" + fileName
-                    }
-
-                    Image {
-                        id: wallpaperBack
-
-                        property string previewSizePath: "wallpapers/" + Dims.w(50)
-                        property string wallpaperPreviewImg: wallpaperSource.value.replace("\\wallpapers/full\\", previewSizePath).slice(0, -3) + "jpg"
-
-                        z: 0
-                        anchors.fill: parent
-                        fillMode: Image.PreserveAspectFit
-                        visible: opacity
-                        opacity: watchface === folderModel.folder + "/" + fileName ? 1 : 0
-                        source: opacity > 0 ? FileInfo.exists(wallpaperPreviewImg) ?
-                                    wallpaperPreviewImg :
-                                    wallpaperSource.value : ""
-                        Behavior on opacity { NumberAnimation { duration: 100 } }
-                    }
-
-                    layer.enabled: true
-                    layer.effect: MultiEffect {
-                        maskEnabled: true
-                        maskSource: ShaderEffectSource {
-                            smooth: true
-                            hideSource: true
-                            sourceItem: Item {
-                                width: maskArea.width
-                                height: maskArea.height
-                                Rectangle {
-                                    anchors.centerIn: parent
-                                    width: Math.min(maskArea.width, maskArea.height)
-                                    height: width
-                                    radius: maskArea.radius
-                                }
-                            }
-                        }
-                    }
-                }
-
-                Icon {
-                    name: "ios-checkmark-circle"
-
-                    z: 100
-                    width: parent.width * .3
-                    height: width
-                    visible: watchface === folderModel.folder + "/" + fileName
-                    anchors {
-                        bottom: parent.bottom
-                        bottomMargin: DeviceSpecs.hasRoundScreen ?
-                                          -parent.height * .03 :
-                                          -parent.height * .08
-                        horizontalCenter: parent.horizontalCenter
-                        horizontalCenterOffset: index % 2 ?
-                                                    DeviceSpecs.hasRoundScreen ?
-                                                        -parent.height * .45 :
-                                                        -parent.height * .40 :
-                                                        DeviceSpecs.hasRoundScreen ?
-                                                            parent.height * .45 :
-                                                            parent.height * .40
-                    }
-
-                    layer.enabled: visible
-                    layer.effect: MultiEffect {
-                        shadowEnabled: true
-                        shadowColor: "#88000000"
-                        shadowHorizontalOffset: 2
-                        shadowVerticalOffset: 2
-                        shadowBlur: 1.0
-                        blurMax: 8
-                    }
-                }
+                width: parent.width
+                height: Dims.l(4)
             }
+
+            RowSeparator {
+                visible: watchfaceSelector.storeEnabled
+            }
+
+            Item {
+                visible: watchfaceSelector.storeEnabled
+                width: parent.width
+                height: visible ? Dims.h(32) : 0
+                opacity: storeModel.online ? 1 : 0.45
+
+                Column {
+                    anchors.centerIn: parent
+
+                    Icon {
+                        name: "ios-cloud-download-outline"
+                        width: Dims.l(12)
+                        height: width
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+
+                    Label {
+                        //% "Loading"
+                        readonly property string loadingText: qsTrId("id-loading")
+                        //% "Update"
+                        readonly property string updateText: qsTrId("id-update")
+                        //% "Get more"
+                        readonly property string getMoreText: qsTrId("id-get-more")
+
+                        width: Dims.l(70)
+                        horizontalAlignment: Text.AlignHCenter
+                        text: storeModel.loading ? loadingText : storeModel.hasCatalog ? updateText : getMoreText
+                        anchors.horizontalCenter: parent.horizontalCenter
+
+                        font {
+                            pixelSize: Dims.l(8)
+                            family: "Noto Sans"
+                            styleName: "SemiCondensed SemiBold"
+                        }
+
+                    }
+
+                }
+
+                HighlightBar {
+                    onClicked: {
+                        // Dimmed AND inert offline: a catalog fetch cannot
+                        // succeed, and the gated rows could not install anyway.
+                        if (storeModel.loading || !storeModel.online)
+                            return ;
+
+                        // Arm the scroll anchor before the rebuilds: the view
+                        // should land on the first catalog row — the content
+                        // this tap asked for — not jump back to the top. The
+                        // pre-tap row count is exactly that row's index.
+                        // Update taps (browse already open) keep their place.
+                        if (!storeModel.browseActive)
+                            watchfaceSelector.pendingBrowseAnchor = grid.count;
+
+                        storeModel.refresh();
+                    }
+                }
+
+            }
+
+            Item {
+                width: parent.width
+                height: DeviceSpecs.hasRoundScreen ? Dims.l(8) : 0
+            }
+
         }
+
     }
+
+    Component {
+        id: watchfaceSettingsContainerComponent
+
+        WatchfaceSettingsContainer {
+        }
+
+    }
+
 }

--- a/src/qml/WatchfaceSettingsContainer.qml
+++ b/src/qml/WatchfaceSettingsContainer.qml
@@ -1,0 +1,194 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ * SPDX-FileCopyrightText: 2023 Arseniy Movshev <dodoradio@outlook.com>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+import Nemo.Configuration
+import QtQuick
+import org.asteroid.controls
+import org.asteroid.utils
+
+/*
+ * Host page for one face's settings and its remove action, pushed from the
+ * selector on a long-press. The face itself is instantiated here, hidden and
+ * on demand: the selector's cheap source scan only detects that a settingsPage
+ * exists, while the actual settings UI is a Component on the face root and
+ * needs an instance to come from. A user face without settings collapses to
+ * the bare remove target; a stock face shows settings only.
+ */
+Item {
+    id: container
+
+    // Injected by LayerStack.push.
+    property int depth
+    property var pop
+    // Set by the pusher: no reliance on unqualified context lookups.
+    property string watchfaceName: ""
+    property string watchfaceFile: ""
+    property bool isStock: false
+    property var store
+    readonly property bool scanHasSettings: store.faceHasSettings(watchfaceName)
+    readonly property bool hasSettings: faceLoader.status === Loader.Ready && faceLoader.item && typeof faceLoader.item.settingsPage !== "undefined"
+
+    ConfigurationValue {
+        id: activeWatchface
+
+        key: "/desktop/asteroid/watchface"
+        defaultValue: "file:///usr/share/asteroid-launcher/watchfaces/000-default-digital.qml"
+    }
+
+    // The on-demand face instance, loaded only when the source scan found a
+    // settingsPage, and never shown: it exists to hand over that Component.
+    Loader {
+        id: faceLoader
+
+        visible: false
+        width: parent.width
+        height: parent.height
+        asynchronous: true
+        source: container.scanHasSettings ? container.watchfaceFile : ""
+    }
+
+    // Bare remove target for a user face with no settings: a large centered
+    // trash icon. The tap area is the icon and a generous margin around it,
+    // not the whole page, so the header cannot start a removal.
+    Item {
+        anchors.fill: parent
+        visible: !container.scanHasSettings && !container.isStock
+
+        Icon {
+            id: bareTrash
+
+            name: "ios-trash-outline"
+            color: "#FF3B30"
+            width: Dims.l(32)
+            height: Dims.l(32)
+            anchors.centerIn: parent
+        }
+
+        MouseArea {
+            anchors.fill: bareTrash
+            anchors.margins: -Dims.l(8)
+            onClicked: {
+                //% "Remove"
+                removeRemorse.action = qsTrId("id-remove") + "\n" + container.watchfaceName;
+                removeRemorse.start();
+            }
+        }
+
+    }
+
+    Flickable {
+        id: settingsFlick
+
+        visible: container.scanHasSettings
+        contentHeight: settingsColumn.height
+        clip: true
+
+        anchors {
+            top: parent.top
+            topMargin: pageHeader.height
+            bottom: parent.bottom
+            left: parent.left
+            right: parent.right
+        }
+
+        Column {
+            id: settingsColumn
+
+            width: parent.width
+
+            Loader {
+                id: settingsLoader
+
+                width: parent.width
+                // Fill the viewport for the usual screen-sized settings page,
+                // but let a taller page extend the content so it scrolls
+                // instead of clipping.
+                height: Math.max(container.height - pageHeader.height, item ? item.implicitHeight : 0)
+                sourceComponent: container.hasSettings ? faceLoader.item.settingsPage : null
+            }
+
+            RowSeparator {
+                visible: !container.isStock
+            }
+
+            Item {
+                visible: !container.isStock
+                width: parent.width
+                height: visible ? Dims.h(24) : 0
+
+                Column {
+                    anchors.centerIn: parent
+
+                    Icon {
+                        name: "ios-trash-outline"
+                        width: Dims.l(12)
+                        height: width
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+
+                    Label {
+                        width: Dims.l(70)
+                        horizontalAlignment: Text.AlignHCenter
+                        //% "Remove"
+                        text: qsTrId("id-remove")
+                        anchors.horizontalCenter: parent.horizontalCenter
+
+                        font {
+                            pixelSize: Dims.l(8)
+                            family: "Noto Sans"
+                            styleName: "SemiCondensed SemiBold"
+                        }
+
+                    }
+
+                }
+
+                HighlightBar {
+                    onClicked: {
+                        //% "Remove"
+                        removeRemorse.action = qsTrId("id-remove") + " " + container.watchfaceName;
+                        removeRemorse.start();
+                    }
+                }
+
+            }
+
+            Item {
+                width: parent.width
+                height: DeviceSpecs.hasRoundScreen ? Dims.l(8) : 0
+            }
+
+        }
+
+    }
+
+    RemorseTimer {
+        id: removeRemorse
+
+        duration: 3000
+        gaugeSegmentAmount: 8
+        gaugeStartDegree: -130
+        gaugeEndFromStartDegree: 265
+        //% "Tap to cancel"
+        cancelText: qsTrId("id-tap-to-cancel")
+        onTriggered: {
+            if (activeWatchface.value === container.watchfaceFile)
+                activeWatchface.value = activeWatchface.defaultValue;
+
+            // Remove first, pop after: the pop destroys this page, and only a
+            // deferred-deletion accident would let a statement after it run.
+            container.store.remove(container.watchfaceName);
+            container.pop();
+        }
+    }
+
+    PageHeader {
+        id: pageHeader
+
+        text: container.watchfaceName
+    }
+
+}

--- a/src/watchfacecatalog.cpp
+++ b/src/watchfacecatalog.cpp
@@ -1,0 +1,227 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "watchfacecatalog.h"
+#include "watchfacehelper.h"
+
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+
+namespace {
+const QString kApiBase = QStringLiteral(
+    "https://api.github.com/repos/AsteroidOS/unofficial-watchfaces/contents/");
+const QString kRawBase = QStringLiteral(
+    "https://raw.githubusercontent.com/AsteroidOS/unofficial-watchfaces/master/");
+const QString kProbeUrl = kRawBase + QStringLiteral("README.md");
+const QString kTreeApi = QStringLiteral(
+    "https://api.github.com/repos/AsteroidOS/unofficial-watchfaces/git/trees/master?recursive=1");
+
+bool writeFile(const QString &path, const QByteArray &data)
+{
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+        return false;
+    f.write(data);
+    f.close();
+    return true;
+}
+
+QByteArray readTrimmed(const QString &path)
+{
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly))
+        return {};
+    return f.readAll().trimmed();
+}
+} // namespace
+
+WatchfaceCatalog::WatchfaceCatalog(QNetworkAccessManager *nam, QObject *parent)
+    : QObject(parent)
+    , m_nam(nam)
+{
+}
+
+bool WatchfaceCatalog::online() const  { return m_online; }
+bool WatchfaceCatalog::loading() const { return m_loading; }
+bool WatchfaceCatalog::hasCatalog() const { return QFile::exists(catalogCachePath()); }
+QStringList WatchfaceCatalog::names() const { return m_names; }
+
+bool WatchfaceCatalog::isSkippedDir(const QString &name)
+{
+    return name.isEmpty()
+        || name.startsWith(QLatin1Char('.'))
+        || name == QLatin1String("tests")
+        || name == QLatin1String("fake-components");
+}
+
+void WatchfaceCatalog::setOnline(bool v)
+{
+    if (m_online == v)
+        return;
+    m_online = v;
+    Q_EMIT onlineChanged();
+}
+
+void WatchfaceCatalog::setLoading(bool v)
+{
+    if (m_loading == v)
+        return;
+    m_loading = v;
+    Q_EMIT loadingChanged();
+}
+
+void WatchfaceCatalog::probeOnline()
+{
+    QNetworkReply *reply = m_nam->head(QNetworkRequest(QUrl(kProbeUrl)));
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        setOnline(reply->error() == QNetworkReply::NoError);
+        reply->deleteLater();
+    });
+}
+
+void WatchfaceCatalog::loadCached()
+{
+    QStringList names;
+    QFile f(catalogCachePath());
+    if (f.open(QIODevice::ReadOnly))
+        names = parseCatalog(f.readAll());
+    m_names = names;
+    Q_EMIT namesChanged();
+}
+
+void WatchfaceCatalog::fetch()
+{
+    fetchCatalog();
+    fetchTree();
+}
+
+void WatchfaceCatalog::fetchCatalog()
+{
+    setLoading(true);
+    QNetworkRequest req{ QUrl(kApiBase) };
+    const QByteArray etag = readCachedEtag();
+    if (!etag.isEmpty())
+        req.setRawHeader("If-None-Match", etag);
+
+    QNetworkReply *reply = m_nam->get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        setLoading(false);
+        const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        if (reply->error() == QNetworkReply::NoError && status == 200) {
+            setOnline(true);
+            const QByteArray body = reply->readAll();
+            writeCatalogCache(body, reply->rawHeader("ETag"));
+            m_names = parseCatalog(body);
+            Q_EMIT namesChanged();
+        } else if (status == 304) {
+            setOnline(true); // unchanged, and the cache is already displayed
+        }
+        // A failure is not proof of being offline: a rate-limit 403 still shows
+        // the network is up, and probeOnline() owns that state. Leaving it alone
+        // keeps the cached list usable instead of greying the action.
+        reply->deleteLater();
+    });
+}
+
+void WatchfaceCatalog::fetchTree()
+{
+    QNetworkRequest req{ QUrl(kTreeApi) };
+    const QByteArray etag = readTreeEtag();
+    if (!etag.isEmpty())
+        req.setRawHeader("If-None-Match", etag);
+
+    QNetworkReply *reply = m_nam->get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        if (reply->error() == QNetworkReply::NoError && status == 200)
+            writeTreeCache(parseTree(reply->readAll()), reply->rawHeader("ETag"));
+        // 304 or any error: keep the cached tree.
+        reply->deleteLater();
+    });
+}
+
+QStringList WatchfaceCatalog::parseCatalog(const QByteArray &body) const
+{
+    QStringList names;
+    const QJsonDocument doc = QJsonDocument::fromJson(body);
+    if (!doc.isArray())
+        return names;
+    for (const QJsonValue &v : doc.array()) {
+        const QJsonObject o = v.toObject();
+        if (o.value(QStringLiteral("type")).toString() != QLatin1String("dir"))
+            continue;
+        const QString name = o.value(QStringLiteral("name")).toString();
+        if (isSkippedDir(name))
+            continue;
+        names.append(name);
+    }
+    return names;
+}
+
+QStringList WatchfaceCatalog::parseTree(const QByteArray &body) const
+{
+    QStringList paths;
+    const QJsonObject root = QJsonDocument::fromJson(body).object();
+    for (const QJsonValue &v : root.value(QStringLiteral("tree")).toArray()) {
+        const QJsonObject o = v.toObject();
+        if (o.value(QStringLiteral("type")).toString() == QLatin1String("blob"))
+            paths.append(o.value(QStringLiteral("path")).toString());
+    }
+    return paths;
+}
+
+QString WatchfaceCatalog::catalogCachePath() const
+{
+    return WatchfaceHelper::instance()->cachePath() + QStringLiteral("catalog.json");
+}
+
+QString WatchfaceCatalog::treeCachePath() const
+{
+    return WatchfaceHelper::instance()->cachePath() + QStringLiteral("tree.txt");
+}
+
+QByteArray WatchfaceCatalog::readCachedEtag() const
+{
+    return readTrimmed(WatchfaceHelper::instance()->cachePath()
+                       + QStringLiteral("catalog.etag"));
+}
+
+QByteArray WatchfaceCatalog::readTreeEtag() const
+{
+    return readTrimmed(WatchfaceHelper::instance()->cachePath() + QStringLiteral("tree.etag"));
+}
+
+void WatchfaceCatalog::writeCatalogCache(const QByteArray &body, const QByteArray &etag)
+{
+    const QString base = WatchfaceHelper::instance()->cachePath();
+    QDir().mkpath(base);
+    writeFile(catalogCachePath(), body);
+    writeFile(base + QStringLiteral("catalog.etag"), etag);
+    Q_EMIT hasCatalogChanged(); // first fetch changes the store action label
+}
+
+void WatchfaceCatalog::writeTreeCache(const QStringList &paths, const QByteArray &etag)
+{
+    const QString base = WatchfaceHelper::instance()->cachePath();
+    QDir().mkpath(base);
+    writeFile(treeCachePath(), paths.join(QLatin1Char('\n')).toUtf8());
+    writeFile(base + QStringLiteral("tree.etag"), etag);
+}
+
+QStringList WatchfaceCatalog::treePaths() const
+{
+    QFile f(treeCachePath());
+    if (!f.open(QIODevice::ReadOnly))
+        return {};
+    return QString::fromUtf8(f.readAll()).split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+}

--- a/src/watchfacecatalog.h
+++ b/src/watchfacecatalog.h
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef WATCHFACECATALOG_H
+#define WATCHFACECATALOG_H
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+class QNetworkAccessManager;
+
+/*!
+ * \brief What the watchface repository offers, fetched and cached.
+ *
+ * Two listings, both conditional on an ETag so a revalidation that changes
+ * nothing costs one 304: the catalog of face directories, and one recursive
+ * tree of every file in the repo. The tree exists so an install can enumerate
+ * a face's files locally; the contents API allows 60 calls an hour per IP and
+ * per-directory calls would exhaust that after a couple of installs.
+ *
+ * Knows nothing about rows, installs or previews. It reports that the name
+ * list changed and the caller decides what that means for its model.
+ */
+class WatchfaceCatalog : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit WatchfaceCatalog(QNetworkAccessManager *nam, QObject *parent = nullptr);
+
+    //! False when the repository is unreachable.
+    bool online() const;
+
+    //! True while the catalog is being fetched.
+    bool loading() const;
+
+    //! True once a catalog has been cached, which lets the caller label the
+    //! store action "update" rather than "get more".
+    bool hasCatalog() const;
+
+    //! Face names from the catalog, empty until loadCached() or a fetch.
+    QStringList names() const;
+
+    //! Every file path in the repo, from the cached tree.
+    QStringList treePaths() const;
+
+    //! Repository directories that are not watchfaces.
+    static bool isSkippedDir(const QString &name);
+
+    //! HEADs a stable raw file. Cheaper than the API and not rate limited.
+    void probeOnline();
+
+    //! Parses the cached catalog so rows appear without waiting on the network.
+    void loadCached();
+
+    //! Revalidates the catalog and the tree.
+    void fetch();
+
+Q_SIGNALS:
+    void onlineChanged();
+    void loadingChanged();
+    void hasCatalogChanged();
+
+    //! names() changed, so anything derived from it needs rebuilding.
+    void namesChanged();
+
+private:
+    void fetchCatalog();
+    void fetchTree();
+    void setOnline(bool v);
+    void setLoading(bool v);
+
+    QString catalogCachePath() const;
+    QString treeCachePath() const;
+    QByteArray readCachedEtag() const;
+    QByteArray readTreeEtag() const;
+    void writeCatalogCache(const QByteArray &body, const QByteArray &etag);
+    void writeTreeCache(const QStringList &paths, const QByteArray &etag);
+    QStringList parseCatalog(const QByteArray &body) const;
+    QStringList parseTree(const QByteArray &body) const;
+
+    QNetworkAccessManager *m_nam = nullptr;
+    bool m_online = false;
+    bool m_loading = false;
+    QStringList m_names;
+};
+
+#endif // WATCHFACECATALOG_H

--- a/src/watchfacehelper.cpp
+++ b/src/watchfacehelper.cpp
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "watchfacehelper.h"
+
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+
+WatchfaceHelper::WatchfaceHelper(QObject *parent)
+    : QObject(parent)
+{
+}
+
+WatchfaceHelper *WatchfaceHelper::instance()
+{
+    static WatchfaceHelper self;
+    return &self;
+}
+
+// ── Paths ───────────────────────────────────────────────────────────────────
+
+QString WatchfaceHelper::userDataPath() const
+{
+    return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+        + QStringLiteral("/asteroid-launcher/");
+}
+
+QString WatchfaceHelper::userWatchfacePath() const
+{
+    return userDataPath() + QStringLiteral("watchfaces/");
+}
+
+QString WatchfaceHelper::userAssetPath() const
+{
+    return QStringLiteral("file://") + userDataPath();
+}
+
+QString WatchfaceHelper::userFontsPath() const
+{
+    return QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
+        + QStringLiteral("/.fonts/");
+}
+
+QString WatchfaceHelper::cachePath() const
+{
+    return QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation)
+        + QStringLiteral("/asteroid-settings/watchface-store/");
+}
+
+// ── Destructive operations ──────────────────────────────────────────────────
+
+void WatchfaceHelper::removeWatchface(const QString &name)
+{
+    // The name is a bare face name from the catalog or the user folder. Refuse
+    // anything that could traverse out of the store's folders or behave as a
+    // glob below; every path built here embeds it.
+    if (name.isEmpty()
+        || name.contains(QLatin1Char('/')) || name.contains(QLatin1Char('\\'))
+        || name.contains(QLatin1String("..")) || name.contains(QLatin1Char('*'))
+        || name.contains(QLatin1Char('?')) || name.contains(QLatin1Char('[')))
+        return;
+
+    QFile::remove(userWatchfacePath() + name + QStringLiteral(".qml"));
+    // A multi-design face keeps its variant components in a <name>/ subfolder.
+    QDir(userWatchfacePath() + name).removeRecursively();
+
+    // Launcher-grabbed previews live under watchfaces-preview/<size>/, one
+    // folder per size the launcher chose to render. Enumerate the folders
+    // rather than assuming a fixed size set, and cover both the webp the
+    // renderer writes and any older png.
+    const QString previewRoot = userDataPath() + QStringLiteral("watchfaces-preview/");
+    const QStringList sizeDirs = QDir(previewRoot).entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+    for (const QString &d : sizeDirs) {
+        QFile::remove(previewRoot + d + QLatin1Char('/') + name + QStringLiteral(".webp"));
+        QFile::remove(previewRoot + d + QLatin1Char('/') + name + QStringLiteral(".png"));
+    }
+
+    // Image assets: a face's own subfolder, plus the flat name-prefixed file
+    // convention. The prefix pattern can only over-match if another installed
+    // face is literally named "<name>-<suffix>"; the repo has no such pair and
+    // the name is validated above, so the simple pattern stays.
+    QDir imgDir(userDataPath() + QStringLiteral("watchfaces-img/"));
+    QDir(imgDir.filePath(name)).removeRecursively();
+    if (imgDir.exists()) {
+        const QStringList filters = { name + QStringLiteral("-*"),
+                                      name + QStringLiteral(".*") };
+        const QStringList files = imgDir.entryList(filters, QDir::Files);
+        for (const QString &f : files)
+            imgDir.remove(f);
+    }
+}

--- a/src/watchfacehelper.h
+++ b/src/watchfacehelper.h
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef WATCHFACEHELPER_H
+#define WATCHFACEHELPER_H
+
+#include <QObject>
+#include <QString>
+
+/*!
+ * \brief Filesystem side of the watchface store: canonical paths and the
+ * destructive operations.
+ *
+ * The store model owns all networking and the model rows; this helper owns
+ * where things live on disk (user watchface, asset, font and cache folders)
+ * and the two operations that reach outside the model: removing an installed
+ * face's files and restarting the launcher session.
+ *
+ * Accessed only through instance(); the constructor is private, has no side
+ * effects, and the instance is created on first use, so merely opening a
+ * settings page costs nothing here.
+ */
+class WatchfaceHelper : public QObject
+{
+    Q_OBJECT
+
+    //! The user asset root as a file:// URL. Exposed because pages that only
+    //! need a path (WallpaperPage listing user wallpapers) should not have to
+    //! construct the store model to get one.
+    Q_PROPERTY(QString userAssetPath READ userAssetPath CONSTANT)
+
+public:
+    static WatchfaceHelper *instance();
+
+    //! Root of the user's launcher data (…/asteroid-launcher/), trailing slash.
+    QString userDataPath() const;
+
+    //! The user watchface folder (userDataPath() + watchfaces/).
+    QString userWatchfacePath() const;
+
+    //! userDataPath() as a file:// URL, for QML consumers.
+    QString userAssetPath() const;
+
+    //! The user font folder the store installs bundled fonts into. This is the
+    //! legacy ~/.fonts location on purpose: it is what the shipped fontconfig
+    //! scans and what the launcher's runtime font registration watches on this
+    //! platform. Moving to the XDG font dir is a coordinated follow-up across
+    //! launcher and settings.
+    QString userFontsPath() const;
+
+    //! The store's cache folder (catalog, repo tree, gallery thumbnails).
+    QString cachePath() const;
+
+    /*!
+     * \brief Remove an installed face's files: its QML, its variant subfolder,
+     * its launcher-grabbed previews and its image assets.
+     *
+     * Bundled fonts are deliberately retained — they may be shared between
+     * faces and cost nothing to re-download — as is a bundled wallpaper the
+     * user may still have selected. \a name must be a bare face name; anything
+     * containing path separators or glob characters is refused.
+     */
+    void removeWatchface(const QString &name);
+
+
+private:
+    explicit WatchfaceHelper(QObject *parent = nullptr);
+    Q_DISABLE_COPY(WatchfaceHelper)
+};
+
+#endif // WATCHFACEHELPER_H

--- a/src/watchfaceinstaller.cpp
+++ b/src/watchfaceinstaller.cpp
@@ -1,0 +1,166 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "watchfaceinstaller.h"
+#include "watchfacehelper.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QSaveFile>
+#include <QUrl>
+
+namespace {
+const QString kRawBase = QStringLiteral(
+    "https://raw.githubusercontent.com/AsteroidOS/unofficial-watchfaces/master/");
+const QString kFacesSub = QStringLiteral("/usr/share/asteroid-launcher/");
+}
+
+//! One in-flight install: files still downloading and counters for progress.
+struct WatchfaceInstaller::Transaction {
+    QString name;
+    QString wallpaper; //!< destination URL of the bundled wallpaper, if any
+    int  pending = 0;
+    int  total   = 0;
+    int  done    = 0;
+    bool failed  = false;
+};
+
+WatchfaceInstaller::WatchfaceInstaller(QNetworkAccessManager *nam, QObject *parent)
+    : QObject(parent)
+    , m_nam(nam)
+{
+}
+
+WatchfaceInstaller::~WatchfaceInstaller()
+{
+    qDeleteAll(m_transactions);
+}
+
+bool WatchfaceInstaller::isInstalling(const QString &name) const
+{
+    return m_transactions.contains(name);
+}
+
+bool WatchfaceInstaller::busy() const
+{
+    return !m_transactions.isEmpty();
+}
+
+void WatchfaceInstaller::start(const QString &name, const QStringList &tree,
+                               const QString &wallpaperDestBase)
+{
+    if (m_transactions.contains(name))
+        return;
+
+    Transaction *tx = new Transaction;
+    tx->name = name;
+    m_transactions.insert(name, tx);
+
+    WatchfaceHelper *h = WatchfaceHelper::instance();
+    const QString userBase = h->userWatchfacePath();
+    const QString userRoot = h->userDataPath();
+
+    // The QML is the essential file: its failure fails the install. No preview
+    // is fetched; the launcher grabs one from its own render on activation.
+    queueFile(tx, kRawBase + name + kFacesSub + QStringLiteral("watchfaces/") + name
+                  + QStringLiteral(".qml"),
+              userBase + name + QStringLiteral(".qml"), true);
+
+    const QString wallRepoDir = name + kFacesSub + QStringLiteral("wallpapers/full/");
+    // Sibling files in the face's own dir: shared scripts, extra assets.
+    queueTreeDir(tx, tree, name + kFacesSub + QStringLiteral("watchfaces/"), userBase,
+                 name + QStringLiteral(".qml"));
+    queueTreeDir(tx, tree, name + kFacesSub + QStringLiteral("watchfaces-img/"),
+                 userRoot + QStringLiteral("watchfaces-img/"));
+    queueTreeDir(tx, tree, wallRepoDir, userRoot + QStringLiteral("wallpapers/full/"));
+    queueTreeDir(tx, tree, name + QStringLiteral("/usr/share/fonts/"), h->userFontsPath());
+
+    // First image directly under the wallpaper dir; licence sidecars are skipped.
+    for (const QString &path : tree) {
+        if (!path.startsWith(wallRepoDir))
+            continue;
+        const QString rel = path.mid(wallRepoDir.length());
+        if (rel.contains(QLatin1Char('/')))
+            continue;
+        if (rel.endsWith(QLatin1String(".jpg")) || rel.endsWith(QLatin1String(".png"))
+            || rel.endsWith(QLatin1String(".svg"))) {
+            tx->wallpaper = wallpaperDestBase + QStringLiteral("full/") + rel;
+            break;
+        }
+    }
+}
+
+void WatchfaceInstaller::queueFile(Transaction *tx, const QString &url, const QString &dest,
+                                   bool isQml)
+{
+    tx->pending++;
+    tx->total++;
+    QDir().mkpath(QFileInfo(dest).absolutePath());
+
+    QNetworkReply *reply = m_nam->get(QNetworkRequest(QUrl(url)));
+    connect(reply, &QNetworkReply::finished, this, [this, tx, reply, dest, isQml]() {
+        bool ok = reply->error() == QNetworkReply::NoError;
+        if (ok) {
+            // Temp file + rename, so a failed write cannot leave a truncated
+            // face that lists as installed.
+            QSaveFile f(dest);
+            if (f.open(QIODevice::WriteOnly)) {
+                f.write(reply->readAll());
+                ok = f.commit();
+            } else {
+                ok = false;
+            }
+        }
+        if (!ok && isQml)
+            tx->failed = true;
+        reply->deleteLater();
+
+        tx->pending--;
+        tx->done++;
+        Q_EMIT progress(tx->name, tx->total ? qreal(tx->done) / tx->total : 0.0);
+        maybeFinish(tx);
+    });
+}
+
+void WatchfaceInstaller::queueTreeDir(Transaction *tx, const QStringList &tree,
+                                      const QString &repoDir, const QString &destPrefix,
+                                      const QString &skip)
+{
+    // Synchronous, no network listing, so tx->pending already counts every file
+    // before the first reply returns. Nested subpaths are preserved.
+    for (const QString &path : tree) {
+        if (!path.startsWith(repoDir))
+            continue;
+        const QString rel = path.mid(repoDir.length());
+        if (rel.isEmpty())
+            continue;
+        // The tree is remote data: refuse a path that would climb out of the
+        // destination folder rather than trusting it into a local write.
+        if (rel.startsWith(QLatin1Char('/')) || rel.contains(QLatin1String("..")))
+            continue;
+        if (!skip.isEmpty() && rel == skip)
+            continue; // already queued, e.g. the essential QML
+        queueFile(tx, kRawBase + path, destPrefix + rel, false);
+    }
+}
+
+void WatchfaceInstaller::maybeFinish(Transaction *tx)
+{
+    if (tx->pending != 0)
+        return;
+
+    // By value: taking and deleting the transaction frees tx->name, which the
+    // signal argument would otherwise dangle on.
+    const QString name = tx->name;
+    const QString wallpaper = tx->wallpaper;
+    const bool success = !tx->failed;
+    delete m_transactions.take(name);
+
+    Q_EMIT finished(name, success, wallpaper);
+}

--- a/src/watchfaceinstaller.h
+++ b/src/watchfaceinstaller.h
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef WATCHFACEINSTALLER_H
+#define WATCHFACEINSTALLER_H
+
+#include <QHash>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+class QNetworkAccessManager;
+
+/*!
+ * \brief Downloads a watchface's files into the user folder as one transaction.
+ *
+ * A face is its QML plus optional assets: sibling scripts, images, a bundled
+ * wallpaper and fonts. Every file is read from the cached repository tree and
+ * pulled from raw, so an install makes no rate-limited API call. Only the QML
+ * is essential; a missing asset does not fail the install.
+ *
+ * Files are written atomically, so no observer — the launcher's folder
+ * watchers, its font registration, the store's own disk enumeration — can see
+ * a half-written face.
+ *
+ * Reports progress and completion by name. What that means for a list row, for
+ * activation or for the import gate is the caller's business.
+ */
+class WatchfaceInstaller : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit WatchfaceInstaller(QNetworkAccessManager *nam, QObject *parent = nullptr);
+    ~WatchfaceInstaller() override;
+
+    //! Whether \a name has a transaction in flight.
+    bool isInstalling(const QString &name) const;
+
+    //! Whether any transaction is in flight.
+    bool busy() const;
+
+    /*!
+     * Starts installing \a name, enumerating its files from \a tree.
+     * \a wallpaperDestBase is the file:// folder a bundled wallpaper lands in,
+     * reported back through finished() so the caller can apply it once.
+     * Does nothing when \a name is already installing.
+     */
+    void start(const QString &name, const QStringList &tree, const QString &wallpaperDestBase);
+
+Q_SIGNALS:
+    //! \a fraction of this face's files are written, 0.0..1.0.
+    void progress(const QString &name, qreal fraction);
+
+    /*!
+     * The transaction ended. \a success is false when the essential QML failed.
+     * \a wallpaper is the bundled wallpaper's destination URL, empty when the
+     * face ships none.
+     */
+    void finished(const QString &name, bool success, const QString &wallpaper);
+
+private:
+    struct Transaction;
+
+    void queueFile(Transaction *tx, const QString &url, const QString &dest, bool isQml);
+    void queueTreeDir(Transaction *tx, const QStringList &tree, const QString &repoDir,
+                      const QString &destPrefix, const QString &skip = QString());
+    void maybeFinish(Transaction *tx);
+
+    QNetworkAccessManager *m_nam = nullptr;
+    QHash<QString, Transaction *> m_transactions;
+};
+
+#endif // WATCHFACEINSTALLER_H

--- a/src/watchfacepreviews.cpp
+++ b/src/watchfacepreviews.cpp
@@ -1,0 +1,206 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "watchfacepreviews.h"
+#include "watchfacehelper.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+
+#include <limits>
+
+namespace {
+const QString kRawBase = QStringLiteral(
+    "https://raw.githubusercontent.com/AsteroidOS/unofficial-watchfaces/master/");
+const QString kFacesSub     = QStringLiteral("/usr/share/asteroid-launcher/");
+const QString kStockPreview = QStringLiteral("/usr/share/asteroid-launcher/watchfaces-preview/");
+
+/*!
+ * \internal
+ * The preview for \a name under \a root from the size folder closest to
+ * \a target.
+ *
+ * Preview trees are laid out as <root>/<pixel size>/<name><suffix>. Which
+ * sizes exist is not known here, and directory order is smallest first, so
+ * taking the first hit would scale up past a better fitting neighbour. A
+ * non-numeric folder name, and the case of no target yet, fall back to
+ * first-hit order.
+ */
+QString nearestSizedPreview(const QString &root, const QString &name,
+                            const QString &suffix, int target)
+{
+    QString best;
+    int bestDelta = std::numeric_limits<int>::max();
+    const QStringList sizeDirs = QDir(root).entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+    for (const QString &d : sizeDirs) {
+        const QString cand = root + d + QLatin1Char('/') + name + suffix;
+        if (!QFile::exists(cand))
+            continue;
+        bool isNumber = false;
+        const int px = d.toInt(&isNumber);
+        const bool comparable = isNumber && target > 0;
+        if (best.isEmpty()) {
+            best = cand;
+            bestDelta = comparable ? qAbs(px - target) : std::numeric_limits<int>::max();
+            continue;
+        }
+        if (!comparable)
+            continue;
+        const int delta = qAbs(px - target);
+        if (delta < bestDelta) {
+            bestDelta = delta;
+            best = cand;
+        }
+    }
+    return best;
+}
+} // namespace
+
+WatchfacePreviews::WatchfacePreviews(QNetworkAccessManager *nam, QObject *parent)
+    : QObject(parent)
+    , m_nam(nam)
+{
+}
+
+void WatchfacePreviews::setPreviewSize(int px)
+{
+    if (m_previewSize == px)
+        return;
+    m_previewSize = px;
+    forgetAll(); // resolution is size dependent
+}
+
+int WatchfacePreviews::previewSize() const
+{
+    return m_previewSize;
+}
+
+QString WatchfacePreviews::galleryCachePathFor(const QString &name) const
+{
+    // Created at download time, not here: this runs on lookup paths too.
+    return WatchfaceHelper::instance()->cachePath()
+        + QStringLiteral("thumbnails/") + name + QStringLiteral(".webp");
+}
+
+QString WatchfacePreviews::pathFor(const QString &name) const
+{
+    const auto it = m_paths.constFind(name);
+    if (it != m_paths.constEnd())
+        return it.value();
+
+    const QString previewRoot = WatchfaceHelper::instance()->userDataPath()
+        + QStringLiteral("watchfaces-preview/");
+
+    // What the launcher grabbed on this device, at whatever size it chose.
+    QString resolved = nearestSizedPreview(previewRoot, name, QStringLiteral(".webp"), m_previewSize);
+
+    // The transparent master a face ships, preferred over the flat gallery
+    // thumbnail so the tile draws on the live background.
+    if (resolved.isEmpty()) {
+        const QString shipped = previewRoot + name + QStringLiteral("-full.webp");
+        if (QFile::exists(shipped))
+            resolved = shipped;
+    }
+    if (resolved.isEmpty()) {
+        const QString stockMaster = kStockPreview + name + QStringLiteral("-full.webp");
+        if (QFile::exists(stockMaster))
+            resolved = stockMaster;
+    }
+
+    // The older stock layout, one opaque PNG per size, for a launcher that
+    // predates the master set.
+    if (resolved.isEmpty())
+        resolved = nearestSizedPreview(kStockPreview, name, QStringLiteral(".png"), m_previewSize);
+
+    if (resolved.isEmpty()) {
+        const QString gallery = galleryCachePathFor(name);
+        if (QFile::exists(gallery))
+            resolved = gallery;
+    }
+
+    m_paths.insert(name, resolved); // misses cached too; forget() reopens them
+    return resolved;
+}
+
+void WatchfacePreviews::request(const QString &name)
+{
+    if (!pathFor(name).isEmpty())
+        return;
+    if (m_queue.contains(name))
+        return;
+    m_queue.append(name);
+    startNext();
+}
+
+void WatchfacePreviews::forget(const QString &name)
+{
+    m_paths.remove(name);
+}
+
+void WatchfacePreviews::forgetAll()
+{
+    m_paths.clear();
+}
+
+void WatchfacePreviews::startNext()
+{
+    if (m_busy || m_queue.isEmpty())
+        return;
+    const QString name = m_queue.takeFirst();
+    const QString dest = galleryCachePathFor(name);
+    if (QFile::exists(dest)) { // cached meanwhile
+        startNext();
+        return;
+    }
+    m_busy = true;
+
+    const QString masterUrl = kRawBase + name + kFacesSub
+        + QStringLiteral("watchfaces-preview/") + name + QStringLiteral("-full.webp");
+    const QString thumbUrl = kRawBase + QStringLiteral(".thumbnails/") + name
+        + QStringLiteral(".webp");
+    QDir().mkpath(QFileInfo(dest).absolutePath());
+
+    // A 404 returns a short text body, not a RIFF image, so cache on the magic
+    // rather than on the status. A missing preview is never fatal.
+    auto cacheIfImage = [this, dest, name](QNetworkReply *r) -> bool {
+        if (r->error() != QNetworkReply::NoError)
+            return false;
+        const QByteArray body = r->readAll();
+        if (!body.startsWith("RIFF"))
+            return false;
+        QFile f(dest);
+        if (f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            f.write(body);
+            f.close();
+            m_paths.remove(name); // the cache dir is not watched
+            Q_EMIT previewReady(name);
+        }
+        return true;
+    };
+
+    QNetworkReply *reply = m_nam->get(QNetworkRequest(QUrl(masterUrl)));
+    connect(reply, &QNetworkReply::finished, this, [this, reply, thumbUrl, cacheIfImage]() {
+        const bool got = cacheIfImage(reply);
+        reply->deleteLater();
+        if (got) {
+            m_busy = false;
+            startNext();
+            return;
+        }
+        // No master shipped: fall back to the gallery thumbnail.
+        QNetworkReply *fb = m_nam->get(QNetworkRequest(QUrl(thumbUrl)));
+        connect(fb, &QNetworkReply::finished, this, [this, fb, cacheIfImage]() {
+            cacheIfImage(fb);
+            fb->deleteLater();
+            m_busy = false;
+            startNext();
+        });
+    });
+}

--- a/src/watchfacepreviews.h
+++ b/src/watchfacepreviews.h
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef WATCHFACEPREVIEWS_H
+#define WATCHFACEPREVIEWS_H
+
+#include <QHash>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+class QNetworkAccessManager;
+
+/*!
+ * \brief Finds the image a watchface tile should show, and fetches it if absent.
+ *
+ * Resolution walks a fixed order of sources, from the one that best matches
+ * this device to the most generic; see previewPathFor(). Results are memoized
+ * including misses, because a tile asks once per row and again on every
+ * refresh.
+ *
+ * A face with no preview anywhere can have one downloaded from the repo, one
+ * at a time. Owns no list state: it reports a finished download by name and
+ * the model decides which row that is.
+ */
+class WatchfacePreviews : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit WatchfacePreviews(QNetworkAccessManager *nam, QObject *parent = nullptr);
+
+    /*!
+     * The pixel size tiles are drawn at. Preview folders are named by pixel
+     * size and the sizes present are whatever the launcher grabbed plus
+     * whatever a face shipped, so resolution picks the nearest folder rather
+     * than the first. Supplied by the caller because it comes from Dims, which
+     * lives in QML.
+     */
+    void setPreviewSize(int px);
+    int previewSize() const;
+
+    /*!
+     * The preview file for \a name, or an empty string when the face has none.
+     *
+     * In order: the transparent preview the launcher grabbed for this device,
+     * the transparent master the face ships, the stock master, the older
+     * per-size stock PNG set, then a downloaded gallery thumbnail.
+     */
+    QString pathFor(const QString &name) const;
+
+    //! Where a downloaded gallery thumbnail for \a name is cached.
+    QString galleryCachePathFor(const QString &name) const;
+
+    //! Queues a download for \a name when nothing resolves for it yet.
+    void request(const QString &name);
+
+    //! Drops the memoized resolution for \a name, or for every name.
+    void forget(const QString &name);
+    void forgetAll();
+
+Q_SIGNALS:
+    //! A download landed and \a name now resolves to a file it did not before.
+    void previewReady(const QString &name);
+
+private:
+    void startNext();
+
+    QNetworkAccessManager *m_nam = nullptr;
+    int m_previewSize = 0;
+    bool m_busy = false;
+    QStringList m_queue;
+    mutable QHash<QString, QString> m_paths;
+};
+
+#endif // WATCHFACEPREVIEWS_H

--- a/src/watchfaceqmlprobe.cpp
+++ b/src/watchfaceqmlprobe.cpp
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "watchfaceqmlprobe.h"
+#include "watchfacehelper.h"
+
+#include <QFile>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QRegularExpression>
+
+namespace {
+const QString kStockDir = QStringLiteral("/usr/share/asteroid-launcher/watchfaces/");
+}
+
+void WatchfaceQmlProbe::setQmlEngine(QQmlEngine *engine)
+{
+    m_engine = engine;
+}
+
+void WatchfaceQmlProbe::ensureEngine(QQmlEngine *fallback) const
+{
+    if (!m_engine)
+        m_engine = fallback;
+}
+
+bool WatchfaceQmlProbe::moduleAvailable(const QString &uri) const
+{
+    const auto it = m_moduleAvail.constFind(uri);
+    if (it != m_moduleAvail.constEnd())
+        return it.value();
+
+    QQmlEngine *engine = m_engine;
+    if (!engine)
+        return true; // uncached, so the real probe still runs once an engine exists
+
+    // A face runs in the launcher, which shares this import path, so a module
+    // missing here is missing for the face too.
+    QQmlComponent probe(engine);
+    probe.setData("import " + uri.toUtf8() + "\nimport QtQml\nQtObject {}", QUrl());
+    const bool avail = probe.status() != QQmlComponent::Error;
+    m_moduleAvail.insert(uri, avail);
+    return avail;
+}
+
+QString WatchfaceQmlProbe::firstUnmetImport(const QString &qmlPath) const
+{
+    QFile f(qmlPath);
+    if (!f.open(QIODevice::ReadOnly))
+        return QString();
+
+    // Leading letter skips a quoted import, which is a relative file rather
+    // than a module.
+    static const QRegularExpression re(QStringLiteral("(?m)^\\s*import\\s+([A-Za-z][\\w.]*)"));
+    auto mit = re.globalMatch(QString::fromUtf8(f.readAll()));
+    while (mit.hasNext()) {
+        const QString uri = mit.next().captured(1);
+        if (!moduleAvailable(uri))
+            return uri;
+    }
+    return QString();
+}
+
+bool WatchfaceQmlProbe::hasSettings(const QString &name) const
+{
+    const auto it = m_hasSettings.constFind(name);
+    if (it != m_hasSettings.constEnd())
+        return it.value();
+
+    QString path = kStockDir + name + QStringLiteral(".qml");
+    if (!QFile::exists(path))
+        path = WatchfaceHelper::instance()->userWatchfacePath() + name + QStringLiteral(".qml");
+
+    bool has = false;
+    QFile f(path);
+    if (f.open(QIODevice::ReadOnly)) {
+        // The arc convention: "property Component settingsPage" on the root.
+        static const QRegularExpression re(
+            QStringLiteral("(?m)^\\s*(?:readonly\\s+)?property\\s+\\w+\\s+settingsPage\\b"));
+        has = re.match(QString::fromUtf8(f.readAll())).hasMatch();
+    }
+    m_hasSettings.insert(name, has);
+    return has;
+}
+
+void WatchfaceQmlProbe::forget(const QString &name)
+{
+    m_hasSettings.remove(name);
+}

--- a/src/watchfaceqmlprobe.h
+++ b/src/watchfaceqmlprobe.h
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef WATCHFACEQMLPROBE_H
+#define WATCHFACEQMLPROBE_H
+
+#include <QHash>
+#include <QString>
+
+class QQmlEngine;
+
+/*!
+ * \brief Answers what a watchface needs and what it offers, by reading its QML.
+ *
+ * Two questions the store asks about a face before showing it: are the modules
+ * it imports present on this device, and does it declare a settings page. Both
+ * are answered by inspecting the face's source, and both are cached because
+ * they are asked once per list row and again on every refresh.
+ *
+ * Holds no store state and does no networking. Given a face name it reads from
+ * disk; given a module URI it asks a QML engine.
+ */
+class WatchfaceQmlProbe
+{
+public:
+    /*!
+     * The engine used to resolve module imports. As a singleton the store is
+     * not attached to an engine the way a QML-declared object is, so the
+     * caller hands one in.
+     */
+    void setQmlEngine(QQmlEngine *engine);
+
+    /*!
+     * Adopts \a fallback when no engine has been set yet. The store is
+     * constructed before an engine exists, so callers that probe from a const
+     * path use this to supply one late rather than fail open forever.
+     */
+    void ensureEngine(QQmlEngine *fallback) const;
+
+    //! Whether \a uri resolves on this device's QML import path.
+    bool moduleAvailable(const QString &uri) const;
+
+    /*!
+     * The first module \a qmlPath imports that is missing here, or an empty
+     * string when every import resolves.
+     */
+    QString firstUnmetImport(const QString &qmlPath) const;
+
+    //! Whether the face \a name declares a settingsPage property.
+    bool hasSettings(const QString &name) const;
+
+    //! Drops the cached answers for \a name, which its .qml changing invalidates.
+    void forget(const QString &name);
+
+private:
+    mutable QQmlEngine *m_engine = nullptr;
+    mutable QHash<QString, bool> m_moduleAvail;
+    mutable QHash<QString, bool> m_hasSettings;
+};
+
+#endif // WATCHFACEQMLPROBE_H

--- a/src/watchfacestoremodel.cpp
+++ b/src/watchfacestoremodel.cpp
@@ -1,0 +1,520 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "watchfacestoremodel.h"
+#include "watchfacecatalog.h"
+#include "watchfacehelper.h"
+#include "watchfaceinstaller.h"
+#include "watchfacepreviews.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QFileSystemWatcher>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QRegularExpression>
+#include <QSaveFile>
+#include <QSet>
+#include <QTimer>
+#include <QUrl>
+
+namespace {
+const QString kRawBase = QStringLiteral(
+    "https://raw.githubusercontent.com/AsteroidOS/unofficial-watchfaces/master/");
+const QString kFacesSub = QStringLiteral("/usr/share/asteroid-launcher/");
+
+// Stock faces shipped with the launcher. Listed as installed=true, stock=true
+// so they appear in the same section as community installs.
+const QString kStockDir     = QStringLiteral("/usr/share/asteroid-launcher/watchfaces/");
+const QString kStockUrlBase = QStringLiteral("file:///usr/share/asteroid-launcher/watchfaces/");
+} // namespace
+
+
+WatchfaceStoreModel::WatchfaceStoreModel(QObject *parent)
+    : QAbstractListModel(parent)
+    , m_nam(new QNetworkAccessManager(this))
+    , m_catalog(new WatchfaceCatalog(m_nam, this))
+    , m_installer(new WatchfaceInstaller(m_nam, this))
+    , m_previews(new WatchfacePreviews(m_nam, this))
+{
+    connect(m_installer, &WatchfaceInstaller::progress, this, &WatchfaceStoreModel::onInstallProgress);
+    connect(m_installer, &WatchfaceInstaller::finished, this, &WatchfaceStoreModel::onInstallFinished);
+    // The catalog owns reachability and the name list; the rows are this
+    // model's answer to them.
+    connect(m_catalog, &WatchfaceCatalog::namesChanged, this,
+            [this]() { rebuildFrom(m_catalog->names()); });
+    connect(m_catalog, &WatchfaceCatalog::loadingChanged, this, &WatchfaceStoreModel::loadingChanged);
+    connect(m_catalog, &WatchfaceCatalog::hasCatalogChanged, this, &WatchfaceStoreModel::hasCatalogChanged);
+    connect(m_catalog, &WatchfaceCatalog::onlineChanged, this, [this]() {
+        emit onlineChanged();
+        // Catalog rows exist only while online, so a connectivity flip reveals
+        // or hides them. Before "get more" there are none to rebuild.
+        if (m_browseActive)
+            rebuildFrom(m_catalog->names());
+    });
+
+    // A finished download resolves to a file that did not exist before, so the
+    // row has to redraw. Which row that is is the model's business, not the
+    // resolver's.
+    connect(m_previews, &WatchfacePreviews::previewReady, this, [this](const QString &name) {
+        const int row = indexOfName(name);
+        if (row >= 0)
+            updateEntry(row, { PreviewRole });
+    });
+
+    // Only what the user already has, from two directory scans. The catalog
+    // costs are deferred to refresh().
+    rebuildFrom(QStringList());
+
+    // A face copied in or removed by any means shows up live. Created if
+    // absent: a watch on a missing path is silently dropped.
+    const QString wfDir = WatchfaceHelper::instance()->userWatchfacePath();
+    QDir().mkpath(wfDir);
+    m_dirWatcher = new QFileSystemWatcher(this);
+    m_dirWatcher->addPath(wfDir);
+    // Activation rewrites files here, so an undebounced watcher fires
+    // mid-rewrite and resets the list under the user's fingers.
+    m_dirDebounce = new QTimer(this);
+    m_dirDebounce->setSingleShot(true);
+    m_dirDebounce->setInterval(500);
+    connect(m_dirDebounce, &QTimer::timeout, this, &WatchfaceStoreModel::rebuildFromCatalogAndDisk);
+    connect(m_dirWatcher, &QFileSystemWatcher::directoryChanged, this, [this, wfDir]() {
+        // Some tools replace the directory atomically and drop the watch; re-add.
+        if (!m_dirWatcher->directories().contains(wfDir) && QDir(wfDir).exists())
+            m_dirWatcher->addPath(wfDir);
+        m_dirDebounce->start();
+    });
+
+    // Watch the launcher's preview folder (and its per-size subfolders) so a
+    // preview the launcher grabs when a face is activated shows up on its tile
+    // live, without re-opening the store.
+    const QString previewRoot = wfDir.left(wfDir.lastIndexOf(QStringLiteral("watchfaces/")))
+        + QStringLiteral("watchfaces-preview/");
+    QDir().mkpath(previewRoot);
+    m_previewWatcher = new QFileSystemWatcher(this);
+    auto watchPreviewDirs = [this, previewRoot]() {
+        m_previewWatcher->addPath(previewRoot);
+        const QStringList subs = QDir(previewRoot).entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+        for (const QString &d : subs)
+            m_previewWatcher->addPath(previewRoot + d);
+    };
+    watchPreviewDirs();
+    // Atomic writes fire the watcher twice per save, so settle before
+    // re-resolving. Unchanged rows keep their URL and do not reload.
+    m_previewDebounce = new QTimer(this);
+    m_previewDebounce->setSingleShot(true);
+    m_previewDebounce->setInterval(300);
+    connect(m_previewDebounce, &QTimer::timeout, this, [this, watchPreviewDirs]() {
+        watchPreviewDirs(); // a new <size>/ folder may have just appeared
+        m_previews->forgetAll();
+        if (!m_entries.isEmpty())
+            emit dataChanged(index(0), index(m_entries.size() - 1), { PreviewRole });
+    });
+    connect(m_previewWatcher, &QFileSystemWatcher::directoryChanged,
+            m_previewDebounce, qOverload<>(&QTimer::start));
+}
+
+// ── QAbstractListModel ──────────────────────────────────────────────────────
+
+int WatchfaceStoreModel::rowCount(const QModelIndex &parent) const
+{
+    return parent.isValid() ? 0 : m_entries.size();
+}
+
+QVariant WatchfaceStoreModel::data(const QModelIndex &index, int role) const
+{
+    if (index.row() < 0 || index.row() >= m_entries.size())
+        return {};
+    const Entry &e = m_entries.at(index.row());
+    switch (role) {
+    case NameRole:        return e.name;
+    case InstalledRole:   return e.installed;
+    case ActiveRole:      return m_activeWatchface == activationValue(e.name);
+    case PreviewRole: {
+        const QString p = m_previews->pathFor(e.name);
+        if (!QFile::exists(p))
+            return QString();
+        // mtime in the query: an unchanged source URL is never refetched, so a
+        // regenerated preview at the same path would not show.
+        return p + QStringLiteral("?") + QString::number(QFileInfo(p).lastModified().toMSecsSinceEpoch());
+    }
+    case DownloadingRole: return e.downloading;
+    case ProgressRole:    return e.progress;
+    case FailedRole:      return e.failed;
+    case StockRole:       return e.stock;
+    case MissingModuleRole:
+        // Lazily, not at rebuild: the model is constructed before an engine
+        // exists, and probing without one reports every module present.
+        if (e.installed && !e.moduleChecked) {
+            Entry &me = const_cast<Entry &>(e);
+            m_probe.ensureEngine(qmlEngine(this));
+            me.missingModule = m_probe.firstUnmetImport(
+                WatchfaceHelper::instance()->userWatchfacePath() + e.name + QStringLiteral(".qml"));
+            me.moduleChecked = true;
+        }
+        return e.missingModule;
+    }
+    return {};
+}
+
+QHash<int, QByteArray> WatchfaceStoreModel::roleNames() const
+{
+    return {
+        { NameRole,        "name" },
+        { InstalledRole,   "installed" },
+        { ActiveRole,      "active" },
+        { PreviewRole,     "preview" },
+        { DownloadingRole, "downloading" },
+        { ProgressRole,    "progress" },
+        { FailedRole,      "failed" },
+        { StockRole,       "stock" },
+        { MissingModuleRole, "missingModule" },
+    };
+}
+
+// ── Properties ──────────────────────────────────────────────────────────────
+
+QString WatchfaceStoreModel::activeWatchface() const { return m_activeWatchface; }
+
+void WatchfaceStoreModel::setActiveWatchface(const QString &name)
+{
+    if (m_activeWatchface == name)
+        return;
+    m_activeWatchface = name;
+    emit activeWatchfaceChanged();
+    if (!m_entries.isEmpty())
+        emit dataChanged(index(0), index(m_entries.size() - 1), { ActiveRole });
+}
+
+bool WatchfaceStoreModel::online()         const { return m_catalog->online(); }
+bool WatchfaceStoreModel::loading()        const { return m_catalog->loading(); }
+bool WatchfaceStoreModel::hasCatalog()     const { return m_catalog->hasCatalog(); }
+bool WatchfaceStoreModel::browseActive()   const { return m_browseActive; }
+int  WatchfaceStoreModel::previewSize()    const { return m_previews->previewSize(); }
+
+void WatchfaceStoreModel::setPreviewSize(int px)
+{
+    if (m_previews->previewSize() == px)
+        return;
+    m_previews->setPreviewSize(px); // drops its memo, resolution is size dependent
+    emit previewSizeChanged();
+    if (!m_entries.isEmpty())
+        emit dataChanged(index(0), index(m_entries.size() - 1), { PreviewRole });
+}
+
+void WatchfaceStoreModel::setQmlEngine(QQmlEngine *engine)
+{
+    // qmlEngine(this) is the fallback the singleton needs: it is constructed
+    // before the factory hands an engine over, and an import probe with no
+    // engine would report every module present.
+    m_probe.setQmlEngine(engine ? engine : qmlEngine(this));
+}
+
+QString WatchfaceStoreModel::userWallpaperPath() const
+{
+    // file:// URL of the user asset root's wallpaper folder, the same location
+    // install() delivers a watchface's bundled wallpaper into.
+    return WatchfaceHelper::instance()->userAssetPath() + QStringLiteral("wallpapers/");
+}
+
+
+// ── List building ───────────────────────────────────────────────────────────
+//
+// Fetching and caching the repository listings is WatchfaceCatalog's job. What
+// stays here is turning a name list plus what is on disk into rows.
+
+void WatchfaceStoreModel::refresh()
+{
+    // Opening the gate shows the cached rows at once; the conditional fetches
+    // revalidate behind them.
+    if (!m_browseActive) {
+        m_browseActive = true;
+        emit browseActiveChanged();
+    }
+    m_catalog->loadCached();
+    m_catalog->probeOnline();
+    m_catalog->fetch();
+}
+
+void WatchfaceStoreModel::probe()
+{
+    m_catalog->probeOnline();
+}
+
+QStringList WatchfaceStoreModel::installedWatchfaceNames() const
+{
+    // Top-level *.qml only: a face is its lowercase frontend file, and a
+    // multi-design face keeps its variants in a <name>/ subfolder that this
+    // non-recursive listing skips, so components never list as bogus faces.
+    const QDir dir(WatchfaceHelper::instance()->userWatchfacePath());
+    QStringList out;
+    for (const QString &f : dir.entryList({ QStringLiteral("*.qml") }, QDir::Files))
+        out.append(f.left(f.size() - 4)); // strip ".qml"
+    return out;
+}
+
+void WatchfaceStoreModel::rebuildFromCatalogAndDisk()
+{
+    // The watcher also fires when activation merely touches a .qml, so rebuild
+    // only when the installed set really changed. During an install the disk and
+    // the rows legitimately disagree until the last file lands, so wait it out.
+    if (m_installer->busy()) {
+        m_dirDebounce->start();
+        return;
+    }
+
+    const QStringList disk = installedWatchfaceNames();
+    QSet<QString> now(disk.cbegin(), disk.cend());
+    QSet<QString> have;
+    for (const Entry &e : m_entries)
+        if (e.installed && !e.stock)
+            have.insert(e.name);
+    if (now == have) {
+        m_pendingDiskSet.clear();
+        return;
+    }
+    // Confirm the same changed set twice: a single read can land in the window
+    // where activation has a .qml renamed away, which would reset the list twice.
+    if (now != m_pendingDiskSet) {
+        m_pendingDiskSet = now;
+        m_dirDebounce->start();
+        return;
+    }
+    m_pendingDiskSet.clear();
+    rebuildFrom(m_catalog->names());
+}
+
+void WatchfaceStoreModel::rebuildFrom(const QStringList &names)
+{
+    beginResetModel();
+    m_entries.clear();
+
+    // Stock faces shipped in the system dir lead the list: always present,
+    // always installed. The "installed" section shows them alongside the
+    // community faces the user has installed.
+    QStringList seen;
+    const QStringList stockFiles =
+        QDir(kStockDir).entryList({ QStringLiteral("*.qml") }, QDir::Files, QDir::Name);
+    for (const QString &f : stockFiles) {
+        Entry e;
+        e.name      = f.left(f.size() - 4); // strip ".qml"
+        e.installed = true;
+        e.stock     = true;
+        seen.append(e.name);
+        m_entries.append(e);
+    }
+
+    // Community section: the catalog's available faces unioned with every face
+    // in the user folder, so a face installed by any means lists even when the
+    // catalog does not carry it. Sorted alphabetically, below the stock faces.
+    const QStringList tree = m_catalog->treePaths();
+    QStringList community = names;
+    for (const QString &n : installedWatchfaceNames())
+        if (!community.contains(n))
+            community.append(n);
+    community.sort();
+    for (const QString &n : community) {
+        if (seen.contains(n) || WatchfaceCatalog::isSkippedDir(n))
+            continue;
+        const bool installed = isInstalledOnDisk(n);
+        // Un-installed catalog faces list only while the user is browsing AND
+        // online: before "get more" they are not asked for, and offline a
+        // catalog face cannot be downloaded — tapping it would move the
+        // wallpaper for the peek yet never install.
+        if (!installed && (!m_browseActive || !m_catalog->online()))
+            continue;
+        // Skip catalog-only names that are not watchfaces (no <name>.qml in the
+        // tree), such as shared component dirs, so they never list as a blank
+        // tile. An installed face always lists, including a local push the
+        // online tree does not carry.
+        if (!installed
+            && !tree.isEmpty()
+            && !tree.contains(n + kFacesSub + QStringLiteral("watchfaces/") + n + QStringLiteral(".qml")))
+            continue;
+        Entry e;
+        e.name      = n;
+        e.installed = installed;
+        // missingModule is probed lazily in data(), once an engine is attached.
+        m_entries.append(e);
+    }
+
+    endResetModel();
+}
+
+int WatchfaceStoreModel::indexOfName(const QString &name) const
+{
+    for (int i = 0; i < m_entries.size(); ++i)
+        if (m_entries.at(i).name == name)
+            return i;
+    return -1;
+}
+
+void WatchfaceStoreModel::updateEntry(int row, const QList<int> &roles)
+{
+    if (row < 0 || row >= m_entries.size())
+        return;
+    emit dataChanged(index(row), index(row), roles);
+}
+
+bool WatchfaceStoreModel::isInstalledOnDisk(const QString &name) const
+{
+    return QFile::exists(WatchfaceHelper::instance()->userWatchfacePath()
+                         + name + QStringLiteral(".qml"));
+}
+
+// ── Preview and QML probing ─────────────────────────────────────────────────
+//
+// Resolution, download and QML inspection live in WatchfacePreviews and
+// WatchfaceQmlProbe. What stays here is the QML-facing surface and the row
+// bookkeeping, which is the model's business.
+
+void WatchfaceStoreModel::requestPreview(const QString &name)
+{
+    m_previews->request(name);
+}
+
+QString WatchfaceStoreModel::watchfaceUrl(const QString &name) const
+{
+    return activationValue(name);
+}
+
+bool WatchfaceStoreModel::faceHasSettings(const QString &name) const
+{
+    return m_probe.hasSettings(name);
+}
+
+// ── Install / remove ────────────────────────────────────────────────────────
+
+QString WatchfaceStoreModel::activationValue(const QString &name) const
+{
+    // Stock faces activate from the system dir; community faces from the user
+    // asset dir where install() places them. The row already knows which side
+    // a face came from, so the hot path (ActiveRole for every row on each
+    // active-face change) needs no filesystem check; the stat fallback only
+    // runs for a name that is not in the model.
+    const int row = indexOfName(name);
+    const bool stock = row >= 0 ? m_entries.at(row).stock
+                                : QFile::exists(kStockDir + name + QStringLiteral(".qml"));
+    if (stock)
+        return kStockUrlBase + name + QStringLiteral(".qml");
+    return WatchfaceHelper::instance()->userAssetPath()
+        + QStringLiteral("watchfaces/") + name + QStringLiteral(".qml");
+}
+
+void WatchfaceStoreModel::install(const QString &name)
+{
+    if (m_installer->isInstalling(name))
+        return;
+    const int row = indexOfName(name);
+    if (row < 0)
+        return;
+
+    m_entries[row].downloading = true;
+    m_entries[row].failed = false;
+    m_entries[row].progress = 0.0;
+    updateEntry(row, { DownloadingRole, FailedRole, ProgressRole });
+
+    m_installer->start(name, m_catalog->treePaths(), userWallpaperPath());
+}
+
+void WatchfaceStoreModel::onInstallProgress(const QString &name, qreal fraction)
+{
+    const int row = indexOfName(name);
+    if (row < 0)
+        return;
+    m_entries[row].progress = fraction;
+    updateEntry(row, { ProgressRole });
+}
+
+void WatchfaceStoreModel::onInstallFinished(const QString &name, bool success,
+                                            const QString &wallpaper)
+{
+    // The new QML is fresh in the user folder. Drop this app's component cache
+    // so its live preview re-reads the directory instead of failing with
+    // "File name case mismatch".
+    QString unmet;
+    if (success) {
+        if (QQmlEngine *engine = qmlEngine(this)) {
+            engine->clearComponentCache();
+            m_probe.ensureEngine(engine);
+        }
+        // A face importing a module missing here would render blank. Keep it
+        // installed but greyed, and never activate it.
+        unmet = m_probe.firstUnmetImport(
+            WatchfaceHelper::instance()->userWatchfacePath() + name + QStringLiteral(".qml"));
+    }
+    const bool available = success && unmet.isEmpty();
+
+    const int row = indexOfName(name);
+    if (row >= 0) {
+        m_entries[row].downloading = false;
+        m_entries[row].progress = success ? 1.0 : 0.0;
+        if (success)
+            m_entries[row].installed = true;
+        m_entries[row].failed = !success;
+        m_entries[row].missingModule = unmet;
+        m_entries[row].moduleChecked = success; // probed here; data() need not re-probe
+        m_probe.forget(name); // fresh QML may have gained or lost a settingsPage
+        updateEntry(row, { DownloadingRole, ProgressRole, InstalledRole, FailedRole, ActiveRole, MissingModuleRole });
+    }
+
+    if (available) {
+        // Force the bundled wallpaper once, on this install only: this never
+        // runs on re-activation, so the user's later choice is respected.
+        if (!wallpaper.isEmpty())
+            emit wallpaperForced(wallpaper);
+        // QML routes this through its activation-delay timer, shared with manual
+        // selection, so a just-installed face never overwrites one the user taps
+        // immediately afterwards.
+        emit activated(activationValue(name));
+    } else if (!success) {
+        emit installFailed(name);
+    }
+    // Installed but unavailable (unmet import): stays greyed, not activated.
+}
+
+void WatchfaceStoreModel::remove(const QString &name)
+{
+    const bool wasActive = m_activeWatchface == activationValue(name);
+
+    WatchfaceHelper::instance()->removeWatchface(name);
+    m_probe.forget(name);
+    m_previews->forget(name);
+    const int row = indexOfName(name);
+    if (row >= 0) {
+        m_entries[row].installed = false;
+        updateEntry(row, { InstalledRole, ActiveRole });
+    }
+
+    // Removing the face that is currently shown would leave the homescreen
+    // blank: the key still points at a file that is now gone. Hand activation
+    // to the nearest face still installed, preferring the one above, which is
+    // the neighbour the user was just looking at.
+    if (wasActive && row >= 0) {
+        const int next = nearestInstalled(row);
+        if (next >= 0)
+            emit activated(activationValue(m_entries.at(next).name));
+    }
+
+}
+
+int WatchfaceStoreModel::nearestInstalled(int row) const
+{
+    for (int i = row - 1; i >= 0; --i)
+        if (m_entries.at(i).installed)
+            return i;
+    for (int i = row + 1; i < m_entries.size(); ++i)
+        if (m_entries.at(i).installed)
+            return i;
+    return -1;
+}
+

--- a/src/watchfacestoremodel.h
+++ b/src/watchfacestoremodel.h
@@ -1,0 +1,233 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef WATCHFACESTOREMODEL_H
+#define WATCHFACESTOREMODEL_H
+
+#include "watchfaceqmlprobe.h"
+
+#include <QAbstractListModel>
+#include <QFileSystemWatcher>
+#include <QList>
+#include <QNetworkAccessManager>
+#include <QSet>
+#include <QString>
+#include <QStringList>
+
+class QQmlEngine;
+class QTimer;
+class WatchfaceCatalog;
+class WatchfaceInstaller;
+class WatchfacePreviews;
+
+/*!
+ * \brief The watchface list QML binds to, with per-face install state.
+ *
+ * Stock faces, installed community faces and, once the user asks to browse,
+ * what the catalog offers. Turns the catalog, the installer, the preview
+ * resolver and the QML probe into rows, and owns what their results mean for
+ * a row, for activation and for the import gate.
+ *
+ * The work itself lives elsewhere: WatchfaceCatalog fetches, WatchfaceInstaller
+ * downloads, WatchfacePreviews resolves images, WatchfaceQmlProbe reads a
+ * face's QML, and WatchfaceHelper is the single source for paths and removal.
+ */
+class WatchfaceStoreModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+    //! The active watchface name, bound from QML to /desktop/asteroid/watchface.
+    //! Drives the Active role so the current face is marked in the list.
+    Q_PROPERTY(QString activeWatchface READ activeWatchface WRITE setActiveWatchface NOTIFY activeWatchfaceChanged)
+
+    //! False when the catalog endpoint is unreachable (offline / no network).
+    Q_PROPERTY(bool online READ online NOTIFY onlineChanged)
+
+    //! True while the catalog is being (re)fetched.
+    Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+
+    //! True once a catalog has been fetched and cached at least once, so QML
+    //! can label the store action "update" rather than "get more".
+    Q_PROPERTY(bool hasCatalog READ hasCatalog NOTIFY hasCatalogChanged)
+
+    //! The pixel size a preview is shown at. Supplied by QML because the screen
+    //! proportion it comes from (Dims) lives there, so no device-size constant
+    //! is carried here. Passed to the preview resolver, which picks the nearest
+    //! size folder on disk.
+    Q_PROPERTY(int previewSize READ previewSize WRITE setPreviewSize NOTIFY previewSizeChanged)
+
+    //! False until the user explicitly asks to browse the catalog ("get
+    //! more"). While false the model lists only stock and installed faces, so
+    //! opening the page costs nothing beyond two directory scans; every
+    //! catalog cost (cache parse, network refresh, thumbnail downloads and the
+    //! delegates for ~80 rows) is deferred to the moment the user asks for it.
+    Q_PROPERTY(bool browseActive READ browseActive NOTIFY browseActiveChanged)
+
+public:
+    enum Role {
+        NameRole = Qt::UserRole + 1, //!< watchface directory name (QString)
+        InstalledRole,               //!< present in the user watchface folder (bool)
+        ActiveRole,                  //!< equals activeWatchface (bool)
+        PreviewRole,                 //!< local cached preview file path, or "" (QString)
+        DownloadingRole,             //!< an install is in flight (bool)
+        ProgressRole,                //!< install progress 0.0..1.0 (qreal)
+        FailedRole,                  //!< last install attempt failed (bool)
+        StockRole,                   //!< shipped in the system dir, not the community catalog (bool)
+        MissingModuleRole            //!< the unmet import module name, or "" when available (QString)
+    };
+    Q_ENUM(Role)
+
+    explicit WatchfaceStoreModel(QObject *parent = nullptr);
+
+    // QAbstractListModel
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    QString activeWatchface() const;
+    void    setActiveWatchface(const QString &name);
+    bool    online() const;
+    bool    loading() const;
+    bool    hasCatalog() const;
+    bool    browseActive() const;
+    int     previewSize() const;
+    void    setPreviewSize(int px);
+
+    //! Hand the QML engine to the model. Set once from the singleton factory;
+    //! the import-availability probe needs an engine and a singleton is not
+    //! attached to one the way a QML-declared object is.
+    void setQmlEngine(QQmlEngine *engine);
+
+    /*!
+     * \brief The "get more" action: open the catalog and refresh it.
+     * Flips browseActive, immediately rebuilds the rows from the cached
+     * catalog so the list fills without waiting for the network, then
+     * revalidates the catalog and repo tree with conditional requests. An
+     * unchanged catalog (304) costs nothing further: the cached rows are
+     * already showing. Previews are fetched lazily as rows become visible.
+     */
+    Q_INVOKABLE void refresh();
+
+    /*!
+     * \brief Check reachability of the catalog endpoint without fetching it.
+     * Called on page open so the store action reflects the online state; the
+     * catalog itself is only fetched when the user taps "get more"/"update".
+     */
+    Q_INVOKABLE void probe();
+
+    /*!
+     * \brief Ensure the preview for a row is cached, fetching it if missing.
+     * Called by the delegate when it first needs the image. Previews are
+     * fetched one at a time so they fill in sequentially and go easy on the
+     * server rather than bursting every request at once.
+     */
+    Q_INVOKABLE void requestPreview(const QString &name);
+
+    /*!
+     * \brief The /desktop/asteroid/watchface value for an installed face,
+     * so QML can activate a community face on tap.
+     */
+    Q_INVOKABLE QString watchfaceUrl(const QString &name) const;
+
+    /*!
+     * \brief Whether a face declares a settingsPage, from a cached scan of its
+     * QML source. The selector needs this for the settings affordances without
+     * instantiating the face: the live tile render is only a fallback for
+     * faces lacking a preview image, so an instantiated item is usually not
+     * available to ask.
+     */
+    Q_INVOKABLE bool faceHasSettings(const QString &name) const;
+
+    /*!
+     * \brief Install a community watchface: its QML, image assets and fonts.
+     * Updates the row's Downloading/Progress/Installed roles as it runs and
+     * activates the face on success.
+     */
+    Q_INVOKABLE void install(const QString &name);
+
+    /*!
+     * \brief Remove a community watchface and all of its user-folder assets.
+     * Activation passes to the nearest face still installed.
+     */
+    Q_INVOKABLE void remove(const QString &name);
+
+signals:
+    void activeWatchfaceChanged();
+    void onlineChanged();
+    void loadingChanged();
+    void hasCatalogChanged();
+    void browseActiveChanged();
+    void previewSizeChanged();
+
+    //! Emitted after a successful install so QML can point the active
+    //! watchface key at the new face. \a value is the full file:// URL.
+    void activated(const QString &value);
+
+    //! Emitted when an install fails, for a transient UI cue.
+    void installFailed(const QString &name);
+
+    //! Emitted once, only on a fresh install and only when the watchface shipped
+    //! its own wallpaper, so QML can set it as the background and a peek shows the
+    //! face on its designed wallpaper. Never emitted on re-activation, so the
+    //! user's later wallpaper choice is respected. \a url is the file:// path in
+    //! the user wallpaper folder.
+    void wallpaperForced(const QString &url);
+
+private:
+    struct Entry {
+        QString name;
+        bool    installed  = false;
+        bool    downloading = false;
+        qreal   progress   = 0.0;
+        bool    failed     = false;
+        bool    stock      = false; //!< shipped in the system dir, not the community catalog
+        QString missingModule;      //!< non-empty = an imported module is not installed here; face is unavailable
+        bool    moduleChecked = false; //!< imports probed once; missingModule is authoritative
+    };
+
+    // Rows from a catalog name list plus what is on disk.
+    void        rebuildFrom(const QStringList &names);
+    int         indexOfName(const QString &name) const;
+    //! Nearest still-installed row to \a row, preferring the one above.
+    int         nearestInstalled(int row) const;
+    void        updateEntry(int row, const QList<int> &roles);
+    bool        isInstalledOnDisk(const QString &name) const;
+    // Top-level *.qml in the user watchface folder = installed user faces. A
+    // face's variant components live in a <name>/ subfolder and are not listed,
+    // so a bare .qml dropped in by any means (store, script, manual copy) shows.
+    QStringList installedWatchfaceNames() const;
+    // Re-list from the last catalog plus the current on-disk faces. Bound to the
+    // folder watcher so a face added or removed on disk appears or leaves live.
+    void        rebuildFromCatalogAndDisk();
+
+    // The user wallpaper folder (file:// URL), where install() delivers a
+    // face's bundled wallpaper.
+    QString userWallpaperPath() const;
+
+    // Activation URL for the /desktop/asteroid/watchface key.
+    QString activationValue(const QString &name) const;
+
+    // What an install means for a row, for activation and for the import gate.
+    void onInstallProgress(const QString &name, qreal fraction);
+    void onInstallFinished(const QString &name, bool success, const QString &wallpaper);
+
+
+    QList<Entry>           m_entries;
+    QString                m_activeWatchface;
+    bool                   m_browseActive = false;
+    QNetworkAccessManager *m_nam;
+    WatchfaceCatalog      *m_catalog = nullptr;
+    WatchfaceInstaller    *m_installer = nullptr;
+    WatchfacePreviews     *m_previews = nullptr;
+    WatchfaceQmlProbe      m_probe;
+    QFileSystemWatcher    *m_dirWatcher = nullptr;
+    QFileSystemWatcher    *m_previewWatcher = nullptr;
+    QTimer                *m_dirDebounce = nullptr;
+    QTimer                *m_previewDebounce = nullptr;
+    QSet<QString>          m_pendingDiskSet;
+};
+
+#endif // WATCHFACESTOREMODEL_H


### PR DESCRIPTION
## What this adds

An on-device watchface store in the watchface settings page. The page lists the
stock faces and the community faces already installed. Behind an explicit "get
more" it also lists what the unofficial-watchfaces repository offers, and a face
can be installed, activated and removed without leaving the watch.

A face that imports a QML module missing on the device is listed greyed with the
missing module named, rather than offered, because it would render blank.

Removing the face currently shown hands activation to the nearest face still
installed, so the homescreen is never left pointing at a file that is gone.

## How it is structured

The work is split so each piece can be judged on its own. The list model no
longer contains the install mechanics, the network layer or the preview
handling:

| unit | what it owns |
|---|---|
| `WatchfaceHelper` | the user watchface, asset, font and cache paths, and removing a face's files |
| `WatchfaceCatalog` | the repository listings, ETag caching, reachability |
| `WatchfacePreviews` | which image a tile shows, and fetching one when nothing resolves |
| `WatchfaceQmlProbe` | what a face imports and whether it declares a settings page |
| `WatchfaceInstaller` | the download transaction |
| `WatchfaceStoreModel` | rows, activation, and the import gate |

The four workers know nothing about list rows. They report by name and the model
decides what that means, through three signals: `namesChanged`,
`previewReady(name)`, and `progress` / `finished(name, ok, wallpaper)`.

## Reviewing it

Every commit is one concern, and each one configures on its own, so the series
bisects. The licence header conversion and the qmlformat pass are separate
commits from any functional change, so no functional diff carries incidental
reordering or spacing churn.

Reviewing commit by commit is the intended path. Accepting or rejecting an
individual unit does not require taking or rejecting the rest.

## Rate limiting

An install enumerates a face's files from one cached recursive repository tree
and pulls each file from raw. The contents API allows 60 calls an hour per IP,
and per-directory calls exhausted that budget after a couple of installs, which
silently dropped bundled fonts. Both listings are fetched conditionally, so a
revalidation that changes nothing costs a 304.

Downloaded files are written atomically, so no observer, the launcher's folder
watchers, its font registration, or the store's own disk enumeration, can see a
half-written face. Paths taken from the tree are refused if they would climb out
of the destination folder, since the listing is remote data.

## Testing

Built and run on two panels with different sizes, a beluga and a sawfish, from a
full image on each. Exercised: opening the page offline, browsing the catalog,
installing a face including its bundled font and wallpaper, installing a face
with an unmet import, removing the active face, and preview regeneration on
activation.

## Related

Part of the set tracked in unofficial-watchfaces#44, alongside
asteroid-launcher#288, #293 and #295. The launcher pieces are independent of
this one: the store renders no previews itself, it shows whatever the launcher
produced, and falls back through shipped and downloaded images when there is
none.

## Credits

The backend restructuring follows review from @dodoradio, whose reading of the
model as several separate concerns is what this shape came from. Thanks also to
Ed Beroset for the commit and review discipline this series is built to.

Claude was used as a coding and review assistant throughout.
